### PR TITLE
feat(matching): prevent duplicate requests, allow re-request after decline

### DIFF
--- a/apps/native/__tests__/partner-profile.test.tsx
+++ b/apps/native/__tests__/partner-profile.test.tsx
@@ -189,3 +189,47 @@ describe("#120 — Contextual Send Request action on candidate profile", () => {
     expect(screen.queryByTestId("send-request-button")).toBeNull();
   });
 });
+
+// ─── #123: Duplicate match request prevention ──────────────────────────────
+
+describe("#123 — Duplicate match request prevention on candidate profile", () => {
+  it("shows conflict error message when a second request is attempted", async () => {
+    const conflictError = Object.assign(new Error("Conflict"), {
+      data: { code: "CONFLICT" },
+    });
+    mockSendMatchRequest.mockRejectedValue(conflictError);
+
+    renderScreen();
+
+    await waitFor(() => screen.getByTestId("send-request-button"));
+    fireEvent.press(screen.getByTestId("send-request-button"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("conflict-error-message")).toBeTruthy();
+    });
+  });
+
+  it("shows Send Request button (not indicator) when previous request was declined", async () => {
+    mockGetMatchRequestStatusFn.mockResolvedValue({ matchRequestStatus: "declined" });
+
+    renderScreen();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("send-request-button")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("request-sent-indicator")).toBeNull();
+  });
+
+  it("allows re-requesting after a decline", async () => {
+    mockGetMatchRequestStatusFn.mockResolvedValue({ matchRequestStatus: "declined" });
+
+    renderScreen();
+
+    await waitFor(() => screen.getByTestId("send-request-button"));
+    fireEvent.press(screen.getByTestId("send-request-button"));
+
+    await waitFor(() => {
+      expect(mockSendMatchRequest).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/native/app/partner/[id].tsx
+++ b/apps/native/app/partner/[id].tsx
@@ -1,7 +1,7 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { Button, Spinner } from "heroui-native";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { Image, ScrollView, Text, View } from "react-native";
 
 import { Container } from "@/components/container";
@@ -23,9 +23,16 @@ export default function PartnerProfileScreen() {
     trpc.matching.getMatchRequestStatus.queryOptions({ candidateUserId: id }),
   );
 
-  const sendRequestMutation = useMutation(
-    trpc.matching.sendMatchRequest.mutationOptions(),
-  );
+  const [sendConflictError, setSendConflictError] = useState<string | null>(null);
+
+  const sendRequestMutation = useMutation({
+    ...trpc.matching.sendMatchRequest.mutationOptions(),
+    onError: (error: { data?: { code?: string } }) => {
+      if (error.data?.code === "CONFLICT") {
+        setSendConflictError("A match request to this candidate already exists.");
+      }
+    },
+  });
 
   // #121 — if profile is no longer available, navigate back
   useEffect(() => {
@@ -62,7 +69,7 @@ export default function PartnerProfileScreen() {
   const profile = profileQuery.data;
   const comments = commentsQuery.data ?? [];
   const requestAlreadySent =
-    (statusQuery.data !== undefined && statusQuery.data.matchRequestStatus !== "none") ||
+    (statusQuery.data?.matchRequestStatus === "pending" || statusQuery.data?.matchRequestStatus === "accepted") ||
     sendRequestMutation.isSuccess;
 
   return (
@@ -172,6 +179,13 @@ export default function PartnerProfileScreen() {
             ))
           )}
         </View>
+
+        {/* #123 — Conflict error */}
+        {sendConflictError && (
+          <View testID="conflict-error-message" className="bg-danger/10 rounded-xl p-3 mb-3">
+            <Text className="text-danger text-sm text-center">{sendConflictError}</Text>
+          </View>
+        )}
 
         {/* #120/#122 — Contextual Send Request */}
         {requestAlreadySent ? (

--- a/apps/native/components/candidate-card.tsx
+++ b/apps/native/components/candidate-card.tsx
@@ -1,6 +1,7 @@
 import { useMutation } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
 import { Button, Spinner } from "heroui-native";
+import { useState } from "react";
 import { Image, Pressable, Text, View } from "react-native";
 
 import { trpc } from "@/utils/trpc";
@@ -23,9 +24,15 @@ export function CandidateCard({
   interests,
 }: CandidateCardProps) {
   const router = useRouter();
-  const sendRequestMutation = useMutation(
-    trpc.matching.sendMatchRequest.mutationOptions(),
-  );
+  const [sendConflictError, setSendConflictError] = useState<string | null>(null);
+  const sendRequestMutation = useMutation({
+    ...trpc.matching.sendMatchRequest.mutationOptions(),
+    onError: (error: { data?: { code?: string } }) => {
+      if (error.data?.code === "CONFLICT") {
+        setSendConflictError("A match request to this candidate already exists.");
+      }
+    },
+  });
 
   function handlePress() {
     router.push(`/partner/${userId}` as never);
@@ -101,6 +108,13 @@ export function CandidateCard({
               </View>
             ))}
           </View>
+        </View>
+      )}
+
+      {/* #123 — Conflict error */}
+      {sendConflictError && (
+        <View testID="conflict-error-message" className="bg-danger/10 rounded-xl p-2 mb-2">
+          <Text className="text-danger text-xs text-center">{sendConflictError}</Text>
         </View>
       )}
 

--- a/packages/api/src/routers/matching.ts
+++ b/packages/api/src/routers/matching.ts
@@ -377,11 +377,12 @@ export const matchingRouter = router({
         });
       }
 
-      // Check for existing active request (dedup at app level)
+      // Check for existing active request (pending or accepted only — declined allows re-request)
       const existing = await db.query.matchRequest.findFirst({
         where: and(
           eq(matchRequest.requesterId, requesterId),
           eq(matchRequest.receiverId, input.receiverId),
+          inArray(matchRequest.status, ["pending", "accepted"]),
         ),
       });
       if (existing) {


### PR DESCRIPTION
## Summary

A Student could send multiple match requests to the same candidate because the duplicate check in `sendMatchRequest` compared against all request statuses, including declined ones. This meant a Student who received a decline couldn't try again, and a Student with a pending request could trigger a confusing CONFLICT error without any visible feedback.

This fixes both problems: the duplicate check now only blocks pending or accepted requests (allowing re-requests after a decline), and both the profile screen and suggestion card surface a clear inline error message when a duplicate is attempted.

## Changes

- **Backend duplicate check** — `sendMatchRequest` now filters by `status IN ('pending', 'accepted')` so declined requests don't block a second attempt
- **Profile screen** — adds CONFLICT `onError` handler with `useState` error state; fixes `requestAlreadySent` logic to only show the indicator for pending/accepted (not declined)
- **Candidate card** — same CONFLICT error handling as the profile screen
- **Tests** — three new `#123` scenarios covering the conflict message, the declined-shows-button case, and the re-request-succeeds case

## Test plan

- [ ] Second request to the same candidate is blocked (conflict error message shown)
- [ ] Re-request after decline is allowed (Send Request button shown when status is declined)
- [ ] Re-request after decline calls the mutation successfully

## Related

Closes #123
