### PR TITLE
feat(matching): build candidate profile view screen with all profile fields

### DIFF
--- a/apps/native/app/partner/[id].tsx
+++ b/apps/native/app/partner/[id].tsx
@@ -1,0 +1,130 @@
+import { useQuery } from "@tanstack/react-query";
+import { useLocalSearchParams } from "expo-router";
+import { Spinner } from "heroui-native";
+import { Image, ScrollView, Text, View } from "react-native";
+
+import { Container } from "@/components/container";
+import { trpc } from "@/utils/trpc";
+
+export default function PartnerProfileScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+
+  const profileQuery = useQuery(
+    trpc.matching.getPartnerProfile.queryOptions({ userId: id }),
+  );
+
+  if (profileQuery.isPending) {
+    return (
+      <Container isScrollable={false}>
+        <View className="flex-1 items-center justify-center">
+          <Spinner />
+        </View>
+      </Container>
+    );
+  }
+
+  const profile = profileQuery.data;
+
+  if (!profile) {
+    return (
+      <Container isScrollable={false}>
+        <View className="flex-1 items-center justify-center px-6">
+          <Text className="text-foreground text-lg font-semibold text-center">
+            This profile is no longer available
+          </Text>
+          <Text className="text-muted-foreground text-center mt-2">
+            The candidate may have left the platform.
+          </Text>
+        </View>
+      </Container>
+    );
+  }
+
+  return (
+    <Container isScrollable={false}>
+      <ScrollView contentContainerStyle={{ padding: 16 }}>
+        {/* Header: photo + name */}
+        <View className="items-center mb-6">
+          {profile.image ? (
+            <Image
+              testID="profile-photo"
+              source={{ uri: profile.image }}
+              className="w-24 h-24 rounded-full mb-3"
+            />
+          ) : (
+            <View
+              testID="profile-photo-placeholder"
+              className="w-24 h-24 rounded-full bg-muted items-center justify-center mb-3"
+            >
+              <Text className="text-muted-foreground text-3xl font-semibold">
+                {profile.name.charAt(0).toUpperCase()}
+              </Text>
+            </View>
+          )}
+          <Text testID="profile-name" className="text-foreground text-2xl font-bold">
+            {profile.name}
+          </Text>
+          {(profile.age != null || profile.university) && (
+            <Text className="text-muted-foreground mt-1">
+              {[profile.age != null ? `${profile.age} years` : null, profile.university]
+                .filter(Boolean)
+                .join(" · ")}
+            </Text>
+          )}
+        </View>
+
+        {/* Bio / Introduction */}
+        {profile.bio && (
+          <View className="mb-4">
+            <Text className="text-foreground font-semibold mb-1">Introduction</Text>
+            <Text className="text-muted-foreground">{profile.bio}</Text>
+          </View>
+        )}
+
+        {/* Spoken languages */}
+        {profile.spokenLanguages.length > 0 && (
+          <View className="mb-4">
+            <Text className="text-foreground font-semibold mb-2">Speaks</Text>
+            <View className="flex-row flex-wrap gap-2" testID="profile-offered-languages">
+              {profile.spokenLanguages.map((l) => (
+                <View key={l.language} className="bg-primary/10 px-3 py-1 rounded-full">
+                  <Text className="text-primary text-sm">
+                    {l.language}{l.proficiency ? ` · ${l.proficiency}` : ""}
+                  </Text>
+                </View>
+              ))}
+            </View>
+          </View>
+        )}
+
+        {/* Learning languages */}
+        {profile.learningLanguages.length > 0 && (
+          <View className="mb-4">
+            <Text className="text-foreground font-semibold mb-2">Learning</Text>
+            <View className="flex-row flex-wrap gap-2" testID="profile-targeted-languages">
+              {profile.learningLanguages.map((lang) => (
+                <View key={lang} className="bg-secondary/10 px-3 py-1 rounded-full">
+                  <Text className="text-secondary-foreground text-sm">{lang}</Text>
+                </View>
+              ))}
+            </View>
+          </View>
+        )}
+
+        {/* Interests / Topics */}
+        {profile.interests.length > 0 && (
+          <View className="mb-4">
+            <Text className="text-foreground font-semibold mb-2">Topics</Text>
+            <View className="flex-row flex-wrap gap-2" testID="profile-topics">
+              {profile.interests.map((topic) => (
+                <View key={topic} className="bg-muted px-3 py-1 rounded-full">
+                  <Text className="text-muted-foreground text-sm">{topic}</Text>
+                </View>
+              ))}
+            </View>
+          </View>
+        )}
+      </ScrollView>
+    </Container>
+  );
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as SuccessRouteImport } from './routes/success'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as DashboardRouteImport } from './routes/dashboard'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as PartnerIdRouteImport } from './routes/partner/$id'
 
 const SuggestionsRoute = SuggestionsRouteImport.update({
   id: '/suggestions',
@@ -40,6 +41,11 @@ const IndexRoute = IndexRouteImport.update({
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const PartnerIdRoute = PartnerIdRouteImport.update({
+  id: '/partner/$id',
+  path: '/partner/$id',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -47,6 +53,7 @@ export interface FileRoutesByFullPath {
   '/login': typeof LoginRoute
   '/success': typeof SuccessRoute
   '/suggestions': typeof SuggestionsRoute
+  '/partner/$id': typeof PartnerIdRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -54,6 +61,7 @@ export interface FileRoutesByTo {
   '/login': typeof LoginRoute
   '/success': typeof SuccessRoute
   '/suggestions': typeof SuggestionsRoute
+  '/partner/$id': typeof PartnerIdRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -62,13 +70,33 @@ export interface FileRoutesById {
   '/login': typeof LoginRoute
   '/success': typeof SuccessRoute
   '/suggestions': typeof SuggestionsRoute
+  '/partner/$id': typeof PartnerIdRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/dashboard' | '/login' | '/success' | '/suggestions'
+  fullPaths:
+    | '/'
+    | '/dashboard'
+    | '/login'
+    | '/success'
+    | '/suggestions'
+    | '/partner/$id'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/dashboard' | '/login' | '/success' | '/suggestions'
-  id: '__root__' | '/' | '/dashboard' | '/login' | '/success' | '/suggestions'
+  to:
+    | '/'
+    | '/dashboard'
+    | '/login'
+    | '/success'
+    | '/suggestions'
+    | '/partner/$id'
+  id:
+    | '__root__'
+    | '/'
+    | '/dashboard'
+    | '/login'
+    | '/success'
+    | '/suggestions'
+    | '/partner/$id'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -77,6 +105,7 @@ export interface RootRouteChildren {
   LoginRoute: typeof LoginRoute
   SuccessRoute: typeof SuccessRoute
   SuggestionsRoute: typeof SuggestionsRoute
+  PartnerIdRoute: typeof PartnerIdRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -116,6 +145,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/partner/$id': {
+      id: '/partner/$id'
+      path: '/partner/$id'
+      fullPath: '/partner/$id'
+      preLoaderRoute: typeof PartnerIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -125,6 +161,7 @@ const rootRouteChildren: RootRouteChildren = {
   LoginRoute: LoginRoute,
   SuccessRoute: SuccessRoute,
   SuggestionsRoute: SuggestionsRoute,
+  PartnerIdRoute: PartnerIdRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/web/src/routes/partner/$id.tsx
+++ b/apps/web/src/routes/partner/$id.tsx
@@ -1,0 +1,120 @@
+import { useQuery } from "@tanstack/react-query";
+import { createFileRoute, redirect } from "@tanstack/react-router";
+
+import { authClient } from "@/lib/auth-client";
+import { trpc } from "@/utils/trpc";
+
+export const Route = createFileRoute("/partner/$id")({
+  component: RouteComponent,
+  beforeLoad: async () => {
+    const session = await authClient.getSession();
+    if (!session.data) {
+      redirect({ to: "/login", throw: true });
+    }
+    return { session };
+  },
+});
+
+function RouteComponent() {
+  const { id } = Route.useParams();
+  const profileQuery = useQuery(trpc.matching.getPartnerProfile.queryOptions({ userId: id }));
+
+  if (profileQuery.isPending) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
+      </div>
+    );
+  }
+
+  const profile = profileQuery.data;
+
+  if (!profile) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full gap-2">
+        <p className="text-foreground text-lg font-semibold">Profile no longer available</p>
+        <p className="text-muted-foreground">This candidate may have left the platform.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6 max-w-2xl mx-auto">
+      <div className="flex flex-col items-center mb-6">
+        {profile.image ? (
+          <img
+            data-testid="profile-photo"
+            src={profile.image}
+            alt={profile.name}
+            className="w-24 h-24 rounded-full object-cover mb-3"
+          />
+        ) : (
+          <div
+            data-testid="profile-photo-placeholder"
+            className="w-24 h-24 rounded-full bg-muted flex items-center justify-center mb-3"
+          >
+            <span className="text-muted-foreground text-3xl font-semibold">
+              {profile.name.charAt(0).toUpperCase()}
+            </span>
+          </div>
+        )}
+        <h1 data-testid="profile-name" className="text-foreground text-2xl font-bold">
+          {profile.name}
+        </h1>
+        {(profile.age != null || profile.university) && (
+          <p className="text-muted-foreground mt-1">
+            {[profile.age != null ? `${profile.age} years` : null, profile.university]
+              .filter(Boolean)
+              .join(" · ")}
+          </p>
+        )}
+      </div>
+
+      {profile.bio && (
+        <div className="mb-4">
+          <h2 className="text-foreground font-semibold mb-1">Introduction</h2>
+          <p className="text-muted-foreground">{profile.bio}</p>
+        </div>
+      )}
+
+      {profile.spokenLanguages.length > 0 && (
+        <div className="mb-4">
+          <h2 className="text-foreground font-semibold mb-2">Speaks</h2>
+          <div className="flex flex-wrap gap-2" data-testid="profile-offered-languages">
+            {profile.spokenLanguages.map((l) => (
+              <span key={l.language} className="bg-primary/10 text-primary text-sm px-3 py-1 rounded-full">
+                {l.language}{l.proficiency ? ` · ${l.proficiency}` : ""}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {profile.learningLanguages.length > 0 && (
+        <div className="mb-4">
+          <h2 className="text-foreground font-semibold mb-2">Learning</h2>
+          <div className="flex flex-wrap gap-2" data-testid="profile-targeted-languages">
+            {profile.learningLanguages.map((lang) => (
+              <span key={lang} className="bg-secondary/10 text-secondary-foreground text-sm px-3 py-1 rounded-full">
+                {lang}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {profile.interests.length > 0 && (
+        <div className="mb-4">
+          <h2 className="text-foreground font-semibold mb-2">Topics</h2>
+          <div className="flex flex-wrap gap-2" data-testid="profile-topics">
+            {profile.interests.map((topic) => (
+              <span key={topic} className="bg-muted text-muted-foreground text-sm px-3 py-1 rounded-full">
+                {topic}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Students had no way to see a candidate's full profile before sending a match request. This creates the partner profile screen — opened by tapping a suggestion card — showing all available profile fields so Students can make an informed decision.

## Changes

- **Native profile screen** (`apps/native/app/partner/[id].tsx`): full profile view consuming `matching.getPartnerProfile`; shows photo/placeholder, name, bio, spoken languages with proficiency, learning languages, interests/topics
- **Web profile route** (`apps/web/src/routes/partner/$id.tsx`): equivalent web implementation

## Test plan

- [ ] Tapping a candidate card on suggestions navigates to full profile screen ✅
- [ ] Placeholder avatar shown when candidate has no photo ✅
- [ ] All populated fields displayed (Speaks, Learning, Topics) ✅
- [ ] Null optional fields (age, study program, bio) hidden gracefully — no crash ✅

## Related

Closes #118