### PR TITLE
feat(matching): display incoming match requests on home page

### DIFF
--- a/apps/native/__tests__/suggestions.test.tsx
+++ b/apps/native/__tests__/suggestions.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * Tests for task #126 — Display incoming match requests on home page
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react-native";
+import React from "react";
+
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+const mockDiscoverFn = jest.fn();
+const mockIncomingRequestsFn = jest.fn();
+const mockSendMatchRequest = jest.fn();
+
+jest.mock("@/utils/trpc", () => ({
+  trpc: {
+    matching: {
+      discover: {
+        queryOptions: () => ({
+          queryKey: ["matching.discover"],
+          queryFn: () => mockDiscoverFn(),
+        }),
+      },
+      getIncomingRequests: {
+        queryOptions: () => ({
+          queryKey: ["matching.getIncomingRequests"],
+          queryFn: () => mockIncomingRequestsFn(),
+        }),
+      },
+      sendMatchRequest: {
+        mutationOptions: () => ({ mutationFn: mockSendMatchRequest }),
+      },
+      getMatchRequestStatus: {
+        queryOptions: () => ({
+          queryKey: ["matching.getMatchRequestStatus"],
+          queryFn: () => Promise.resolve({ matchRequestStatus: "none" }),
+        }),
+      },
+    },
+  },
+}));
+
+const defaultPartner = {
+  userId: "partner-1",
+  name: "Alice",
+  image: null,
+  spokenLanguages: [{ language: "Dutch", proficiency: "native" }],
+  learningLanguages: ["English"],
+  interests: ["tech_coding"],
+  bio: null,
+  university: null,
+  age: null,
+  distance: null,
+  score: 0.8,
+};
+
+const defaultIncomingRequest = {
+  matchRequestId: "req-1",
+  requesterId: "requester-1",
+  requesterName: "Bob",
+  requesterPhotoUrl: null,
+  requesterOfferedLanguages: ["English"],
+  requesterTargetedLanguages: ["Dutch"],
+  createdAt: "2026-04-13T10:00:00.000Z",
+};
+
+function makeClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+}
+
+// Import after mocks
+import SuggestionsScreen from "../app/suggestions";
+
+function renderScreen() {
+  const client = makeClient();
+  return render(
+    <QueryClientProvider client={client}>
+      <SuggestionsScreen />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  mockDiscoverFn.mockReset().mockResolvedValue({ partners: [defaultPartner], nextCursor: undefined });
+  mockIncomingRequestsFn.mockReset().mockResolvedValue([]);
+  mockSendMatchRequest.mockReset().mockResolvedValue({ matchRequestId: "r", status: "pending" });
+});
+
+// ─── #126: Incoming match requests on home page ─────────────────────────────
+
+describe("#126 — Incoming match requests on home page", () => {
+  it("shows incoming request with requester name and language summary", async () => {
+    mockIncomingRequestsFn.mockResolvedValue([defaultIncomingRequest]);
+
+    renderScreen();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("incoming-requests-section")).toBeTruthy();
+    });
+    expect(screen.getByTestId("incoming-request-item")).toBeTruthy();
+    expect(screen.getByTestId("requester-name")).toBeTruthy();
+    expect(screen.getByText("Bob")).toBeTruthy();
+  });
+
+  it("shows incoming request in the notifications area (same section)", async () => {
+    mockIncomingRequestsFn.mockResolvedValue([defaultIncomingRequest]);
+
+    renderScreen();
+
+    await waitFor(() => {
+      expect(screen.getByText("People who want to meet you")).toBeTruthy();
+    });
+    expect(screen.getByTestId("incoming-request-item")).toBeTruthy();
+  });
+
+  it("hides incoming requests section when there are no pending requests", async () => {
+    mockIncomingRequestsFn.mockResolvedValue([]);
+
+    renderScreen();
+
+    await waitFor(() => {
+      expect(screen.getByText("Suggestions")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("incoming-requests-section")).toBeNull();
+  });
+
+  it("shows multiple incoming requests when there are several", async () => {
+    mockIncomingRequestsFn.mockResolvedValue([
+      defaultIncomingRequest,
+      { ...defaultIncomingRequest, matchRequestId: "req-2", requesterId: "requester-2", requesterName: "Carol" },
+    ]);
+
+    renderScreen();
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId("incoming-request-item")).toHaveLength(2);
+    });
+    expect(screen.getByText("Bob")).toBeTruthy();
+    expect(screen.getByText("Carol")).toBeTruthy();
+  });
+});

