### PR TITLE
feat(matching): show enable-notifications banner when notification permission denied

### DIFF
--- a/apps/native/__tests__/suggestions.test.tsx
+++ b/apps/native/__tests__/suggestions.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * Tests for task #133 — Ensure incoming request appears on home page regardless of notification permission status
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react-native";
+import React from "react";
+
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock("../components/candidate-card", () => ({
+  CandidateCard: () => null,
+}));
+
+const mockGetPermissionsAsync = jest.fn();
+
+jest.mock("expo-notifications", () => ({
+  getPermissionsAsync: () => mockGetPermissionsAsync(),
+}));
+
+const mockDiscoverFn = jest.fn();
+
+jest.mock("@/utils/trpc", () => ({
+  trpc: {
+    matching: {
+      discover: {
+        queryOptions: () => ({
+          queryKey: ["matching.discover"],
+          queryFn: () => mockDiscoverFn(),
+        }),
+      },
+    },
+  },
+}));
+
+const defaultPartner = {
+  userId: "partner-1",
+  name: "Alice",
+  image: null,
+  spokenLanguages: [{ language: "Dutch", proficiency: "native" }],
+  learningLanguages: ["English"],
+  interests: ["tech_coding"],
+  bio: null,
+  university: null,
+  age: null,
+  distance: null,
+  score: 0.8,
+};
+
+function makeClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+}
+
+// Import after mocks
+import SuggestionsScreen from "../app/suggestions";
+
+function renderScreen() {
+  const client = makeClient();
+  return render(
+    <QueryClientProvider client={client}>
+      <SuggestionsScreen />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  mockDiscoverFn.mockReset().mockResolvedValue({ partners: [defaultPartner], nextCursor: undefined });
+  mockGetPermissionsAsync.mockReset().mockResolvedValue({ granted: true, status: "granted" });
+});
+
+// ─── #133: Incoming requests visible regardless of notification permission ──
+
+describe("#133 — Incoming requests visible regardless of notification permission", () => {
+  it("shows suggestions list when notifications are disabled", async () => {
+    mockGetPermissionsAsync.mockResolvedValue({ granted: false, status: "denied" });
+
+    renderScreen();
+
+    await waitFor(() => {
+      expect(screen.getByText("Suggestions")).toBeTruthy();
+    });
+  });
+
+  it("shows a non-blocking enable-notifications banner when permissions are denied", async () => {
+    mockGetPermissionsAsync.mockResolvedValue({ granted: false, status: "denied" });
+
+    renderScreen();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("enable-notifications-banner")).toBeTruthy();
+    });
+  });
+
+  it("banner does not block the suggestions list", async () => {
+    mockGetPermissionsAsync.mockResolvedValue({ granted: false, status: "denied" });
+
+    renderScreen();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("enable-notifications-banner")).toBeTruthy();
+    });
+    // Suggestions list is still rendered alongside the banner
+    expect(screen.getByText("Suggestions")).toBeTruthy();
+  });
+
+  it("does not show the banner when notifications are enabled", async () => {
+    mockGetPermissionsAsync.mockResolvedValue({ granted: true, status: "granted" });
+
+    renderScreen();
+
+    await waitFor(() => {
+      expect(screen.getByText("Suggestions")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("enable-notifications-banner")).toBeNull();
+  });
+});

--- a/apps/native/app/suggestions.tsx
+++ b/apps/native/app/suggestions.tsx
@@ -1,7 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
+import * as Notifications from "expo-notifications";
 import { Button, Spinner } from "heroui-native";
-import { useState, useCallback } from "react";
-import { FlatList, RefreshControl, Share, Text, View } from "react-native";
+import { useState, useCallback, useEffect } from "react";
+import { FlatList, Platform, RefreshControl, Share, Text, View } from "react-native";
 
 import { CandidateCard } from "@/components/candidate-card";
 import { Container } from "@/components/container";
@@ -33,8 +34,29 @@ function EmptySuggestionState() {
   );
 }
 
+function EnableNotificationsBanner() {
+  return (
+    <View
+      testID="enable-notifications-banner"
+      className="bg-muted border border-border rounded-xl px-4 py-3 mb-4 flex-row items-center gap-3"
+    >
+      <Text className="text-muted-foreground text-sm flex-1">
+        Enable notifications to be alerted instantly when someone wants to meet you.
+      </Text>
+    </View>
+  );
+}
+
 export default function SuggestionsScreen() {
   const [refreshing, setRefreshing] = useState(false);
+  const [notificationsGranted, setNotificationsGranted] = useState(true);
+
+  useEffect(() => {
+    if (Platform.OS === "web") return;
+    Notifications.getPermissionsAsync()
+      .then((perm) => setNotificationsGranted(perm.granted))
+      .catch(() => { /* ignore — banner is informational only */ });
+  }, []);
 
   const discoverQuery = useQuery(trpc.matching.discover.queryOptions({}));
 
@@ -60,6 +82,7 @@ export default function SuggestionsScreen() {
     return (
       <Container isScrollable={false}>
         <View className="flex-1 p-4">
+          {!notificationsGranted && <EnableNotificationsBanner />}
           <Text className="text-foreground text-2xl font-bold mb-4">Suggestions</Text>
           <EmptySuggestionState />
         </View>
@@ -77,9 +100,12 @@ export default function SuggestionsScreen() {
           <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
         }
         ListHeaderComponent={
-          <Text className="text-foreground text-2xl font-bold mb-4">
-            Suggestions
-          </Text>
+          <>
+            {!notificationsGranted && <EnableNotificationsBanner />}
+            <Text className="text-foreground text-2xl font-bold mb-4">
+              Suggestions
+            </Text>
+          </>
         }
         renderItem={({ item }) => (
           <CandidateCard


### PR DESCRIPTION
## Summary

Students who decline push notifications would miss match request alerts silently. This PR adds a non-blocking informational banner to the home page when notification permission is denied, surfacing the gap without blocking access to the incoming requests list or suggestions. The \`getIncomingRequests\` query is permission-agnostic (server-side), so requests always appear regardless of device permission status.

## Changes

- **\`apps/native/app/suggestions.tsx\`**: \`EnableNotificationsBanner\` component + \`useEffect\` that calls \`Notifications.getPermissionsAsync()\` on mount; banner renders above suggestions list when permission is denied; skipped on web platform.

## Test plan

- [ ] Banner appears when notification permission is denied
- [ ] Banner does not appear when notifications are enabled
- [ ] Suggestions list renders alongside banner (banner is non-blocking)
- [ ] All 24 automated Jest tests pass

## Related

Closes #133