### PR TITLE
feat(matching): open requester profile from incoming request tap

### DIFF
--- a/apps/native/__tests__/partner-profile.test.tsx
+++ b/apps/native/__tests__/partner-profile.test.tsx
@@ -4,6 +4,7 @@
  *   #120 — Surface "Send Request" action contextually based on match status
  *   #121 — Handle removed/unavailable candidate profile gracefully
  *   #122 — Send Request button on candidate profile screen
+ *   #127 — Allow receiver to open requester's profile before deciding
  */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react-native";
@@ -11,8 +12,9 @@ import React from "react";
 
 // Mock expo-router (must be before any imports that use it)
 const mockBack = jest.fn();
+let mockSearchParams: { id: string; matchRequestId?: string } = { id: "candidate-123" };
 jest.mock("expo-router", () => ({
-  useLocalSearchParams: () => ({ id: "candidate-123" }),
+  useLocalSearchParams: () => mockSearchParams,
   useRouter: () => ({ back: mockBack }),
 }));
 
@@ -85,6 +87,7 @@ function renderScreen() {
 }
 
 beforeEach(() => {
+  mockSearchParams = { id: "candidate-123" };
   mockBack.mockClear();
   mockSendMatchRequest.mockClear().mockResolvedValue({ matchRequestId: "req-1", status: "pending" });
   mockProfileFn.mockReset().mockResolvedValue(defaultProfile);
@@ -258,5 +261,44 @@ describe("#123 — Duplicate match request prevention on candidate profile", () 
     await waitFor(() => {
       expect(mockSendMatchRequest).toHaveBeenCalledTimes(1);
     });
+  });
+});
+
+// ─── #127: Accept/Decline bar when opened from incoming request ────────────
+
+describe("#127 — Accept/Decline action bar on requester profile", () => {
+  it("shows Accept/Decline action bar when opened from incoming request context", async () => {
+    mockSearchParams = { id: "candidate-123", matchRequestId: "req-abc" };
+
+    renderScreen();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("accept-decline-bar")).toBeTruthy();
+    });
+    expect(screen.getByTestId("accept-button")).toBeTruthy();
+    expect(screen.getByTestId("decline-button")).toBeTruthy();
+  });
+
+  it("hides Send Request section when opened from incoming request context", async () => {
+    mockSearchParams = { id: "candidate-123", matchRequestId: "req-abc" };
+
+    renderScreen();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("accept-decline-bar")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("send-request-button")).toBeNull();
+    expect(screen.queryByTestId("request-sent-indicator")).toBeNull();
+  });
+
+  it("shows Send Request section when not opened from incoming request context", async () => {
+    mockSearchParams = { id: "candidate-123" };
+
+    renderScreen();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("send-request-button")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("accept-decline-bar")).toBeNull();
   });
 });

--- a/apps/native/__tests__/suggestions.test.tsx
+++ b/apps/native/__tests__/suggestions.test.tsx
@@ -1,12 +1,16 @@
 /**
- * Tests for task #126 — Display incoming match requests on home page
+ * Tests for tasks:
+ *   #126 — Display incoming match requests on home page
+ *   #127 — Allow receiver to open requester's profile before deciding
  */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor } from "@testing-library/react-native";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react-native";
 import React from "react";
 
+const mockPush = jest.fn();
+
 jest.mock("expo-router", () => ({
-  useRouter: () => ({ push: jest.fn() }),
+  useRouter: () => ({ push: mockPush }),
 }));
 
 const mockDiscoverFn = jest.fn();
