### PR TITLE
feat(notifications): enrich match request notification with requester name and language summary

### DIFF
--- a/apps/server/src/notifications.ts
+++ b/apps/server/src/notifications.ts
@@ -6,8 +6,10 @@
  */
 import { eq } from "drizzle-orm";
 import { db } from "@sip-and-speak/db";
-import { userDeviceToken } from "@sip-and-speak/db/schema/sip-and-speak";
+import { userDeviceToken, userLanguage } from "@sip-and-speak/db/schema/sip-and-speak";
+import { user } from "@sip-and-speak/db/schema/auth";
 import { domainEvents, type MatchRequestSentEvent } from "@sip-and-speak/api/domain-events";
+import { buildMatchRequestNotificationBody } from "@sip-and-speak/api/routers/matching-utils";
 
 const EXPO_PUSH_URL = "https://exp.host/--/api/v2/push/send";
 
@@ -43,24 +45,40 @@ async function sendExpoPushNotification(
 }
 
 async function handleMatchRequestSent(event: MatchRequestSentEvent): Promise<void> {
-  const { matchRequestId, receiverId } = event;
+  const { matchRequestId, requesterId, receiverId } = event;
 
-  // Look up receiver's device tokens
-  const tokens = await db
-    .select({ id: userDeviceToken.id, token: userDeviceToken.token })
-    .from(userDeviceToken)
-    .where(eq(userDeviceToken.userId, receiverId));
+  // Fetch requester's name and primary languages in parallel with device token lookup
+  const [requesterResult, requesterLanguages, tokens] = await Promise.all([
+    db
+      .select({ name: user.name })
+      .from(user)
+      .where(eq(user.id, requesterId))
+      .limit(1),
+    db
+      .select({ language: userLanguage.language, type: userLanguage.type })
+      .from(userLanguage)
+      .where(eq(userLanguage.userId, requesterId)),
+    db
+      .select({ id: userDeviceToken.id, token: userDeviceToken.token })
+      .from(userDeviceToken)
+      .where(eq(userDeviceToken.userId, receiverId)),
+  ]);
 
   if (tokens.length === 0) {
     console.info("[push] No device token for receiver — skipping", { matchRequestId, receiverId });
     return;
   }
 
+  const requesterName = requesterResult[0]?.name ?? "Someone";
+  const offeredLanguage = requesterLanguages.find((l) => l.type === "spoken")?.language ?? null;
+  const targetedLanguage = requesterLanguages.find((l) => l.type === "learning")?.language ?? null;
+  const notificationBody = buildMatchRequestNotificationBody(requesterName, offeredLanguage, targetedLanguage);
+
   const messages: ExpoPushMessage[] = tokens.map(({ token }) => ({
     to: token,
-    title: "Someone wants to meet you!",
-    body: "Open the app to see who sent you a match request.",
-    data: { matchRequestId },
+    title: "New match request",
+    body: notificationBody,
+    data: { matchRequestId, requesterId },
   }));
 
   console.info("[push] Sending MatchRequestSent notification", {

--- a/packages/api/src/__tests__/matching.test.ts
+++ b/packages/api/src/__tests__/matching.test.ts
@@ -1,11 +1,11 @@
 /**
- * Tests for task #125 — Exclude requested candidates from future suggestion lists
- *
- * Tests cover the pure buildExcludedUserIds helper used by the discover procedure.
+ * Tests for:
+ *   #125 — Exclude requested candidates from future suggestion lists
+ *   #131 — Include requester name and language summary in notification payload
  */
 import { describe, expect, it } from "bun:test";
 
-import { buildExcludedUserIds } from "../routers/matching-utils";
+import { buildExcludedUserIds, buildMatchRequestNotificationBody } from "../routers/matching-utils";
 
 const ME = "user-me";
 
@@ -36,5 +36,29 @@ describe("#125 — buildExcludedUserIds", () => {
     // Declined requests are excluded from activeRequests by the SQL filter —
     // this test confirms that if no requests are passed, no one is excluded.
     expect(buildExcludedUserIds(ME, [])).toEqual([]);
+  });
+});
+
+// ─── #131: Notification payload composition ─────────────────────────────────
+
+describe("#131 — buildMatchRequestNotificationBody", () => {
+  it("includes requester name and language summary when profile is complete", () => {
+    const body = buildMatchRequestNotificationBody("Ana", "Portuguese", "Dutch");
+    expect(body).toBe("Ana wants to meet you — speaks Portuguese, learning Dutch");
+  });
+
+  it("omits language summary when requester profile is incomplete (no languages)", () => {
+    const body = buildMatchRequestNotificationBody("Ana", null, null);
+    expect(body).toBe("Ana wants to meet you");
+  });
+
+  it("omits language summary when only offered language is present", () => {
+    const body = buildMatchRequestNotificationBody("Ana", "Portuguese", null);
+    expect(body).toBe("Ana wants to meet you");
+  });
+
+  it("omits language summary when only targeted language is present", () => {
+    const body = buildMatchRequestNotificationBody("Ana", null, "Dutch");
+    expect(body).toBe("Ana wants to meet you");
   });
 });

--- a/packages/api/src/routers/matching-utils.ts
+++ b/packages/api/src/routers/matching-utils.ts
@@ -87,6 +87,22 @@ export function computeCompositeScore(
 }
 
 /**
+ * Compose the push notification body for a MatchRequestSent event.
+ * Includes language summary only when both offered and targeted languages are known.
+ * Format: "{name} wants to meet you — speaks {offered}, learning {targeted}"
+ */
+export function buildMatchRequestNotificationBody(
+  requesterName: string,
+  offeredLanguage: string | null,
+  targetedLanguage: string | null,
+): string {
+  if (offeredLanguage && targetedLanguage) {
+    return `${requesterName} wants to meet you — speaks ${offeredLanguage}, learning ${targetedLanguage}`;
+  }
+  return `${requesterName} wants to meet you`;
+}
+
+/**
  * Extract excluded user IDs from active match requests involving the given user.
  * Bidirectional: a candidate who sent a request to the user is also excluded.
  */


### PR DESCRIPTION
## Summary

The initial push notification for incoming match requests only said "Open the app to see who sent you a match request" — no context about who it was or why to care. This PR enriches the payload with the requester's name and primary offered/targeted language, letting receivers decide whether to open the app before it interrupts them. Language summary is omitted gracefully when the requester's profile is incomplete.

## Changes

- **`apps/server/src/notifications.ts`**: extended `handleMatchRequestSent` to fetch requester name (from `user`) and primary spoken/learning languages (from `userLanguage`) in parallel with device token lookup; uses new `buildMatchRequestNotificationBody` helper to compose the body; adds `requesterId` to the push data payload.
- **`packages/api/src/routers/matching-utils.ts`**: pure `buildMatchRequestNotificationBody(name, offered, targeted)` helper — includes language summary only when both languages are present.
- **`packages/api/src/__tests__/matching.test.ts`**: 4 bun unit tests covering complete profile, incomplete profile, and partial language cases.

## Test plan

- [ ] Notification body includes requester name and "speaks X, learning Y" when profile is complete
- [ ] Notification body is just "{name} wants to meet you" when languages are missing
- [ ] Notification data includes `requesterId` (for deep-link in T16.3)
- [ ] All 9 bun unit tests pass

## Related

Closes #131