### PR TITLE
feat(matching): surface Send Request contextually based on match status

### DIFF
--- a/apps/native/__tests__/partner-profile.test.tsx
+++ b/apps/native/__tests__/partner-profile.test.tsx
@@ -1,6 +1,7 @@
 /**
  * Tests for tasks:
  *   #119 — Display comments section on candidate profile
+ *   #120 — Surface "Send Request" action contextually based on match status
  *   #121 — Handle removed/unavailable candidate profile gracefully
  *   #122 — Send Request button on candidate profile screen
  */
@@ -19,6 +20,7 @@ jest.mock("expo-router", () => ({
 const mockProfileFn = jest.fn();
 const mockCommentsFn = jest.fn();
 const mockSendMatchRequest = jest.fn();
+const mockGetMatchRequestStatusFn = jest.fn();
 
 jest.mock("@/utils/trpc", () => ({
   trpc: {
@@ -31,6 +33,12 @@ jest.mock("@/utils/trpc", () => ({
       },
       sendMatchRequest: {
         mutationOptions: () => ({ mutationFn: mockSendMatchRequest }),
+      },
+      getMatchRequestStatus: {
+        queryOptions: () => ({
+          queryKey: ["matching.getMatchRequestStatus"],
+          queryFn: () => mockGetMatchRequestStatusFn(),
+        }),
       },
     },
     profile: {
@@ -81,6 +89,7 @@ beforeEach(() => {
   mockSendMatchRequest.mockClear().mockResolvedValue({ matchRequestId: "req-1", status: "pending" });
   mockProfileFn.mockReset().mockResolvedValue(defaultProfile);
   mockCommentsFn.mockReset().mockResolvedValue([]);
+  mockGetMatchRequestStatusFn.mockReset().mockResolvedValue({ matchRequestStatus: "none" });
 });
 
 // ─── #119: Comments section ────────────────────────────────────────────────
@@ -152,5 +161,31 @@ describe("#122 — Send Request on candidate profile screen", () => {
     await waitFor(() => {
       expect(mockSendMatchRequest).toHaveBeenCalledTimes(1);
     });
+  });
+});
+
+// ─── #120: Contextual Send Request based on match status ───────────────────
+
+describe("#120 — Contextual Send Request action on candidate profile", () => {
+  it("shows Send Request button when no request has been sent", async () => {
+    mockGetMatchRequestStatusFn.mockResolvedValue({ matchRequestStatus: "none" });
+
+    renderScreen();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("send-request-button")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("request-sent-indicator")).toBeNull();
+  });
+
+  it("hides Send Request button and shows Request Sent indicator when a request has already been sent", async () => {
+    mockGetMatchRequestStatusFn.mockResolvedValue({ matchRequestStatus: "pending" });
+
+    renderScreen();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("request-sent-indicator")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("send-request-button")).toBeNull();
   });
 });

--- a/apps/native/app/partner/[id].tsx
+++ b/apps/native/app/partner/[id].tsx
@@ -19,6 +19,10 @@ export default function PartnerProfileScreen() {
     trpc.profile.getCandidateComments.queryOptions({ candidateUserId: id }),
   );
 
+  const statusQuery = useQuery(
+    trpc.matching.getMatchRequestStatus.queryOptions({ candidateUserId: id }),
+  );
+
   const sendRequestMutation = useMutation(
     trpc.matching.sendMatchRequest.mutationOptions(),
   );
@@ -57,6 +61,9 @@ export default function PartnerProfileScreen() {
 
   const profile = profileQuery.data;
   const comments = commentsQuery.data ?? [];
+  const requestAlreadySent =
+    (statusQuery.data !== undefined && statusQuery.data.matchRequestStatus !== "none") ||
+    sendRequestMutation.isSuccess;
 
   return (
     <Container isScrollable={false}>
@@ -166,22 +173,26 @@ export default function PartnerProfileScreen() {
           )}
         </View>
 
-        {/* #122 — Send Request */}
-        <Button
-          testID="send-request-button"
-          variant="primary"
-          isDisabled={sendRequestMutation.isPending || sendRequestMutation.isSuccess}
-          onPress={() => sendRequestMutation.mutate({ receiverId: id })}
-          className="mb-4"
-        >
-          {sendRequestMutation.isPending ? (
-            <Spinner size="sm" />
-          ) : (
-            <Button.Label>
-              {sendRequestMutation.isSuccess ? "Request Sent" : "Send Request"}
-            </Button.Label>
-          )}
-        </Button>
+        {/* #120/#122 — Contextual Send Request */}
+        {requestAlreadySent ? (
+          <View testID="request-sent-indicator" className="bg-muted rounded-xl p-4 mb-4 items-center">
+            <Text className="text-muted-foreground font-medium">Request Sent</Text>
+          </View>
+        ) : (
+          <Button
+            testID="send-request-button"
+            variant="primary"
+            isDisabled={sendRequestMutation.isPending || statusQuery.isPending}
+            onPress={() => sendRequestMutation.mutate({ receiverId: id })}
+            className="mb-4"
+          >
+            {sendRequestMutation.isPending ? (
+              <Spinner size="sm" />
+            ) : (
+              <Button.Label>Send Request</Button.Label>
+            )}
+          </Button>
+        )}
       </ScrollView>
     </Container>
   );

--- a/packages/api/src/routers/matching.ts
+++ b/packages/api/src/routers/matching.ts
@@ -336,6 +336,24 @@ export const matchingRouter = router({
       };
     }),
 
+  getMatchRequestStatus: protectedProcedure
+    .input(z.object({ candidateUserId: z.string() }))
+    .query(async ({ ctx, input }) => {
+      const requesterId = ctx.session.user.id;
+      const existing = await db.query.matchRequest.findFirst({
+        where: and(
+          eq(matchRequest.requesterId, requesterId),
+          eq(matchRequest.receiverId, input.candidateUserId),
+        ),
+      });
+      const status = existing?.status;
+      const matchRequestStatus =
+        status === "pending" || status === "accepted" || status === "declined"
+          ? status
+          : ("none" as const);
+      return { matchRequestStatus };
+    }),
+
   sendMatchRequest: protectedProcedure
     .input(z.object({ receiverId: z.string() }))
     .mutation(async ({ ctx, input }) => {


### PR DESCRIPTION
## Summary

Students could tap "Send Request" on a candidate profile even if they had already sent a request — leading to confusion and a CONFLICT error from the server. This adds a `getMatchRequestStatus` tRPC query so the profile screen knows the current request state on load, hiding the action button and showing a "Request Sent" indicator when a request is already pending, accepted, or declined.

Closes Feature #13 AC: _"A 'Send Request' action is available on profiles the Student has not yet requested."_

## Changes

- **New tRPC query** — `matching.getMatchRequestStatus(candidateUserId)` reads the `matchRequest` table and returns `none | pending | accepted | declined`. Returns `none` for voided or absent requests.
- **Profile screen** — runs the status query in parallel with `getPartnerProfile`; renders a "Request Sent" indicator (`request-sent-indicator`) when a prior request exists, or the Send Request button (`send-request-button`) when status is `none`. Also handles the post-mutation success case.
- **Tests** — two new `#120` scenarios added to `partner-profile.test.tsx`, mocking the new query; existing `#119`, `#121`, `#122` scenarios continue to pass.

## Test plan

- [ ] Send Request button is shown when no request has been sent
- [ ] Send Request button is hidden and "Request Sent" indicator is shown after a request has been sent

## Related

Closes #120