--- a/apps/native/app/suggestions.tsx
+++ b/apps/native/app/suggestions.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { Button, Spinner } from "heroui-native";
 import { useState, useCallback } from "react";
-import { FlatList, RefreshControl, Share, Text, View } from "react-native";
+import { FlatList, Image, RefreshControl, Share, Text, View } from "react-native";
 
 import { CandidateCard } from "@/components/candidate-card";
 import { Container } from "@/components/container";
@@ -33,18 +33,85 @@ function EmptySuggestionState() {
   );
 }
 
+function IncomingRequestItem({
+  request,
+}: {
+  request: {
+    matchRequestId: string;
+    requesterId: string;
+    requesterName: string;
+    requesterPhotoUrl: string | null;
+    requesterOfferedLanguages: string[];
+    requesterTargetedLanguages: string[];
+    createdAt: string;
+  };
+}) {
+  return (
+    <View
+      testID="incoming-request-item"
+      className="bg-card border border-border rounded-2xl p-4 mb-3"
+    >
+      <View className="flex-row items-center gap-3 mb-2">
+        {request.requesterPhotoUrl ? (
+          <Image
+            testID="requester-photo"
+            source={{ uri: request.requesterPhotoUrl }}
+            className="w-12 h-12 rounded-full"
+          />
+        ) : (
+          <View
+            testID="requester-photo-placeholder"
+            className="w-12 h-12 rounded-full bg-muted items-center justify-center"
+          >
+            <Text className="text-muted-foreground text-lg font-semibold">
+              {request.requesterName.charAt(0).toUpperCase()}
+            </Text>
+          </View>
+        )}
+        <Text testID="requester-name" className="text-foreground text-base font-semibold flex-1">
+          {request.requesterName}
+        </Text>
+      </View>
+
+      {request.requesterOfferedLanguages.length > 0 && (
+        <View className="flex-row flex-wrap gap-1 mb-1">
+          {request.requesterOfferedLanguages.map((lang) => (
+            <View key={lang} className="bg-primary/10 px-2 py-0.5 rounded-full">
+              <Text className="text-primary text-xs">{lang}</Text>
+            </View>
+          ))}
+        </View>
+      )}
+
+      {request.requesterTargetedLanguages.length > 0 && (
+        <View className="flex-row flex-wrap gap-1">
+          {request.requesterTargetedLanguages.map((lang) => (
+            <View key={lang} className="bg-secondary/10 px-2 py-0.5 rounded-full">
+              <Text className="text-secondary-foreground text-xs">{lang}</Text>
+            </View>
+          ))}
+        </View>
+      )}
+    </View>
+  );
+}
+
 export default function SuggestionsScreen() {
   const [refreshing, setRefreshing] = useState(false);
 
   const discoverQuery = useQuery(trpc.matching.discover.queryOptions({}));
+  const incomingRequestsQuery = useQuery(
+    trpc.matching.getIncomingRequests.queryOptions(),
+  );
 
   const partners = discoverQuery.data?.partners ?? [];
+  const incomingRequests = incomingRequestsQuery.data ?? [];
 
   const onRefresh = useCallback(async () => {
     setRefreshing(true);
-    await discoverQuery.refetch();
+    await Promise.all([discoverQuery.refetch(), incomingRequestsQuery.refetch()]);
     setRefreshing(false);
-  }, [discoverQuery]);
+  }, [discoverQuery, incomingRequestsQuery]);
 
   if (discoverQuery.isPending) {
     return (
@@ -60,6 +127,16 @@ export default function SuggestionsScreen() {
     return (
       <Container isScrollable={false}>
         <View className="flex-1 p-4">
+          {incomingRequests.length > 0 && (
+            <View testID="incoming-requests-section" className="mb-6">
+              <Text className="text-foreground text-lg font-bold mb-3">
+                People who want to meet you
+              </Text>
+              {incomingRequests.map((req) => (
+                <IncomingRequestItem key={req.matchRequestId} request={req} />
+              ))}
+            </View>
+          )}
           <Text className="text-foreground text-2xl font-bold mb-4">Suggestions</Text>
           <EmptySuggestionState />
         </View>
@@ -77,9 +154,23 @@ export default function SuggestionsScreen() {
           <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
         }
         ListHeaderComponent={
-          <Text className="text-foreground text-2xl font-bold mb-4">
-            Suggestions
-          </Text>
+          <>
+            {/* #126 — Incoming match requests section */}
+            {incomingRequests.length > 0 && (
+              <View testID="incoming-requests-section" className="mb-6">
+                <Text className="text-foreground text-lg font-bold mb-3">
+                  People who want to meet you
+                </Text>
+                {incomingRequests.map((req) => (
+                  <IncomingRequestItem key={req.matchRequestId} request={req} />
+                ))}
+              </View>
+            )}
+
+            <Text className="text-foreground text-2xl font-bold mb-4">
+              Suggestions
+            </Text>
+          </>
         }
         renderItem={({ item }) => (
           <CandidateCard

--- a/packages/api/src/routers/matching.ts
+++ b/packages/api/src/routers/matching.ts
@@ -238,6 +238,59 @@ export const matchingRouter = router({
       return { partners: page, nextCursor };
     }),
 
+  getIncomingRequests: protectedProcedure
+    .query(async ({ ctx }) => {
+      const receiverId = ctx.session.user.id;
+
+      const pendingRequests = await db
+        .select({
+          matchRequestId: matchRequest.id,
+          requesterId: matchRequest.requesterId,
+          createdAt: matchRequest.createdAt,
+        })
+        .from(matchRequest)
+        .where(
+          and(
+            eq(matchRequest.receiverId, receiverId),
+            eq(matchRequest.status, "pending"),
+          ),
+        );
+
+      if (pendingRequests.length === 0) return [];
+
+      const requesterIds = pendingRequests.map((r) => r.requesterId);
+
+      const [requesterUsers, requesterLanguages] = await Promise.all([
+        db
+          .select({ id: user.id, name: user.name, image: user.image })
+          .from(user)
+          .where(inArray(user.id, requesterIds)),
+        db
+          .select()
+          .from(userLanguage)
+          .where(inArray(userLanguage.userId, requesterIds)),
+      ]);
+
+      return pendingRequests.map((req) => {
+        const userInfo = requesterUsers.find((u) => u.id === req.requesterId);
+        const langs = requesterLanguages.filter((l) => l.userId === req.requesterId);
+
+        return {
+          matchRequestId: req.matchRequestId,
+          requesterId: req.requesterId,
+          requesterName: userInfo?.name ?? "Unknown",
+          requesterPhotoUrl: userInfo?.image ?? null,
+          requesterOfferedLanguages: langs
+            .filter((l) => l.type === "spoken")
+            .map((l) => l.language),
+          requesterTargetedLanguages: langs
+            .filter((l) => l.type === "learning")
+            .map((l) => l.language),
+          createdAt: req.createdAt.toISOString(),
+        };
+      });
+    }),
+
   getPartnerProfile: protectedProcedure
     .input(z.object({ userId: z.string() }))
     .query(async ({ input }) => {


### PR DESCRIPTION
## Summary

- Add `matching.getIncomingRequests` tRPC query (returns pending requests where `receiverId = me`)
- Add "People who want to meet you" section on suggestions screen with requester name, photo, and language summary
- Section hidden when no incoming requests (empty state unchanged)

## Test plan

- [x] Shows incoming request with requester info — 4 passing tests in `suggestions.test.tsx`
- [x] Hides section when no requests
- [x] Shows multiple requests

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)