### PR TITLE
feat(profile): student selects and manages interest categories — Feature #10

### DIFF
--- a/.wolf/anatomy.md
+++ b/.wolf/anatomy.md
@@ -1,6 +1,6 @@
 # anatomy.md
 
-> Auto-maintained by OpenWolf. Last scanned: 2026-04-12T21:29:40.626Z
+> Auto-maintained by OpenWolf. Last scanned: 2026-04-12T21:38:33.703Z
 > Files: 206 tracked | Anatomy hits: 0 | Misses: 0
 
 ## ../../../../tmp/
@@ -295,9 +295,9 @@
 ## apps/native/app/
 
 - `_layout.tsx` — unstable_settings (~926 tok)
-- `edit-profile.tsx` — LANGUAGES (~3029 tok)
+- `edit-profile.tsx` — LANGUAGES (~3722 tok)
 - `enrolment.tsx` — Unified enrolment (students + alumni): email + OTP + resend + registry error handling (~2699 tok)
-- `index.tsx` — LANGUAGES (~5386 tok)
+- `index.tsx` — LANGUAGES (~5467 tok)
 
 ## apps/native/components/
 
@@ -386,7 +386,7 @@
 ## packages/api/src/
 
 - `context.ts` — Exports CreateContextOptions, createContext, Context (~126 tok)
-- `domain-events.ts` — Exports LanguageProfileUpdatedEvent, domainEvents (~227 tok)
+- `domain-events.ts` — Exports LanguageProfileUpdatedEvent, InterestProfileUpdatedEvent, domainEvents (~268 tok)
 - `index.ts` — tRPC router (~156 tok)
 
 ## packages/api/src/routers/
@@ -395,7 +395,7 @@
 - `index.ts` — tRPC router: 2 procedures (~198 tok)
 - `matching.ts` — Haversine distance in km between two lat/lng points (~2987 tok)
 - `meetup.ts` — All bookable half-hour slots from 08:00 to 20:00 (~2170 tok)
-- `profile.ts` — Zod schemas: interestEnum, proficiencyEnum, spokenLanguageSchema, learningProficiencyEnum + 3 more (~3296 tok)
+- `profile.ts` — Zod schemas: interestEnum, proficiencyEnum, spokenLanguageSchema, learningProficiencyEnum + 3 more (~3562 tok)
 - `venue.ts` — tRPC router: 2 procedures (~825 tok)
 
 ## packages/auth/

--- a/.wolf/buglog.json
+++ b/.wolf/buglog.json
@@ -674,6 +674,38 @@
       "related_bugs": [],
       "occurrences": 3,
       "last_seen": "2026-04-12T21:29:30.595Z"
+    },
+    {
+      "id": "bug-042",
+      "timestamp": "2026-04-12T21:37:52.489Z",
+      "error_message": "CSS fix: variant",
+      "file": "apps/native/app/edit-profile.tsx",
+      "root_cause": "variant: \"danger\", label: \"Failed to remove language.\" → \"danger\", label: \"Failed to update interest.\"",
+      "fix": "Changed variant: \"danger\", label: \"Failed to remove language.\" → \"danger\", label: \"Failed to update interest.\"",
+      "tags": [
+        "auto-detected",
+        "style-fix",
+        "tsx"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-04-12T21:37:52.489Z"
+    },
+    {
+      "id": "bug-043",
+      "timestamp": "2026-04-12T21:39:15.045Z",
+      "error_message": "TS2304 Cannot find name setError in edit-profile.tsx",
+      "file": "apps/native/app/edit-profile.tsx",
+      "root_cause": "handleAdd called setError(null) but no setError state was declared in EditProfileScreen",
+      "fix": "Removed the stray setError(null) call — edit-profile has no server-error state",
+      "tags": [
+        "typescript",
+        "pre-existing",
+        "edit-profile"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-04-12T21:39:15.046Z"
     }
   ]
 }

--- a/.wolf/memory.md
+++ b/.wolf/memory.md
@@ -221,3 +221,30 @@
 | 23:29 | Edited apps/native/app/edit-profile.tsx | modified handleUpdateProficiency() | ~34 |
 | 23:29 | Session end: 6 writes across 1 files (edit-profile.tsx) | 1 reads | ~3662 tok |
 | 23:31 | Session end: 6 writes across 1 files (edit-profile.tsx) | 1 reads | ~3662 tok |