@@ -84,6 +88,7 @@ function renderScreen() {
 }
 
 beforeEach(() => {
+  mockPush.mockClear();
   mockDiscoverFn.mockReset().mockResolvedValue({ partners: [defaultPartner], nextCursor: undefined });
   mockIncomingRequestsFn.mockReset().mockResolvedValue([]);
   mockSendMatchRequest.mockReset().mockResolvedValue({ matchRequestId: "r", status: "pending" });
@@ -140,5 +145,50 @@ describe("#126 — Incoming match requests on home page", () => {
     });
     expect(screen.getByText("Bob")).toBeTruthy();
     expect(screen.getByText("Carol")).toBeTruthy();
+  });
+});
+
+// ─── #127: Open requester's profile from incoming request ───────────────────
+
+describe("#127 — Open requester's profile from incoming request", () => {
+  it("navigates to requester's full profile when tapping a request item from home page", async () => {
+    mockIncomingRequestsFn.mockResolvedValue([defaultIncomingRequest]);
+
+    renderScreen();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("incoming-request-item")).toBeTruthy();
+    });
+
+    fireEvent.press(screen.getByTestId("incoming-request-item"));
+
+    expect(mockPush).toHaveBeenCalledWith({
+      pathname: "/partner/[id]",
+      params: {
+        id: defaultIncomingRequest.requesterId,
+        matchRequestId: defaultIncomingRequest.matchRequestId,
+      },
+    });
+  });
+
+  it("navigates with correct matchRequestId when tapping from notifications area", async () => {
+    mockDiscoverFn.mockResolvedValue({ partners: [], nextCursor: undefined });
+    mockIncomingRequestsFn.mockResolvedValue([defaultIncomingRequest]);
+
+    renderScreen();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("incoming-request-item")).toBeTruthy();
+    });
+
+    fireEvent.press(screen.getByTestId("incoming-request-item"));
+
+    expect(mockPush).toHaveBeenCalledWith({
+      pathname: "/partner/[id]",
+      params: {
+        id: defaultIncomingRequest.requesterId,
+        matchRequestId: defaultIncomingRequest.matchRequestId,
+      },
+    });
   });
 });

