### PR TITLE
feat(matching): show confirmation feedback after match request is sent

### DIFF
--- a/apps/native/__tests__/candidate-card.test.tsx
+++ b/apps/native/__tests__/candidate-card.test.tsx
@@ -45,6 +45,30 @@ beforeEach(() => {
   mockSendMatchRequest.mockClear();
 });
 
+// ─── #124: Confirmation feedback ───────────────────────────────────────────
+
+describe("#124 — Confirmation feedback on suggestion card", () => {
+  it("shows confirmation message after successfully sending a request", async () => {
+    renderWithQuery(<CandidateCard {...defaultProps} />);
+
+    fireEvent.press(screen.getByTestId("send-request-button"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("confirmation-message")).toBeTruthy();
+    });
+  });
+
+  it("updates card to show 'Request Sent' instead of 'Send Request' after success", async () => {
+    renderWithQuery(<CandidateCard {...defaultProps} />);
+
+    fireEvent.press(screen.getByTestId("send-request-button"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Request Sent")).toBeTruthy();
+    });
+  });
+});
+
 describe("#122 — Send Request on suggestion card", () => {
   it("renders a Send Request button", () => {
     renderWithQuery(<CandidateCard {...defaultProps} />);

--- a/apps/native/__tests__/partner-profile.test.tsx
+++ b/apps/native/__tests__/partner-profile.test.tsx
@@ -141,6 +141,33 @@ describe("#121 — Handle removed/unavailable candidate profile gracefully", () 
   });
 });
 
+// ─── #124: Confirmation feedback ───────────────────────────────────────────
+
+describe("#124 — Confirmation feedback on candidate profile", () => {
+  it("shows confirmation message after successfully sending a request", async () => {
+    renderScreen();
+
+    await waitFor(() => screen.getByTestId("send-request-button"));
+    fireEvent.press(screen.getByTestId("send-request-button"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("confirmation-message")).toBeTruthy();
+    });
+  });
+
+  it("shows Request Sent indicator instead of Send Request button after success", async () => {
+    renderScreen();
+
+    await waitFor(() => screen.getByTestId("send-request-button"));
+    fireEvent.press(screen.getByTestId("send-request-button"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("request-sent-indicator")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("send-request-button")).toBeNull();
+  });
+});
+
 // ─── #122: Send Request on profile screen ──────────────────────────────────
 
 describe("#122 — Send Request on candidate profile screen", () => {

--- a/apps/native/app/partner/[id].tsx
+++ b/apps/native/app/partner/[id].tsx
@@ -180,6 +180,15 @@ export default function PartnerProfileScreen() {
           )}
         </View>
 
+        {/* #124 — Confirmation feedback */}
+        {sendRequestMutation.isSuccess && (
+          <View testID="confirmation-message" className="bg-primary/10 rounded-xl p-3 mb-3">
+            <Text className="text-primary text-sm text-center">
+              Request sent! We'll let you know when they respond.
+            </Text>
+          </View>
+        )}
+
         {/* #123 — Conflict error */}
         {sendConflictError && (
           <View testID="conflict-error-message" className="bg-danger/10 rounded-xl p-3 mb-3">

--- a/apps/native/components/candidate-card.tsx
+++ b/apps/native/components/candidate-card.tsx
@@ -111,6 +111,15 @@ export function CandidateCard({
         </View>
       )}
 
+      {/* #124 — Confirmation feedback */}
+      {sendRequestMutation.isSuccess && (
+        <View testID="confirmation-message" className="bg-primary/10 rounded-xl p-2 mb-2">
+          <Text className="text-primary text-xs text-center">
+            Request sent! We'll let you know when they respond.
+          </Text>
+        </View>
+      )}
+
       {/* #123 — Conflict error */}
       {sendConflictError && (
         <View testID="conflict-error-message" className="bg-danger/10 rounded-xl p-2 mb-2">


### PR DESCRIPTION
## Summary

- Show inline confirmation banner on suggestion card after `sendMatchRequest` succeeds
- Show inline confirmation banner on candidate profile screen after `sendMatchRequest` succeeds
- Both locations already updated button state to "Request Sent" — this adds the explicit confirmation message

## Test plan

- [x] `#124 — Confirmation feedback on suggestion card` — shows `confirmation-message` testID after press
- [x] `#124 — Confirmation feedback on candidate profile` — shows `confirmation-message` and `request-sent-indicator` after press
- All 17 tests passing in candidate-card and partner-profile suites

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)