+| 23:32 | Session end: 6 writes across 1 files (edit-profile.tsx) | 1 reads | ~3662 tok |
+
+## Session: 2026-04-12 23:32
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+
+## Session: 2026-04-12 23:34
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+
+## Session: 2026-04-12 23:35
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+| 23:37 | Edited packages/api/src/domain-events.ts | expanded (+6 lines) | ~102 |
+| 23:37 | Edited packages/api/src/routers/profile.ts | 2→2 lines | ~23 |
+| 23:37 | Edited packages/api/src/routers/profile.ts | added 1 condition(s) | ~432 |
+| 23:37 | Edited apps/native/app/edit-profile.tsx | expanded (+10 lines) | ~163 |
+| 23:37 | Edited apps/native/app/edit-profile.tsx | expanded (+9 lines) | ~344 |
+| 23:38 | Edited apps/native/app/edit-profile.tsx | CSS: interest | ~556 |
+| 23:38 | Edited apps/native/app/index.tsx | added 1 condition(s) | ~155 |
+| 23:38 | Edited apps/native/app/index.tsx | added 1 condition(s) | ~137 |
+| 23:38 | Edited apps/native/app/edit-profile.tsx | modified handleAdd() | ~39 |
+| 23:39 | Implemented feature #10 tasks #53/#54/#55: interest selection UI + toggleInterest tRPC + InterestProfileUpdated event + completeness enforcement | edit-profile.tsx, index.tsx, profile.ts, domain-events.ts | closed issues 53/54/55 | ~800 |
+| 23:39 | Session end: 9 writes across 4 files (domain-events.ts, profile.ts, edit-profile.tsx, index.tsx) | 6 reads | ~16115 tok |

--- a/apps/native/app/edit-profile.tsx
+++ b/apps/native/app/edit-profile.tsx
@@ -21,6 +21,16 @@ const LANGUAGES = [
   "Russian",
 ] as const;
 
+const INTERESTS = [
+  { value: "modern_art", label: "Modern Art" },
+  { value: "tech_coding", label: "Tech & Coding" },
+  { value: "jazz_music", label: "Jazz Music" },
+  { value: "culinary_arts", label: "Culinary Arts" },
+  { value: "sustainability", label: "Sustainability" },
+  { value: "cinephile", label: "Cinephile" },
+  { value: "cosmology", label: "Cosmology" },
+] as const;
+
 const SPOKEN_PROFICIENCY = [
   { value: "beginner", label: "Beginner" },
   { value: "intermediate", label: "Intermediate" },
@@ -58,11 +68,20 @@ export default function EditProfileScreen() {
     },
   });
 
+  const toggleInterestMutation = useMutation({
+    ...trpc.profile.toggleInterest.mutationOptions(),
+    onSuccess: () => queryClient.invalidateQueries(),
+    onError: () => {
+      toast.show({ variant: "danger", label: "Failed to update interest." });
+    },
+  });
+
   const languages = profileQuery.data?.languages ?? [];
   const spokenLanguages = languages.filter((l) => l.type === "spoken");
   const learningLanguages = languages.filter((l) => l.type === "learning");
+  const savedInterests = profileQuery.data?.interests ?? [];
 
-  const isMutating = upsertMutation.isPending || removeMutation.isPending;
+  const isMutating = upsertMutation.isPending || removeMutation.isPending || toggleInterestMutation.isPending;
 
   const availableForSpoken = LANGUAGES.filter(
     (l) =>
@@ -76,7 +95,6 @@ export default function EditProfileScreen() {
   );
 
   function handleAdd(lang: string, type: LanguageType) {
-    setError(null);
     upsertMutation.mutate({ language: lang, type, proficiency: "beginner" });
     setAddingType(null);
   }
@@ -265,6 +283,48 @@ export default function EditProfileScreen() {
                 </Button>
               )
             )}
