### PR TITLE
feat(matching): handle empty suggestion list state with share-app prompt

### DIFF
--- a/apps/native/app/suggestions.tsx
+++ b/apps/native/app/suggestions.tsx
@@ -1,11 +1,37 @@
 import { useQuery } from "@tanstack/react-query";
-import { Spinner } from "heroui-native";
+import { Button, Spinner } from "heroui-native";
 import { useState, useCallback } from "react";
-import { FlatList, RefreshControl, Text, View } from "react-native";
+import { FlatList, RefreshControl, Share, Text, View } from "react-native";
 
 import { CandidateCard } from "@/components/candidate-card";
 import { Container } from "@/components/container";
 import { trpc } from "@/utils/trpc";
+
+const APP_SHARE_URL = "https://sip-and-speak.app";
+const APP_SHARE_MESSAGE =
+  "I'm using Sip&Speak to find a language exchange partner at TU/e — you should join too! " +
+  APP_SHARE_URL;
+
+function EmptySuggestionState() {
+  async function handleShare() {
+    await Share.share({ message: APP_SHARE_MESSAGE, url: APP_SHARE_URL });
+  }
+
+  return (
+    <View testID="empty-suggestion-state" className="flex-1 items-center justify-center px-6 gap-4">
+      <Text className="text-foreground text-xl font-semibold text-center">
+        No matches yet
+      </Text>
+      <Text className="text-muted-foreground text-center">
+        We couldn't find a match for your language yet — would you like to share
+        this app with a friend?
+      </Text>
+      <Button onPress={handleShare} testID="share-action">
+        <Button.Label>Share the app</Button.Label>
+      </Button>
+    </View>
+  );
+}
 
 export default function SuggestionsScreen() {
   const [refreshing, setRefreshing] = useState(false);
@@ -25,6 +51,17 @@ export default function SuggestionsScreen() {
       <Container isScrollable={false}>
         <View className="flex-1 items-center justify-center">
           <Spinner />
+        </View>
+      </Container>
+    );
+  }
+
+  if (!discoverQuery.isPending && partners.length === 0) {
+    return (
+      <Container isScrollable={false}>
+        <View className="flex-1 p-4">
+          <Text className="text-foreground text-2xl font-bold mb-4">Suggestions</Text>
+          <EmptySuggestionState />
         </View>
       </Container>
     );

--- a/apps/web/src/routes/suggestions.tsx
+++ b/apps/web/src/routes/suggestions.tsx
@@ -101,6 +101,39 @@ function CandidateCard({
   );
 }
 
+const APP_SHARE_URL = "https://sip-and-speak.app";
+const APP_SHARE_MESSAGE =
+  "I'm using Sip&Speak to find a language exchange partner at TU/e — you should join too! " +
+  APP_SHARE_URL;
+
+async function handleWebShare() {
+  if (navigator.share) {
+    await navigator.share({ title: "Sip&Speak", text: APP_SHARE_MESSAGE, url: APP_SHARE_URL });
+  } else {
+    await navigator.clipboard.writeText(APP_SHARE_URL);
+    // Toast not available here without additional setup — inline alert as fallback
+    alert("App link copied to clipboard!");
+  }
+}
+
+function EmptySuggestionState() {
+  return (
+    <div data-testid="empty-suggestion-state" className="flex flex-col items-center justify-center py-16 gap-4 text-center">
+      <p className="text-foreground text-xl font-semibold">No matches yet</p>
+      <p className="text-muted-foreground max-w-sm">
+        We couldn't find a match for your language yet — would you like to share this app with a friend?
+      </p>
+      <button
+        data-testid="share-action"
+        onClick={handleWebShare}
+        className="bg-primary text-primary-foreground px-4 py-2 rounded-lg font-medium hover:opacity-90 transition-opacity"
+      >
+        Share the app
+      </button>
+    </div>
+  );
+}
+
 function RouteComponent() {
   const discoverQuery = useQuery(trpc.matching.discover.queryOptions({}));
 
@@ -110,6 +143,15 @@ function RouteComponent() {
     return (
       <div className="flex items-center justify-center h-full">
         <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
+      </div>
+    );
+  }
+
+  if (!discoverQuery.isPending && partners.length === 0) {
+    return (
+      <div className="p-6 max-w-2xl mx-auto">
+        <h1 className="text-foreground text-2xl font-bold mb-6">Suggestions</h1>
+        <EmptySuggestionState />
       </div>
     );
   }


### PR DESCRIPTION
## Summary

When no compatible candidates exist, Students previously saw a blank list with no guidance. This turns that dead end into a viral growth moment — a friendly empty state with a share action so Students can invite a potential partner directly.

## Changes

- **Empty state in native suggestions screen** (`apps/native/app/suggestions.tsx`): `EmptySuggestionState` component shown when `discover` resolves with zero results; uses `Share.share()` for native OS share sheet
- **Empty state in web suggestions route** (`apps/web/src/routes/suggestions.tsx`): equivalent implementation using `navigator.share` with `navigator.clipboard` fallback

## Test plan

- [ ] Friendly message and share button visible when no candidates exist ✅
- [ ] Tapping "Share the app" opens native share sheet with `sip-and-speak.app` URL ✅
- [ ] Spinner shown during loading — empty state not rendered until query resolves ✅
- [ ] Web clipboard fallback when `navigator.share` unavailable — 🚫 blocked until web routing is implemented

## Related

Closes #117