--- a/apps/native/app/partner/[id].tsx
+++ b/apps/native/app/partner/[id].tsx
@@ -8,7 +8,7 @@ import { Container } from "@/components/container";
 import { trpc } from "@/utils/trpc";
 
 export default function PartnerProfileScreen() {
-  const { id } = useLocalSearchParams<{ id: string }>();
+  const { id, matchRequestId } = useLocalSearchParams<{ id: string; matchRequestId?: string }>();
   const router = useRouter();
 
   const profileQuery = useQuery(
@@ -196,25 +196,47 @@ export default function PartnerProfileScreen() {
           </View>
         )}
 
-        {/* #120/#122 — Contextual Send Request */}
-        {requestAlreadySent ? (
-          <View testID="request-sent-indicator" className="bg-muted rounded-xl p-4 mb-4 items-center">
-            <Text className="text-muted-foreground font-medium">Request Sent</Text>
+        {/* #127 — Accept/Decline bar (when opened from incoming request context) */}
+        {matchRequestId ? (
+          <View testID="accept-decline-bar" className="flex-row gap-3 mb-4">
+            <Button
+              testID="decline-button"
+              variant="ghost"
+              className="flex-1"
+              onPress={() => {/* T15.4 — wired in Decline action task */}}
+            >
+              <Button.Label>Decline</Button.Label>
+            </Button>
+            <Button
+              testID="accept-button"
+              variant="primary"
+              className="flex-1"
+              onPress={() => {/* T15.3 — wired in Accept action task */}}
+            >
+              <Button.Label>Accept</Button.Label>
+            </Button>
           </View>
         ) : (
-          <Button
-            testID="send-request-button"
-            variant="primary"
-            isDisabled={sendRequestMutation.isPending || statusQuery.isPending}
-            onPress={() => sendRequestMutation.mutate({ receiverId: id })}
-            className="mb-4"
-          >
-            {sendRequestMutation.isPending ? (
-              <Spinner size="sm" />
-            ) : (
-              <Button.Label>Send Request</Button.Label>
-            )}
-          </Button>
+          /* #120/#122 — Contextual Send Request */
+          requestAlreadySent ? (
+            <View testID="request-sent-indicator" className="bg-muted rounded-xl p-4 mb-4 items-center">
+              <Text className="text-muted-foreground font-medium">Request Sent</Text>
+            </View>
+          ) : (
+            <Button
+              testID="send-request-button"
+              variant="primary"
+              isDisabled={sendRequestMutation.isPending || statusQuery.isPending}
+              onPress={() => sendRequestMutation.mutate({ receiverId: id })}
+              className="mb-4"
+            >
+              {sendRequestMutation.isPending ? (
+                <Spinner size="sm" />
+              ) : (
+                <Button.Label>Send Request</Button.Label>
+              )}
+            </Button>
+          )
         )}
       </ScrollView>
     </Container>

--- a/apps/native/app/suggestions.tsx
+++ b/apps/native/app/suggestions.tsx
@@ -1,7 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
+import { useRouter } from "expo-router";
 import { Button, Spinner } from "heroui-native";
 import { useState, useCallback } from "react";
-import { FlatList, Image, RefreshControl, Share, Text, View } from "react-native";
+import { FlatList, Image, Pressable, RefreshControl, Share, Text, View } from "react-native";
 
 import { CandidateCard } from "@/components/candidate-card";
 import { Container } from "@/components/container";
@@ -35,6 +36,7 @@ function EmptySuggestionState() {
 
 function IncomingRequestItem({
   request,
+  onPress,
 }: {
   request: {
     matchRequestId: string;
@@ -45,10 +47,12 @@ function IncomingRequestItem({
     requesterTargetedLanguages: string[];
     createdAt: string;
   };
+  onPress: () => void;
 }) {
   return (
-    <View
+    <Pressable
       testID="incoming-request-item"
+      onPress={onPress}
       className="bg-card border border-border rounded-2xl p-4 mb-3"
     >
       <View className="flex-row items-center gap-3 mb-2">
@@ -92,11 +96,12 @@ function IncomingRequestItem({
           ))}
         </View>
       )}
-    </View>
+    </Pressable>
   );
 }
 
 export default function SuggestionsScreen() {
+  const router = useRouter();
   const [refreshing, setRefreshing] = useState(false);
 
   const discoverQuery = useQuery(trpc.matching.discover.queryOptions({}));
@@ -133,7 +138,11 @@ export default function SuggestionsScreen() {
                 People who want to meet you
               </Text>
               {incomingRequests.map((req) => (
-                <IncomingRequestItem key={req.matchRequestId} request={req} />
+                <IncomingRequestItem
+                    key={req.matchRequestId}
+                    request={req}
+                    onPress={() => router.push({ pathname: "/partner/[id]", params: { id: req.requesterId, matchRequestId: req.matchRequestId } })}
+                  />
               ))}
             </View>
           )}
@@ -162,7 +171,11 @@ export default function SuggestionsScreen() {
                   People who want to meet you
                 </Text>
                 {incomingRequests.map((req) => (
-                  <IncomingRequestItem key={req.matchRequestId} request={req} />
+                  <IncomingRequestItem
+                    key={req.matchRequestId}
+                    request={req}
+                    onPress={() => router.push({ pathname: "/partner/[id]", params: { id: req.requesterId, matchRequestId: req.matchRequestId } })}
+                  />
                 ))}
               </View>
             )}


### PR DESCRIPTION
## Summary

Receivers need enough context to make an informed accept/decline decision before committing to a match. This PR makes incoming match request items tappable, navigating the receiver to the requester's full profile. It also adds a conditional Accept/Decline action bar to the profile screen — displayed only when the screen is opened from an incoming request context, replacing the Send Request button in that flow. The actual Accept/Decline mutations are wired in T15.3 and T15.4.

## Changes

- **Incoming request list** (`suggestions.tsx`): `IncomingRequestItem` is now a `Pressable` that fires `router.push` to `/partner/[id]` with both `id` (requesterId) and `matchRequestId` as navigation params.
- **Partner profile screen** (`partner/[id].tsx`): reads the optional `matchRequestId` search param; when present, renders an Accept/Decline action bar (`accept-decline-bar`) instead of the Send Request section.
- **Tests**: two new describe blocks — one in `suggestions.test.tsx` covering tap navigation, one in `partner-profile.test.tsx` covering the conditional action bar appearance.

## Test plan

- [ ] Tapping an incoming request item navigates to the requester's full profile with correct `matchRequestId` param
- [ ] Accept/Decline action bar is visible when profile is opened from an incoming request context
- [ ] Send Request button is hidden when Accept/Decline bar is shown
- [ ] Send Request button remains visible when profile is opened from suggestion list (no `matchRequestId`)
- [ ] All 21 automated Jest tests pass

## Related

Closes #127
