### PR TITLE
feat(matching): send match request — confirmation feedback + discovery exclusion

### DIFF
--- a/apps/native/__tests__/candidate-card.test.tsx
+++ b/apps/native/__tests__/candidate-card.test.tsx
@@ -45,6 +45,30 @@ beforeEach(() => {
   mockSendMatchRequest.mockClear();
 });
 
+// ─── #124: Confirmation feedback ───────────────────────────────────────────
+
+describe("#124 — Confirmation feedback on suggestion card", () => {
+  it("shows confirmation message after successfully sending a request", async () => {
+    renderWithQuery(<CandidateCard {...defaultProps} />);
+
+    fireEvent.press(screen.getByTestId("send-request-button"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("confirmation-message")).toBeTruthy();
+    });
+  });
+
+  it("updates card to show 'Request Sent' instead of 'Send Request' after success", async () => {
+    renderWithQuery(<CandidateCard {...defaultProps} />);
+
+    fireEvent.press(screen.getByTestId("send-request-button"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Request Sent")).toBeTruthy();
+    });
+  });
+});
+
 describe("#122 — Send Request on suggestion card", () => {
   it("renders a Send Request button", () => {
     renderWithQuery(<CandidateCard {...defaultProps} />);

--- a/apps/native/__tests__/partner-profile.test.tsx
+++ b/apps/native/__tests__/partner-profile.test.tsx
@@ -141,6 +141,33 @@ describe("#121 — Handle removed/unavailable candidate profile gracefully", () 
   });
 });
 
+// ─── #124: Confirmation feedback ───────────────────────────────────────────
+
+describe("#124 — Confirmation feedback on candidate profile", () => {
+  it("shows confirmation message after successfully sending a request", async () => {
+    renderScreen();
+
+    await waitFor(() => screen.getByTestId("send-request-button"));
+    fireEvent.press(screen.getByTestId("send-request-button"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("confirmation-message")).toBeTruthy();
+    });
+  });
+
+  it("shows Request Sent indicator instead of Send Request button after success", async () => {
+    renderScreen();
+
+    await waitFor(() => screen.getByTestId("send-request-button"));
+    fireEvent.press(screen.getByTestId("send-request-button"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("request-sent-indicator")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("send-request-button")).toBeNull();
+  });
+});
+
 // ─── #122: Send Request on profile screen ──────────────────────────────────
 
 describe("#122 — Send Request on candidate profile screen", () => {

--- a/apps/native/app/partner/[id].tsx
+++ b/apps/native/app/partner/[id].tsx
@@ -180,6 +180,15 @@ export default function PartnerProfileScreen() {
           )}
         </View>
 
+        {/* #124 — Confirmation feedback */}
+        {sendRequestMutation.isSuccess && (
+          <View testID="confirmation-message" className="bg-primary/10 rounded-xl p-3 mb-3">
+            <Text className="text-primary text-sm text-center">
+              Request sent! We'll let you know when they respond.
+            </Text>
+          </View>
+        )}
+
         {/* #123 — Conflict error */}
         {sendConflictError && (
           <View testID="conflict-error-message" className="bg-danger/10 rounded-xl p-3 mb-3">

--- a/apps/native/components/candidate-card.tsx
+++ b/apps/native/components/candidate-card.tsx
@@ -111,6 +111,15 @@ export function CandidateCard({
         </View>
       )}
 
+      {/* #124 — Confirmation feedback */}
+      {sendRequestMutation.isSuccess && (
+        <View testID="confirmation-message" className="bg-primary/10 rounded-xl p-2 mb-2">
+          <Text className="text-primary text-xs text-center">
+            Request sent! We'll let you know when they respond.
+          </Text>
+        </View>
+      )}
+
       {/* #123 — Conflict error */}
       {sendConflictError && (
         <View testID="conflict-error-message" className="bg-danger/10 rounded-xl p-2 mb-2">

--- a/packages/api/src/__tests__/matching.test.ts
+++ b/packages/api/src/__tests__/matching.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Tests for task #125 — Exclude requested candidates from future suggestion lists
+ *
+ * Tests cover the pure buildExcludedUserIds helper used by the discover procedure.
+ */
+import { describe, expect, it } from "bun:test";
+
+import { buildExcludedUserIds } from "../routers/matching-utils";
+
+const ME = "user-me";
+
+describe("#125 — buildExcludedUserIds", () => {
+  it("excludes receiver when student has sent a pending request", () => {
+    const requests = [{ requesterId: ME, receiverId: "candidate-a" }];
+    expect(buildExcludedUserIds(ME, requests)).toEqual(["candidate-a"]);
+  });
+
+  it("excludes requester when a candidate has sent a request to the student", () => {
+    const requests = [{ requesterId: "candidate-b", receiverId: ME }];
+    expect(buildExcludedUserIds(ME, requests)).toEqual(["candidate-b"]);
+  });
+
+  it("handles bidirectional exclusion (both directions in the same list)", () => {
+    const requests = [
+      { requesterId: ME, receiverId: "candidate-c" },
+      { requesterId: "candidate-d", receiverId: ME },
+    ];
+    expect(buildExcludedUserIds(ME, requests)).toEqual(["candidate-c", "candidate-d"]);
+  });
+
+  it("returns empty array when there are no active requests", () => {
+    expect(buildExcludedUserIds(ME, [])).toEqual([]);
+  });
+
+  it("declined request records are not passed in (caller filters by status)", () => {
+    // Declined requests are excluded from activeRequests by the SQL filter —
+    // this test confirms that if no requests are passed, no one is excluded.
+    expect(buildExcludedUserIds(ME, [])).toEqual([]);
+  });
+});

--- a/packages/api/src/routers/matching-utils.ts
+++ b/packages/api/src/routers/matching-utils.ts
@@ -1,0 +1,100 @@
+// Pure, side-effect-free helpers for the matching router.
+// Exported separately so they can be unit-tested without importing the DB or env.
+
+const MAX_RADIUS_KM = 50;
+
+/** Haversine distance in km between two lat/lng points */
+export function haversineDistance(
+  lat1: number,
+  lon1: number,
+  lat2: number,
+  lon2: number,
+): number {
+  const R = 6371;
+  const toRad = (deg: number) => (deg * Math.PI) / 180;
+  const dLat = toRad(lat2 - lat1);
+  const dLon = toRad(lon2 - lon1);
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+/**
+ * Language complementarity score.
+ * 1.0 — partner speaks a language user wants to learn AND partner wants to learn a language user speaks.
+ * 0.5 — only one direction matches.
+ * 0   — no complementarity.
+ */
+export function computeLanguageScore(
+  userSpoken: string[],
+  userLearning: string[],
+  partnerSpoken: string[],
+  partnerLearning: string[],
+): number {
+  const partnerSpeaksWhatUserLearns = userLearning.some((lang) =>
+    partnerSpoken.includes(lang),
+  );
+  const partnerLearnsWhatUserSpeaks = partnerLearning.some((lang) =>
+    userSpoken.includes(lang),
+  );
+
+  if (partnerSpeaksWhatUserLearns && partnerLearnsWhatUserSpeaks) return 1.0;
+  if (partnerSpeaksWhatUserLearns || partnerLearnsWhatUserSpeaks) return 0.5;
+  return 0;
+}
+
+/**
+ * Interest overlap score: sharedInterests / max(userInterests, partnerInterests).
+ * Returns 0 when both lists are empty.
+ */
+export function computeInterestScore(
+  userInterests: string[],
+  partnerInterests: string[],
+): number {
+  const maxLen = Math.max(userInterests.length, partnerInterests.length);
+  if (maxLen === 0) return 0;
+  const shared = userInterests.filter((i) => partnerInterests.includes(i));
+  return shared.length / maxLen;
+}
+
+/**
+ * Proximity score: 1 - min(distance / maxRadius, 1).
+ * Closer = higher score.
+ */
+export function computeProximityScore(
+  distanceKm: number,
+  maxRadius: number = MAX_RADIUS_KM,
+): number {
+  return 1 - Math.min(distanceKm / maxRadius, 1);
+}
+
+/**
+ * Composite matching score.
+ * Default weights: language 0.5, interest 0.3, proximity 0.2.
+ * "near_you" filter boosts proximity: language 0.3, interest 0.2, proximity 0.5.
+ */
+export function computeCompositeScore(
+  languageScore: number,
+  interestScore: number,
+  proximityScore: number,
+  filter?: "near_you" | "language",
+): number {
+  if (filter === "near_you") {
+    return languageScore * 0.3 + interestScore * 0.2 + proximityScore * 0.5;
+  }
+  return languageScore * 0.5 + interestScore * 0.3 + proximityScore * 0.2;
+}
+
+/**
+ * Extract excluded user IDs from active match requests involving the given user.
+ * Bidirectional: a candidate who sent a request to the user is also excluded.
+ */
+export function buildExcludedUserIds(
+  userId: string,
+  activeRequests: { requesterId: string; receiverId: string }[],
+): string[] {
+  return activeRequests.map((r) =>
+    r.requesterId === userId ? r.receiverId : r.requesterId,
+  );
+}

--- a/packages/api/src/routers/matching.ts
+++ b/packages/api/src/routers/matching.ts
@@ -1,4 +1,4 @@
-import { and, eq, ne, inArray } from "drizzle-orm";
+import { and, eq, ne, inArray, notInArray, or } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { db } from "@sip-and-speak/db";
@@ -11,93 +11,23 @@ import {
 import { user } from "@sip-and-speak/db/schema/auth";
 import { protectedProcedure, router } from "../index";
 import { domainEvents } from "../domain-events";
+import {
+  haversineDistance,
+  computeLanguageScore,
+  computeInterestScore,
+  computeProximityScore,
+  computeCompositeScore,
+  buildExcludedUserIds,
+} from "./matching-utils";
 
-// --- Scoring helpers (exported for testing) ---
-
-const MAX_RADIUS_KM = 50;
-
-/** Haversine distance in km between two lat/lng points */
-export function haversineDistance(
-  lat1: number,
-  lon1: number,
-  lat2: number,
-  lon2: number,
-): number {
-  const R = 6371; // Earth radius in km
-  const toRad = (deg: number) => (deg * Math.PI) / 180;
-  const dLat = toRad(lat2 - lat1);
-  const dLon = toRad(lon2 - lon1);
-  const a =
-    Math.sin(dLat / 2) ** 2 +
-    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2;
-  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-}
-
-/**
- * Language complementarity score.
- * 1.0 — partner speaks a language user wants to learn AND partner wants to learn a language user speaks.
- * 0.5 — only one direction matches.
- * 0   — no complementarity.
- */
-export function computeLanguageScore(
-  userSpoken: string[],
-  userLearning: string[],
-  partnerSpoken: string[],
-  partnerLearning: string[],
-): number {
-  const partnerSpeaksWhatUserLearns = userLearning.some((lang) =>
-    partnerSpoken.includes(lang),
-  );
-  const partnerLearnsWhatUserSpeaks = partnerLearning.some((lang) =>
-    userSpoken.includes(lang),
-  );
-
-  if (partnerSpeaksWhatUserLearns && partnerLearnsWhatUserSpeaks) return 1.0;
-  if (partnerSpeaksWhatUserLearns || partnerLearnsWhatUserSpeaks) return 0.5;
-  return 0;
-}
-
-/**
- * Interest overlap score: sharedInterests / max(userInterests, partnerInterests).
- * Returns 0 when both lists are empty.
- */
-export function computeInterestScore(
-  userInterests: string[],
-  partnerInterests: string[],
-): number {
-  const maxLen = Math.max(userInterests.length, partnerInterests.length);
-  if (maxLen === 0) return 0;
-  const shared = userInterests.filter((i) => partnerInterests.includes(i));
-  return shared.length / maxLen;
-}
-
-/**
- * Proximity score: 1 - min(distance / maxRadius, 1).
- * Closer = higher score.
- */
-export function computeProximityScore(
-  distanceKm: number,
-  maxRadius: number = MAX_RADIUS_KM,
-): number {
-  return 1 - Math.min(distanceKm / maxRadius, 1);
-}
-
-/**
- * Composite matching score.
- * Default weights: language 0.5, interest 0.3, proximity 0.2.
- * "near_you" filter boosts proximity: language 0.3, interest 0.2, proximity 0.5.
- */
-export function computeCompositeScore(
-  languageScore: number,
-  interestScore: number,
-  proximityScore: number,
-  filter?: "near_you" | "language",
-): number {
-  if (filter === "near_you") {
-    return languageScore * 0.3 + interestScore * 0.2 + proximityScore * 0.5;
-  }
-  return languageScore * 0.5 + interestScore * 0.3 + proximityScore * 0.2;
-}
+export {
+  haversineDistance,
+  computeLanguageScore,
+  computeInterestScore,
+  computeProximityScore,
+  computeCompositeScore,
+  buildExcludedUserIds,
+};
 
 // --- Router ---
 
@@ -137,6 +67,25 @@ export const matchingRouter = router({
         .map((l) => l.language);
       const myInterestNames = myInterests.map((i) => i.interest);
 
+      // #125 — Build exclusion list: candidates with an active request in either direction
+      const activeRequests = await db
+        .select({
+          requesterId: matchRequest.requesterId,
+          receiverId: matchRequest.receiverId,
+        })
+        .from(matchRequest)
+        .where(
+          and(
+            or(
+              eq(matchRequest.requesterId, userId),
+              eq(matchRequest.receiverId, userId),
+            ),
+            inArray(matchRequest.status, ["pending", "accepted"]),
+          ),
+        );
+
+      const excludedUserIds = buildExcludedUserIds(userId, activeRequests);
+
       // Fetch all other users who have completed onboarding
       const otherProfiles = await db
         .select()
@@ -145,6 +94,9 @@ export const matchingRouter = router({
           and(
             ne(languageProfile.userId, userId),
             eq(languageProfile.onboardingComplete, true),
+            excludedUserIds.length > 0
+              ? notInArray(languageProfile.userId, excludedUserIds)
+              : undefined,
           ),
         );
 


### PR DESCRIPTION
## Summary

- Show inline confirmation message after match request is sent (card + profile)
- Exclude candidates with pending/accepted requests from discovery list (bidirectional)
- Extract scoring helpers to `matching-utils.ts` for unit testability

## Tests

- 17 passing Jest tests (candidate-card + partner-profile suites)
- 5 passing Bun unit tests (matching-utils exclusion logic)

Closes #124
Closes #125
Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)