### PR TITLE
feat(profile): add profile review screen and matching-eligible submission flow

### DIFF
--- a/apps/native/app/_layout.tsx
+++ b/apps/native/app/_layout.tsx
@@ -57,6 +57,7 @@ function StackLayout() {
       <Stack.Screen name="enrolment" options={{ title: "Enrol with TU/e", headerBackVisible: false }} />
       <Stack.Screen name="onboarding" options={{ title: "Set Up Your Profile", headerBackVisible: false }} />
       <Stack.Screen name="edit-profile" options={{ title: "Edit Profile" }} />
+      <Stack.Screen name="review-profile" options={{ title: "Review Profile" }} />
       <Stack.Screen name="partner/[id]" options={{ title: "Partner Profile" }} />
       <Stack.Screen name="schedule/[partnerId]" options={{ title: "Schedule Meet-Up" }} />
       <Stack.Screen name="chat/[conversationId]" options={{ title: "Chat" }} />

--- a/apps/native/app/edit-profile.tsx
+++ b/apps/native/app/edit-profile.tsx
@@ -1,4 +1,5 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
+import { useRouter } from "expo-router";
 import { Button, Card, Spinner, useToast } from "heroui-native";
 import { useState } from "react";
 import { Pressable, ScrollView, Text, View } from "react-native";
@@ -47,6 +48,7 @@ const LEARNING_PROFICIENCY = [
 type LanguageType = "spoken" | "learning";
 
 export default function EditProfileScreen() {
+  const router = useRouter();
   const { toast } = useToast();
   const [addingType, setAddingType] = useState<LanguageType | null>(null);
 
@@ -333,6 +335,12 @@ export default function EditProfileScreen() {
               <Text className="text-muted-foreground text-sm">Saving…</Text>
             </View>
           )}
+
+          <View className="mt-4 pt-4 border-t border-border">
+            <Button onPress={() => router.push("/review-profile")}>
+              <Button.Label>Review & Submit Profile</Button.Label>
+            </Button>
+          </View>
 
         </View>
       </ScrollView>

--- a/apps/native/app/index.tsx
+++ b/apps/native/app/index.tsx
@@ -74,10 +74,10 @@ export default function OnboardingScreen() {
   const onboardingStatus = useQuery(trpc.profile.getOnboardingStatus.queryOptions());
 
   useEffect(() => {
-    if (onboardingStatus.data?.complete) {
+    if (onboardingStatus.data?.hasProfile) {
       router.replace("/edit-profile");
     }
-  }, [onboardingStatus.data?.complete]);
+  }, [onboardingStatus.data?.hasProfile]);
 
   const [step, setStep] = useState(1);
   const [spokenLanguages, setSpokenLanguages] = useState<SpokenLanguage[]>([]);

--- a/apps/native/app/review-profile.tsx
+++ b/apps/native/app/review-profile.tsx
@@ -1,0 +1,207 @@
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { useRouter } from "expo-router";
+import { Button, Spinner, useToast } from "heroui-native";
+import { ScrollView, Text, View } from "react-native";
+
+import { Container } from "@/components/container";
+import { queryClient, trpc } from "@/utils/trpc";
+
+const INTERESTS_LABEL: Record<string, string> = {
+  modern_art: "Modern Art",
+  tech_coding: "Tech & Coding",
+  jazz_music: "Jazz Music",
+  culinary_arts: "Culinary Arts",
+  sustainability: "Sustainability",
+  cinephile: "Cinephile",
+  cosmology: "Cosmology",
+};
+
+export default function ReviewProfileScreen() {
+  const router = useRouter();
+  const { toast } = useToast();
+
+  const profileQuery = useQuery(trpc.profile.getMyProfile.queryOptions());
+
+  const submitMutation = useMutation({
+    ...trpc.profile.submitProfile.mutationOptions(),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries();
+      toast.show({ variant: "success", label: "You're in the matching pool!" });
+      router.replace("/edit-profile");
+    },
+    onError: (e) => {
+      toast.show({
+        variant: "danger",
+        label: (e as { message?: string }).message ?? "Submission failed. Please try again.",
+      });
+    },
+  });
+
+  const languages = profileQuery.data?.languages ?? [];
+  const spokenLanguages = languages.filter((l) => l.type === "spoken");
+  const learningLanguages = languages.filter((l) => l.type === "learning");
+  const interests = profileQuery.data?.interests ?? [];
+
+  const hasSpoken = spokenLanguages.length > 0;
+  const hasLearning = learningLanguages.length > 0;
+  const hasInterests = interests.length > 0;
+  const isComplete = hasSpoken && hasLearning && hasInterests;
+
+  if (profileQuery.isPending) {
+    return (
+      <Container isScrollable={false}>
+        <View className="flex-1 items-center justify-center">
+          <Spinner />
+        </View>
+      </Container>
+    );
+  }
+
+  return (
+    <Container isScrollable={false}>
+      <ScrollView
+        contentContainerStyle={{ flexGrow: 1 }}
+        keyboardShouldPersistTaps="handled"
+      >
+        <View className="flex-1 p-6 gap-6">
+
+          <View>
+            <Text className="text-foreground text-2xl font-bold mb-1">Review your profile</Text>
+            <Text className="text-muted-foreground text-sm">
+              {isComplete
+                ? "Everything looks great — submit to enter the matching pool."
+                : "Complete all sections below before you can submit."}
+            </Text>
+          </View>
+
+          {/* Spoken Languages */}
+          <View className={`rounded-xl border p-4 ${!hasSpoken ? "border-destructive bg-destructive/5" : "border-border bg-card"}`}>
+            <View className="flex-row items-center justify-between mb-2">
+              <Text className="text-foreground font-semibold text-base">Spoken Languages</Text>
+              {!hasSpoken && (
+                <View className="bg-destructive/15 rounded-full px-2 py-0.5">
+                  <Text className="text-destructive text-xs font-medium">Required</Text>
+                </View>
+              )}
+            </View>
+
+            {hasSpoken ? (
+              <View className="flex-row flex-wrap gap-2">
+                {spokenLanguages.map((l) => (
+                  <View key={l.language} className="bg-muted rounded-full px-3 py-1">
+                    <Text className="text-foreground text-sm">{l.language} · {l.proficiency}</Text>
+                  </View>
+                ))}
+              </View>
+            ) : (
+              <>
+                <Text className="text-muted-foreground text-sm mb-3">
+                  Add at least one language you speak.
+                </Text>
+                <Button variant="outline" onPress={() => router.push("/edit-profile")}>
+                  <Button.Label>Add spoken language</Button.Label>
+                </Button>
+              </>
+            )}
+
+            {hasSpoken && (
+              <Button variant="ghost" onPress={() => router.push("/edit-profile")} className="mt-2 self-start -ml-2">
+                <Button.Label>Edit</Button.Label>
+              </Button>
+            )}
+          </View>
+
+          {/* Learning Languages */}
+          <View className={`rounded-xl border p-4 ${!hasLearning ? "border-destructive bg-destructive/5" : "border-border bg-card"}`}>
+            <View className="flex-row items-center justify-between mb-2">
+              <Text className="text-foreground font-semibold text-base">Learning Languages</Text>
+              {!hasLearning && (
+                <View className="bg-destructive/15 rounded-full px-2 py-0.5">
+                  <Text className="text-destructive text-xs font-medium">Required</Text>
+                </View>
+              )}
+            </View>
+
+            {hasLearning ? (
+              <View className="flex-row flex-wrap gap-2">
+                {learningLanguages.map((l) => (
+                  <View key={l.language} className="bg-muted rounded-full px-3 py-1">
+                    <Text className="text-foreground text-sm">{l.language} · {l.proficiency ?? "—"}</Text>
+                  </View>
+                ))}
+              </View>
+            ) : (
+              <>
+                <Text className="text-muted-foreground text-sm mb-3">
+                  Add at least one language you want to learn.
+                </Text>
+                <Button variant="outline" onPress={() => router.push("/edit-profile")}>
+                  <Button.Label>Add learning language</Button.Label>
+                </Button>
+              </>
+            )}
+
+            {hasLearning && (
+              <Button variant="ghost" onPress={() => router.push("/edit-profile")} className="mt-2 self-start -ml-2">
+                <Button.Label>Edit</Button.Label>
+              </Button>
+            )}
+          </View>
+
+          {/* Interests */}
+          <View className={`rounded-xl border p-4 ${!hasInterests ? "border-destructive bg-destructive/5" : "border-border bg-card"}`}>
+            <View className="flex-row items-center justify-between mb-2">
+              <Text className="text-foreground font-semibold text-base">Interests</Text>
+              {!hasInterests && (
+                <View className="bg-destructive/15 rounded-full px-2 py-0.5">
+                  <Text className="text-destructive text-xs font-medium">Required</Text>
+                </View>
+              )}
+            </View>
+
+            {hasInterests ? (
+              <View className="flex-row flex-wrap gap-2">
+                {interests.map((i) => (
+                  <View key={i.interest} className="bg-muted rounded-full px-3 py-1">
+                    <Text className="text-foreground text-sm">
+                      {INTERESTS_LABEL[i.interest] ?? i.interest}
+                    </Text>
+                  </View>
+                ))}
+              </View>
+            ) : (
+              <>
+                <Text className="text-muted-foreground text-sm mb-3">
+                  Select at least one interest to help us find your best match.
+                </Text>
+                <Button variant="outline" onPress={() => router.push("/edit-profile")}>
+                  <Button.Label>Add interests</Button.Label>
+                </Button>
+              </>
+            )}
+
+            {hasInterests && (
+              <Button variant="ghost" onPress={() => router.push("/edit-profile")} className="mt-2 self-start -ml-2">
+                <Button.Label>Edit</Button.Label>
+              </Button>
+            )}
+          </View>
+
+          <View className="mt-2">
+            <Button
+              onPress={() => submitMutation.mutate()}
+              isDisabled={!isComplete || submitMutation.isPending}
+            >
+              {submitMutation.isPending ? (
+                <Spinner size="sm" color="default" />
+              ) : (
+                <Button.Label>Submit — Enter Matching Pool</Button.Label>
+              )}
+            </Button>
+          </View>
+
+        </View>
+      </ScrollView>
+    </Container>
+  );
+}

--- a/packages/api/src/domain-events.ts
+++ b/packages/api/src/domain-events.ts
@@ -10,9 +10,15 @@ export interface InterestProfileUpdatedEvent {
   changedAt: Date;
 }
 
+export interface ProfileCompletedEvent {
+  userId: string;
+  completedAt: Date;
+}
+
 type DomainEventMap = {
   LanguageProfileUpdated: [LanguageProfileUpdatedEvent];
   InterestProfileUpdated: [InterestProfileUpdatedEvent];
+  ProfileCompleted: [ProfileCompletedEvent];
 };
 
 class TypedEventEmitter extends EventEmitter {

--- a/packages/api/src/routers/profile.ts
+++ b/packages/api/src/routers/profile.ts
@@ -81,6 +81,24 @@ function assertNoNativeSpokenLearningConflict(
   }
 }
 
+async function syncMatchingEligibility(userId: string): Promise<boolean> {
+  const [languages, interests] = await Promise.all([
+    db.select({ type: userLanguage.type }).from(userLanguage).where(eq(userLanguage.userId, userId)),
+    db.select({ id: userInterest.id }).from(userInterest).where(eq(userInterest.userId, userId)).limit(1),
+  ]);
+
+  const hasSpoken = languages.some((l) => l.type === "spoken");
+  const hasLearning = languages.some((l) => l.type === "learning");
+  const isEligible = hasSpoken && hasLearning && interests.length > 0;
+
+  await db
+    .update(languageProfile)
+    .set({ onboardingComplete: isEligible })
+    .where(eq(languageProfile.userId, userId));
+
+  return isEligible;
+}
+
 export const profileRouter = router({
   getMyProfile: protectedProcedure.query(async ({ ctx }) => {
     const userId = ctx.session.user.id;
@@ -281,7 +299,51 @@ export const profileRouter = router({
       columns: { onboardingComplete: true },
     });
 
-    return { complete: profile?.onboardingComplete ?? false };
+    return {
+      complete: profile?.onboardingComplete ?? false,
+      hasProfile: profile !== null,
+    };
+  }),
+
+  submitProfile: protectedProcedure.mutation(async ({ ctx }) => {
+    const userId = ctx.session.user.id;
+
+    const [languages, interests, existing] = await Promise.all([
+      db.select().from(userLanguage).where(eq(userLanguage.userId, userId)),
+      db.select().from(userInterest).where(eq(userInterest.userId, userId)),
+      db.query.languageProfile.findFirst({
+        where: eq(languageProfile.userId, userId),
+        columns: { onboardingComplete: true },
+      }),
+    ]);
+
+    const hasSpoken = languages.some((l) => l.type === "spoken");
+    const hasLearning = languages.some((l) => l.type === "learning");
+    const hasInterest = interests.length > 0;
+
+    if (!hasSpoken || !hasLearning || !hasInterest) {
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message: "Profile is incomplete. Add at least one spoken language, one learning language, and one interest.",
+      });
+    }
+
+    const wasAlreadyEligible = existing?.onboardingComplete ?? false;
+
+    if (existing) {
+      await db
+        .update(languageProfile)
+        .set({ onboardingComplete: true })
+        .where(eq(languageProfile.userId, userId));
+    } else {
+      await db.insert(languageProfile).values({ userId, onboardingComplete: true });
+    }
+
+    if (!wasAlreadyEligible) {
+      domainEvents.emit("ProfileCompleted", { userId, completedAt: new Date() });
+    }
+
+    return { success: true };
   }),
 
   upsertLanguage: protectedProcedure
@@ -361,6 +423,7 @@ export const profileRouter = router({
         });
       }
 