+          </View>
+
+          {/* Interests */}
+          <View>
+            <Text className="text-foreground text-xl font-bold mb-1">Interests</Text>
+            <Text className="text-muted-foreground text-sm mb-3">
+              Select at least one interest to be eligible for matching.
+            </Text>
+
+            {savedInterests.length === 0 && (
+              <View className="bg-destructive/10 border border-destructive rounded-lg p-3 mb-3">
+                <Text className="text-destructive text-sm">
+                  No interests selected — select at least one to enter the matching pool.
+                </Text>
+              </View>
+            )}
+
+            <View className="flex-row flex-wrap gap-2">
+              {INTERESTS.map((item) => {
+                const selected = savedInterests.some((i) => i.interest === item.value);
+                return (
+                  <Pressable
+                    key={item.value}
+                    onPress={() => toggleInterestMutation.mutate({ interest: item.value })}
+                    disabled={toggleInterestMutation.isPending}
+                    className={`px-4 py-2 rounded-full border ${
+                      selected
+                        ? "bg-primary border-primary"
+                        : "bg-background border-border"
+                    }`}
+                  >
+                    <Text
+                      className={
+                        selected ? "text-primary-foreground font-medium" : "text-foreground"
+                      }
+                    >
+                      {item.label}
+                    </Text>
+                  </Pressable>
+                );
+              })}
+            </View>
           </View>
 
           {isMutating && (

--- a/apps/native/app/index.tsx
+++ b/apps/native/app/index.tsx
@@ -150,6 +150,10 @@ export default function OnboardingScreen() {
       setValidationError("Please select at least one language to learn.");
       return;
     }
+    if (step === 3 && interests.length === 0) {
+      setValidationError("Please select at least one interest.");
+      return;
+    }
     setValidationError(null);
     setStep((s) => Math.min(s + 1, TOTAL_STEPS));
   }
@@ -166,6 +170,10 @@ export default function OnboardingScreen() {
     }
     if (learningLanguages.length === 0) {
       setValidationError("Please select at least one language to learn.");
+      return;
+    }
+    if (interests.length === 0) {
+      setValidationError("Please select at least one interest to enter the matching pool.");
       return;
     }
     setValidationError(null);

--- a/packages/api/src/domain-events.ts
+++ b/packages/api/src/domain-events.ts
@@ -5,8 +5,14 @@ export interface LanguageProfileUpdatedEvent {
   changedAt: Date;
 }
 
+export interface InterestProfileUpdatedEvent {
+  userId: string;
+  changedAt: Date;
+}
+
 type DomainEventMap = {
   LanguageProfileUpdated: [LanguageProfileUpdatedEvent];
+  InterestProfileUpdated: [InterestProfileUpdatedEvent];
 };
 
 class TypedEventEmitter extends EventEmitter {

--- a/packages/api/src/routers/profile.ts
+++ b/packages/api/src/routers/profile.ts
@@ -47,7 +47,7 @@ const upsertProfileInput = z.object({
   longitude: z.number().optional(),
   spokenLanguages: z.array(spokenLanguageSchema).min(1),
   learningLanguages: z.array(learningLanguageSchema).min(1),
-  interests: z.array(interestEnum),
+  interests: z.array(interestEnum).min(1, "Select at least one interest"),
 });
 
 const partialProfileInput = z.object({
@@ -387,6 +387,39 @@ export const profileRouter = router({
         );
 
       domainEvents.emit("LanguageProfileUpdated", { userId, changedAt: new Date() });
+
+      return { success: true };
+    }),
+
+  toggleInterest: protectedProcedure
+    .input(z.object({ interest: interestEnum }))
+    .mutation(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+
+      const existing = await db
+        .select()
+        .from(userInterest)
+        .where(
+          and(
+            eq(userInterest.userId, userId),
+            eq(userInterest.interest, input.interest),
+          ),
+        );
+
+      if (existing.length > 0) {
+        await db
+          .delete(userInterest)
+          .where(
+            and(
+              eq(userInterest.userId, userId),
+              eq(userInterest.interest, input.interest),
+            ),
+          );
+      } else {
+        await db.insert(userInterest).values({ userId, interest: input.interest });
+      }
+
+      domainEvents.emit("InterestProfileUpdated", { userId, changedAt: new Date() });
 
       return { success: true };
     }),


### PR DESCRIPTION
## Summary

Shared interests are a secondary matching signal in Sip&Speak — students with overlapping passions make better conversation partners beyond just language goals. This PR implements Feature #10: the full interest selection lifecycle so students can build their Interest Profile and be eligible for the matching pool.

Students need to select interests during onboarding (step 3) and be able to update them anytime via their profile. A profile with no interests selected is incomplete and cannot enter matching.

## Changes

**Backend (`packages/api`)**
- Added `InterestProfileUpdatedEvent` type and `InterestProfileUpdated` event to the domain event map
- Added `toggleInterest` tRPC procedure — inserts the interest if absent, deletes it if already selected, then emits `InterestProfileUpdated`
- Tightened `upsertProfile` to require at least one interest (`z.array(interestEnum).min(1)`) as the server-side matching-eligibility gate

**Native app (`apps/native`)**
- Added interests section to `edit-profile` screen: all 7 category chips (Modern Art, Tech & Coding, Jazz Music, Culinary Arts, Sustainability, Cinephile, Cosmology) toggle on/off with immediate persistence
- Destructive empty-state banner on edit-profile when no interests are selected, with a clear call-to-action
- Onboarding step 3 → 4 transition now validates at least one interest before advancing
- Final onboarding save validates at least one interest before calling `upsertProfile`
- Fixed pre-existing TS bug: stray `setError(null)` call in `handleAdd` referenced an undeclared state

## Test plan

- [ ] Onboarding step 3: selecting an interest chip highlights it; deselecting unhighlights it
- [ ] Onboarding: advancing from step 3 with no interests selected shows "Please select at least one interest." error
- [ ] Onboarding: saving (step 4) with no interests selected shows matching-eligibility error
- [ ] Onboarding: saving with ≥1 interest selected succeeds and navigates to edit-profile
- [ ] Edit-profile: interests section shows all 7 categories; previously saved selections are pre-highlighted
- [ ] Edit-profile: tapping a deselected chip selects it and persists immediately (no reload needed)
- [ ] Edit-profile: tapping a selected chip deselects it and persists immediately
- [ ] Edit-profile: deselecting all interests shows the destructive empty-state banner
- [ ] Edit-profile: selecting all 7 interests is allowed (broad match pool)
- [ ] API: `toggleInterest` with an unselected interest inserts a row in `user_interest`
- [ ] API: `toggleInterest` with an already-selected interest deletes the row
- [ ] API: `upsertProfile` with an empty interests array returns a validation error

## Related

Closes #53
Closes #54
Closes #55
Closes #10