### PR TITLE
test(matching): add bidirectional language compatibility filter tests

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -9,7 +9,9 @@
       "default": "./src/*.ts"
     }
   },
-  "scripts": {},
+  "scripts": {
+    "test": "bun test"
+  },
   "dependencies": {
     "@sip-and-speak/auth": "workspace:*",
     "@sip-and-speak/db": "workspace:*",

--- a/packages/api/src/__tests__/matching.test.ts
+++ b/packages/api/src/__tests__/matching.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "bun:test";
+
+import { computeLanguageScore } from "../routers/matching.scoring";
+
+describe("computeLanguageScore", () => {
+  describe("Bidirectional language compatibility filter", () => {
+    it("Strict bidirectional match scores highest", () => {
+      // A speaks Dutch and learns English; partner speaks English and learns Dutch
+      const score = computeLanguageScore(
+        ["Dutch"],    // userSpoken
+        ["English"],  // userLearning
+        ["English"],  // partnerSpoken
+        ["Dutch"],    // partnerLearning
+      );
+      expect(score).toBe(1.0);
+    });
+
+    it("One-directional match scores lower", () => {
+      // A speaks Dutch and learns English; partner speaks English but learns French (not Dutch)
+      const score = computeLanguageScore(
+        ["Dutch"],    // userSpoken
+        ["English"],  // userLearning
+        ["English"],  // partnerSpoken
+        ["French"],   // partnerLearning
+      );
+      expect(score).toBe(0.5);
+    });
+
+    it("No language overlap scores zero", () => {
+      // A speaks Dutch and learns English; partner speaks Japanese and learns Mandarin
+      const score = computeLanguageScore(
+        ["Dutch"],     // userSpoken
+        ["English"],   // userLearning
+        ["Japanese"],  // partnerSpoken
+        ["Mandarin"],  // partnerLearning
+      );
+      expect(score).toBe(0.0);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("empty user arrays score zero", () => {
+      const score = computeLanguageScore([], [], ["English"], ["Dutch"]);
+      expect(score).toBe(0.0);
+    });
+
+    it("empty partner arrays score zero", () => {
+      const score = computeLanguageScore(["Dutch"], ["English"], [], []);
+      expect(score).toBe(0.0);
+    });
+
+    it("multiple spoken languages — bidirectional if any pair matches", () => {
+      const score = computeLanguageScore(
+        ["Dutch", "French"],
+        ["English", "Spanish"],
+        ["English", "German"],
+        ["French", "Italian"],
+      );
+      // partnerSpeaksWhatUserLearns: English ∈ [English, German] ✓
+      // partnerLearnsWhatUserSpeaks: French ∈ [Dutch, French] ✓
+      expect(score).toBe(1.0);
+    });
+  });
+});

--- a/packages/api/src/routers/matching.scoring.ts
+++ b/packages/api/src/routers/matching.scoring.ts
@@ -1,0 +1,86 @@
+// Pure scoring helpers — no DB or env imports so they can be unit-tested directly.
+
+export const MAX_RADIUS_KM = 50;
+
+/** Haversine distance in km between two lat/lng points */
+export function haversineDistance(
+  lat1: number,
+  lon1: number,
+  lat2: number,
+  lon2: number,
+): number {
+  const R = 6371; // Earth radius in km
+  const toRad = (deg: number) => (deg * Math.PI) / 180;
+  const dLat = toRad(lat2 - lat1);
+  const dLon = toRad(lon2 - lon1);
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+/**
+ * Language complementarity score.
+ * 1.0 — partner speaks a language user wants to learn AND partner wants to learn a language user speaks.
+ * 0.5 — only one direction matches.
+ * 0   — no complementarity.
+ */
+export function computeLanguageScore(
+  userSpoken: string[],
+  userLearning: string[],
+  partnerSpoken: string[],
+  partnerLearning: string[],
+): number {
+  const partnerSpeaksWhatUserLearns = userLearning.some((lang) =>
+    partnerSpoken.includes(lang),
+  );
+  const partnerLearnsWhatUserSpeaks = partnerLearning.some((lang) =>
+    userSpoken.includes(lang),
+  );
+
+  if (partnerSpeaksWhatUserLearns && partnerLearnsWhatUserSpeaks) return 1.0;
+  if (partnerSpeaksWhatUserLearns || partnerLearnsWhatUserSpeaks) return 0.5;
+  return 0;
+}
+
+/**
+ * Interest overlap score: sharedInterests / max(userInterests, partnerInterests).
+ * Returns 0 when both lists are empty.
+ */
+export function computeInterestScore(
+  userInterests: string[],
+  partnerInterests: string[],
+): number {
+  const maxLen = Math.max(userInterests.length, partnerInterests.length);
+  if (maxLen === 0) return 0;
+  const shared = userInterests.filter((i) => partnerInterests.includes(i));
+  return shared.length / maxLen;
+}
+
+/**
+ * Proximity score: 1 - min(distance / maxRadius, 1).
+ * Closer = higher score.
+ */
+export function computeProximityScore(
+  distanceKm: number,
+  maxRadius: number = MAX_RADIUS_KM,
+): number {
+  return 1 - Math.min(distanceKm / maxRadius, 1);
+}
+
+/**
+ * Composite matching score.
+ * Default weights: language 0.5, interest 0.3, proximity 0.2.
+ * "near_you" filter boosts proximity: language 0.3, interest 0.2, proximity 0.5.
+ */
+export function computeCompositeScore(
+  languageScore: number,
+  interestScore: number,
+  proximityScore: number,
+  filter?: "near_you" | "language",
+): number {
+  if (filter === "near_you") {
+    return languageScore * 0.3 + interestScore * 0.2 + proximityScore * 0.5;
+  }
+  return languageScore * 0.5 + interestScore * 0.3 + proximityScore * 0.2;
+}

--- a/packages/api/src/routers/matching.ts
+++ b/packages/api/src/routers/matching.ts
@@ -8,93 +8,23 @@ import {
 } from "@sip-and-speak/db/schema/sip-and-speak";
 import { user } from "@sip-and-speak/db/schema/auth";
 import { protectedProcedure, router } from "../index";
+import {
+  haversineDistance,
+  computeLanguageScore,
+  computeInterestScore,
+  computeProximityScore,
+  computeCompositeScore,
+  MAX_RADIUS_KM,
+} from "./matching.scoring";
 
-// --- Scoring helpers (exported for testing) ---
-
-const MAX_RADIUS_KM = 50;
-
-/** Haversine distance in km between two lat/lng points */
-export function haversineDistance(
-  lat1: number,
-  lon1: number,
-  lat2: number,
-  lon2: number,
-): number {
-  const R = 6371; // Earth radius in km
-  const toRad = (deg: number) => (deg * Math.PI) / 180;
-  const dLat = toRad(lat2 - lat1);
-  const dLon = toRad(lon2 - lon1);
-  const a =
-    Math.sin(dLat / 2) ** 2 +
-    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2;
-  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-}
-
-/**
- * Language complementarity score.
- * 1.0 — partner speaks a language user wants to learn AND partner wants to learn a language user speaks.
- * 0.5 — only one direction matches.
- * 0   — no complementarity.
- */
-export function computeLanguageScore(
-  userSpoken: string[],
-  userLearning: string[],
-  partnerSpoken: string[],
-  partnerLearning: string[],
-): number {
-  const partnerSpeaksWhatUserLearns = userLearning.some((lang) =>
-    partnerSpoken.includes(lang),
-  );
-  const partnerLearnsWhatUserSpeaks = partnerLearning.some((lang) =>
-    userSpoken.includes(lang),
-  );
-
-  if (partnerSpeaksWhatUserLearns && partnerLearnsWhatUserSpeaks) return 1.0;
-  if (partnerSpeaksWhatUserLearns || partnerLearnsWhatUserSpeaks) return 0.5;
-  return 0;
-}
-
-/**
- * Interest overlap score: sharedInterests / max(userInterests, partnerInterests).
- * Returns 0 when both lists are empty.
- */
-export function computeInterestScore(
-  userInterests: string[],
-  partnerInterests: string[],
-): number {
-  const maxLen = Math.max(userInterests.length, partnerInterests.length);
-  if (maxLen === 0) return 0;
-  const shared = userInterests.filter((i) => partnerInterests.includes(i));
-  return shared.length / maxLen;
-}
-
-/**
- * Proximity score: 1 - min(distance / maxRadius, 1).
- * Closer = higher score.
- */
-export function computeProximityScore(
-  distanceKm: number,
-  maxRadius: number = MAX_RADIUS_KM,
-): number {
-  return 1 - Math.min(distanceKm / maxRadius, 1);
-}
-
-/**
- * Composite matching score.
- * Default weights: language 0.5, interest 0.3, proximity 0.2.
- * "near_you" filter boosts proximity: language 0.3, interest 0.2, proximity 0.5.
- */
-export function computeCompositeScore(
-  languageScore: number,
-  interestScore: number,
-  proximityScore: number,
-  filter?: "near_you" | "language",
-): number {
-  if (filter === "near_you") {
-    return languageScore * 0.3 + interestScore * 0.2 + proximityScore * 0.5;
-  }
-  return languageScore * 0.5 + interestScore * 0.3 + proximityScore * 0.2;
-}
+export {
+  haversineDistance,
+  computeLanguageScore,
+  computeInterestScore,
+  computeProximityScore,
+  computeCompositeScore,
+  MAX_RADIUS_KM,
+};
 
 // --- Router ---
 


### PR DESCRIPTION
## Summary

Task #113 — Implement bidirectional language compatibility filter.

The `computeLanguageScore` function already encoded the correct bidirectional
logic, but had no automated tests. This PR extracts the pure scoring helpers
(`computeLanguageScore`, `computeInterestScore`, `computeProximityScore`,
`computeCompositeScore`, `haversineDistance`) into a side-effect-free module
(`matching.scoring.ts`) so they can be unit-tested without triggering database
env validation, then adds a test suite covering all Gherkin scenarios.

## Changes

- Extracted pure scoring functions from `matching.ts` into `matching.scoring.ts`
- `matching.ts` re-exports all helpers for backward compatibility
- Added `packages/api/src/__tests__/matching.test.ts` with 6 tests (3 Gherkin + 3 edge cases)
- Added `"test": "bun test"` script to `packages/api/package.json`

## Test plan

- [x] Strict bidirectional match (A↔B) scores 1.0
- [x] One-directional match scores 0.5
- [x] No language overlap scores 0.0
- [x] Empty language arrays score 0.0
- [x] Multiple spoken languages — any valid pair triggers bidirectional score
- [x] `bun test packages/api` → 6/6 pass

## Related

Closes #113