+      await syncMatchingEligibility(userId);
       domainEvents.emit("LanguageProfileUpdated", { userId, changedAt: new Date() });
 
       return { success: true };
@@ -386,6 +449,7 @@ export const profileRouter = router({
           ),
         );
 
+      await syncMatchingEligibility(userId);
       domainEvents.emit("LanguageProfileUpdated", { userId, changedAt: new Date() });
 
       return { success: true };
@@ -419,6 +483,7 @@ export const profileRouter = router({
         await db.insert(userInterest).values({ userId, interest: input.interest });
       }
 
+      await syncMatchingEligibility(userId);
       domainEvents.emit("InterestProfileUpdated", { userId, changedAt: new Date() });
 
       return { success: true };


### PR DESCRIPTION
## Summary

Students completing onboarding had no explicit gate before entering the matching pool. This PR introduces the **Profile Review & Submit** flow (Feature #11): a dedicated read-only review screen where Students inspect their full Language Profile and Interest Profile, see which sections are still incomplete, and explicitly submit to transition from the _Registering_ state to _matching-eligible_.

The backend enforces completeness server-side (≥1 spoken language, ≥1 learning language, ≥1 interest) and emits a `ProfileCompleted` domain event on first explicit submission. After submission, edits that make the profile incomplete automatically pause eligibility, and completing the profile again restores it — without requiring a second manual submission.

## Changes

- **New screen** (`apps/native/app/review-profile.tsx`): read-only profile summary with per-section completeness indicators, CTAs to navigate to edit-profile for any incomplete section, and a Submit button that is disabled until all checks pass
- **New tRPC procedure** (`profile.submitProfile`): validates completeness, sets `onboardingComplete = true`, emits `ProfileCompleted` domain event; idempotent on repeat calls
- **Auto-restore on edit**: `syncMatchingEligibility` helper is called after every `upsertLanguage`, `removeLanguage`, and `toggleInterest` mutation — re-evaluates and updates `onboardingComplete` so eligibility is paused/restored dynamically with no manual re-submission required
- **Wizard skip guard**: `getOnboardingStatus` now returns `hasProfile` alongside `complete`; the onboarding wizard uses `hasProfile` to skip re-showing the wizard to users who have already set up a profile (even if they later edit to an incomplete state)
- **Review entry point**: a "Review & Submit Profile" button added to `edit-profile.tsx`; `review-profile` route registered in the Stack layout

## Test plan

- [ ] Open the app as a new user with no profile data — wizard is shown
- [ ] Skip the wizard and go to edit-profile — wizard is not shown again on re-entry to `/`
- [ ] On the review screen with no spoken languages: section is bordered in red, "Required" badge shown, "Add spoken language" button navigates to edit-profile
- [ ] Same for learning languages and interests
- [ ] Submit button is disabled when any section is incomplete
- [ ] Add all required data in edit-profile, return to review screen — warning indicators disappear, submit button enables
- [ ] Tap Submit with a complete profile — success toast shown, navigated to edit-profile
- [ ] Tap Submit a second time — idempotent (no duplicate event, returns success)
- [ ] Remove a language after submitting, check profile via `getOnboardingStatus` — `onboardingComplete` is false
- [ ] Re-add the language — `onboardingComplete` is restored to true automatically

## Related

Closes #56
Closes #57
Closes #58
Closes #59
