### PR TITLE
feat(matching): Decline action removes request and navigates back (#129)

### DIFF
--- a/apps/native/__tests__/partner-profile.test.tsx
+++ b/apps/native/__tests__/partner-profile.test.tsx
@@ -6,6 +6,7 @@
  *   #122 — Send Request button on candidate profile screen
  *   #127 — Allow receiver to open requester's profile before deciding
  *   #128 — Accept action transitioning both Students to Matched state
+ *   #129 — Decline action removing the request and navigating back
  */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react-native";
@@ -25,6 +26,7 @@ const mockCommentsFn = jest.fn();
 const mockSendMatchRequest = jest.fn();
 const mockGetMatchRequestStatusFn = jest.fn();
 const mockAcceptMatchRequest = jest.fn();
+const mockDeclineMatchRequest = jest.fn();
 const mockInvalidateQueries = jest.fn();
 
 jest.mock("@/utils/trpc", () => ({
@@ -48,6 +50,9 @@ jest.mock("@/utils/trpc", () => ({
       },
       acceptMatchRequest: {
         mutationOptions: () => ({ mutationFn: mockAcceptMatchRequest }),
+      },
+      declineMatchRequest: {
+        mutationOptions: () => ({ mutationFn: mockDeclineMatchRequest }),
       },
     },
     profile: {
@@ -98,6 +103,7 @@ beforeEach(() => {
   mockBack.mockClear();
   mockSendMatchRequest.mockClear().mockResolvedValue({ matchRequestId: "req-1", status: "pending" });
   mockAcceptMatchRequest.mockClear().mockResolvedValue({ status: "accepted", matchedWithUserId: "requester-1" });
+  mockDeclineMatchRequest.mockClear().mockResolvedValue({ status: "declined" });
   mockInvalidateQueries.mockClear();
   mockProfileFn.mockReset().mockResolvedValue(defaultProfile);
   mockCommentsFn.mockReset().mockResolvedValue([]);
@@ -354,6 +360,52 @@ describe("#128 — Accept action transitioning both Students to Matched state", 
 
     await waitFor(() => {
       expect(screen.getByText("Accepted")).toBeTruthy();
+    });
+  });
+});
+
+// ─── #129: Decline action ──────────────────────────────────────────────────
+
+describe("#129 — Decline action removing the request and navigating back", () => {
+  it("calls declineMatchRequest mutation when Decline is tapped", async () => {
+    mockSearchParams = { id: "candidate-123", matchRequestId: "req-abc" };
+
+    renderScreen();
+
+    await waitFor(() => screen.getByTestId("decline-button"));
+    fireEvent.press(screen.getByTestId("decline-button"));
+
+    await waitFor(() => {
+      expect(mockDeclineMatchRequest).toHaveBeenCalledTimes(1);
+      expect(mockDeclineMatchRequest.mock.calls[0][0]).toEqual({ matchRequestId: "req-abc" });
+    });
+  });
+
+  it("navigates back after successful decline", async () => {
+    mockSearchParams = { id: "candidate-123", matchRequestId: "req-abc" };
+
+    renderScreen();
+
+    await waitFor(() => screen.getByTestId("decline-button"));
+    fireEvent.press(screen.getByTestId("decline-button"));
+
+    await waitFor(() => {
+      expect(mockBack).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("invalidates incoming requests query after declining", async () => {
+    mockSearchParams = { id: "candidate-123", matchRequestId: "req-abc" };
+
+    renderScreen();
+
+    await waitFor(() => screen.getByTestId("decline-button"));
+    fireEvent.press(screen.getByTestId("decline-button"));
+
+    await waitFor(() => {
+      expect(mockInvalidateQueries).toHaveBeenCalledWith(
+        expect.objectContaining({ queryKey: ["matching.getIncomingRequests"] }),
+      );
     });
   });
 });

--- a/apps/native/app/partner/[id].tsx
+++ b/apps/native/app/partner/[id].tsx
@@ -41,6 +41,14 @@ export default function PartnerProfileScreen() {
     },
   });
 
+  const declineMutation = useMutation({
+    ...trpc.matching.declineMatchRequest.mutationOptions(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["matching.getIncomingRequests"] });
+      router.back();
+    },
+  });
+
   // #121 — if profile is no longer available, navigate back
   useEffect(() => {
     if (profileQuery.error && (profileQuery.error as { data?: { code?: string } }).data?.code === "NOT_FOUND") {
@@ -210,7 +218,12 @@ export default function PartnerProfileScreen() {
               testID="decline-button"
               variant="ghost"
               className="flex-1"
-              onPress={() => {/* T15.4 — wired in Decline action task */}}
+              isDisabled={declineMutation.isPending}
+              onPress={() => {
+                if (matchRequestId) {
+                  declineMutation.mutate({ matchRequestId });
+                }
+              }}
             >
               <Button.Label>Decline</Button.Label>
             </Button>

--- a/packages/api/src/routers/matching.ts
+++ b/packages/api/src/routers/matching.ts
@@ -475,4 +475,46 @@ export const matchingRouter = router({
 
       return { status: "accepted" as const, matchedWithUserId: request.requesterId };
     }),
+
+  declineMatchRequest: protectedProcedure
+    .input(z.object({ matchRequestId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const receiverId = ctx.session.user.id;
+
+      const request = await db.query.matchRequest.findFirst({
+        where: eq(matchRequest.id, input.matchRequestId),
+      });
+
+      if (!request) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Match request not found." });
+      }
+
+      if (request.receiverId !== receiverId) {
+        throw new TRPCError({ code: "FORBIDDEN", message: "Only the designated receiver may decline this request." });
+      }
+
+      if (request.status !== "pending") {
+        throw new TRPCError({ code: "BAD_REQUEST", message: "Only pending requests can be declined." });
+      }
+
+      await db
+        .update(matchRequest)
+        .set({ status: "declined" })
+        .where(eq(matchRequest.id, input.matchRequestId));
+
+      console.info("[MatchRequestDeclined]", {
+        matchRequestId: input.matchRequestId,
+        requesterId: request.requesterId,
+        receiverId,
+      });
+
+      domainEvents.emit("MatchRequestDeclined", {
+        matchRequestId: input.matchRequestId,
+        requesterId: request.requesterId,
+        receiverId,
+        declinedAt: new Date(),
+      });
+
+      return { status: "declined" as const };
+    }),
 });


### PR DESCRIPTION
## Summary

- `declineMatchRequest` tRPC mutation: only receiver can decline, must be `pending`, emits `MatchRequestDeclined` event
- Decline button wired on partner profile screen; invalidates incoming requests and navigates back on success

## Test plan

- [x] 3 new #129 test scenarios pass (calls mutation, navigates back, invalidates query)
- [x] All 21 tests pass

Closes #129