### PR TITLE
feat(matching): Respond to match request — Feature #15

### DIFF
--- a/apps/native/__tests__/partner-profile.test.tsx
+++ b/apps/native/__tests__/partner-profile.test.tsx
@@ -4,6 +4,7 @@
  *   #120 — Surface "Send Request" action contextually based on match status
  *   #121 — Handle removed/unavailable candidate profile gracefully
  *   #122 — Send Request button on candidate profile screen
+ *   #127 — Allow receiver to open requester's profile before deciding
  */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react-native";
@@ -11,8 +12,9 @@ import React from "react";
 
 // Mock expo-router (must be before any imports that use it)
 const mockBack = jest.fn();
+let mockSearchParams: { id: string; matchRequestId?: string } = { id: "candidate-123" };
 jest.mock("expo-router", () => ({
-  useLocalSearchParams: () => ({ id: "candidate-123" }),
+  useLocalSearchParams: () => mockSearchParams,
   useRouter: () => ({ back: mockBack }),
 }));
 
@@ -85,6 +87,7 @@ function renderScreen() {
 }
 
 beforeEach(() => {
+  mockSearchParams = { id: "candidate-123" };
   mockBack.mockClear();
   mockSendMatchRequest.mockClear().mockResolvedValue({ matchRequestId: "req-1", status: "pending" });
   mockProfileFn.mockReset().mockResolvedValue(defaultProfile);
@@ -258,5 +261,44 @@ describe("#123 — Duplicate match request prevention on candidate profile", () 
     await waitFor(() => {
       expect(mockSendMatchRequest).toHaveBeenCalledTimes(1);
     });
+  });
+});
+
+// ─── #127: Accept/Decline bar when opened from incoming request ────────────
+
+describe("#127 — Accept/Decline action bar on requester profile", () => {
+  it("shows Accept/Decline action bar when opened from incoming request context", async () => {
+    mockSearchParams = { id: "candidate-123", matchRequestId: "req-abc" };
+
+    renderScreen();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("accept-decline-bar")).toBeTruthy();
+    });
+    expect(screen.getByTestId("accept-button")).toBeTruthy();
+    expect(screen.getByTestId("decline-button")).toBeTruthy();
+  });
+
+  it("hides Send Request section when opened from incoming request context", async () => {
+    mockSearchParams = { id: "candidate-123", matchRequestId: "req-abc" };
+
+    renderScreen();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("accept-decline-bar")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("send-request-button")).toBeNull();
+    expect(screen.queryByTestId("request-sent-indicator")).toBeNull();
+  });
+
+  it("shows Send Request section when not opened from incoming request context", async () => {
+    mockSearchParams = { id: "candidate-123" };
+
+    renderScreen();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("send-request-button")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("accept-decline-bar")).toBeNull();
   });
 });

--- a/apps/native/__tests__/partner-profile.test.tsx
+++ b/apps/native/__tests__/partner-profile.test.tsx
@@ -6,6 +6,7 @@
  *   #122 — Send Request button on candidate profile screen
  *   #127 — Allow receiver to open requester's profile before deciding
  *   #128 — Accept action transitioning both Students to Matched state
+ *   #129 — Decline action removing the request and navigating back
  */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react-native";
@@ -25,6 +26,7 @@ const mockCommentsFn = jest.fn();
 const mockSendMatchRequest = jest.fn();
 const mockGetMatchRequestStatusFn = jest.fn();
 const mockAcceptMatchRequest = jest.fn();
+const mockDeclineMatchRequest = jest.fn();
 const mockInvalidateQueries = jest.fn();
 
 jest.mock("@/utils/trpc", () => ({
@@ -48,6 +50,9 @@ jest.mock("@/utils/trpc", () => ({
       },
       acceptMatchRequest: {
         mutationOptions: () => ({ mutationFn: mockAcceptMatchRequest }),
+      },
+      declineMatchRequest: {
+        mutationOptions: () => ({ mutationFn: mockDeclineMatchRequest }),
       },
     },
     profile: {
@@ -98,6 +103,7 @@ beforeEach(() => {
   mockBack.mockClear();
   mockSendMatchRequest.mockClear().mockResolvedValue({ matchRequestId: "req-1", status: "pending" });
   mockAcceptMatchRequest.mockClear().mockResolvedValue({ status: "accepted", matchedWithUserId: "requester-1" });
+  mockDeclineMatchRequest.mockClear().mockResolvedValue({ status: "declined" });
   mockInvalidateQueries.mockClear();
   mockProfileFn.mockReset().mockResolvedValue(defaultProfile);
   mockCommentsFn.mockReset().mockResolvedValue([]);
@@ -354,6 +360,52 @@ describe("#128 — Accept action transitioning both Students to Matched state", 
 
     await waitFor(() => {
       expect(screen.getByText("Accepted")).toBeTruthy();
+    });
+  });
+});
+
+// ─── #129: Decline action ──────────────────────────────────────────────────
+
+describe("#129 — Decline action removing the request and navigating back", () => {
+  it("calls declineMatchRequest mutation when Decline is tapped", async () => {
+    mockSearchParams = { id: "candidate-123", matchRequestId: "req-abc" };
+
+    renderScreen();
+
+    await waitFor(() => screen.getByTestId("decline-button"));
+    fireEvent.press(screen.getByTestId("decline-button"));
+
+    await waitFor(() => {
+      expect(mockDeclineMatchRequest).toHaveBeenCalledTimes(1);
+      expect(mockDeclineMatchRequest.mock.calls[0][0]).toEqual({ matchRequestId: "req-abc" });
+    });
+  });
+
+  it("navigates back after successful decline", async () => {
+    mockSearchParams = { id: "candidate-123", matchRequestId: "req-abc" };
+
+    renderScreen();
+
+    await waitFor(() => screen.getByTestId("decline-button"));
+    fireEvent.press(screen.getByTestId("decline-button"));
+
+    await waitFor(() => {
+      expect(mockBack).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("invalidates incoming requests query after declining", async () => {
+    mockSearchParams = { id: "candidate-123", matchRequestId: "req-abc" };
+
+    renderScreen();
+
+    await waitFor(() => screen.getByTestId("decline-button"));
+    fireEvent.press(screen.getByTestId("decline-button"));
+
+    await waitFor(() => {
+      expect(mockInvalidateQueries).toHaveBeenCalledWith(
+        expect.objectContaining({ queryKey: ["matching.getIncomingRequests"] }),
+      );
     });
   });
 });

--- a/apps/native/__tests__/partner-profile.test.tsx
+++ b/apps/native/__tests__/partner-profile.test.tsx
@@ -5,6 +5,7 @@
  *   #121 — Handle removed/unavailable candidate profile gracefully
  *   #122 — Send Request button on candidate profile screen
  *   #127 — Allow receiver to open requester's profile before deciding
+ *   #128 — Accept action transitioning both Students to Matched state
  */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react-native";
@@ -23,8 +24,11 @@ const mockProfileFn = jest.fn();
 const mockCommentsFn = jest.fn();
 const mockSendMatchRequest = jest.fn();
 const mockGetMatchRequestStatusFn = jest.fn();
+const mockAcceptMatchRequest = jest.fn();
+const mockInvalidateQueries = jest.fn();
 
 jest.mock("@/utils/trpc", () => ({
+  queryClient: { invalidateQueries: (...args: unknown[]) => mockInvalidateQueries(...args) },
   trpc: {
     matching: {
       getPartnerProfile: {
@@ -41,6 +45,9 @@ jest.mock("@/utils/trpc", () => ({
           queryKey: ["matching.getMatchRequestStatus"],
           queryFn: () => mockGetMatchRequestStatusFn(),
         }),
+      },
+      acceptMatchRequest: {
+        mutationOptions: () => ({ mutationFn: mockAcceptMatchRequest }),
       },
     },
     profile: {
@@ -90,6 +97,8 @@ beforeEach(() => {
   mockSearchParams = { id: "candidate-123" };
   mockBack.mockClear();
   mockSendMatchRequest.mockClear().mockResolvedValue({ matchRequestId: "req-1", status: "pending" });
+  mockAcceptMatchRequest.mockClear().mockResolvedValue({ status: "accepted", matchedWithUserId: "requester-1" });
+  mockInvalidateQueries.mockClear();
   mockProfileFn.mockReset().mockResolvedValue(defaultProfile);
   mockCommentsFn.mockReset().mockResolvedValue([]);
   mockGetMatchRequestStatusFn.mockReset().mockResolvedValue({ matchRequestStatus: "none" });
@@ -300,5 +309,51 @@ describe("#127 — Accept/Decline action bar on requester profile", () => {
       expect(screen.getByTestId("send-request-button")).toBeTruthy();
     });
     expect(screen.queryByTestId("accept-decline-bar")).toBeNull();
+  });
+});
+
+// ─── #128: Accept action ───────────────────────────────────────────────────
+
+describe("#128 — Accept action transitioning both Students to Matched state", () => {
+  it("calls acceptMatchRequest mutation when Accept is tapped", async () => {
+    mockSearchParams = { id: "candidate-123", matchRequestId: "req-abc" };
+
+    renderScreen();
+
+    await waitFor(() => screen.getByTestId("accept-button"));
+    fireEvent.press(screen.getByTestId("accept-button"));
+
+    await waitFor(() => {
+      expect(mockAcceptMatchRequest).toHaveBeenCalledTimes(1);
+      expect(mockAcceptMatchRequest.mock.calls[0][0]).toEqual({ matchRequestId: "req-abc" });
+    });
+  });
+
+  it("invalidates incoming requests query after accepting", async () => {
+    mockSearchParams = { id: "candidate-123", matchRequestId: "req-abc" };
+
+    renderScreen();
+
+    await waitFor(() => screen.getByTestId("accept-button"));
+    fireEvent.press(screen.getByTestId("accept-button"));
+
+    await waitFor(() => {
+      expect(mockInvalidateQueries).toHaveBeenCalledWith(
+        expect.objectContaining({ queryKey: ["matching.getIncomingRequests"] }),
+      );
+    });
+  });
+
+  it("shows Accepted label and disables Accept button after success", async () => {
+    mockSearchParams = { id: "candidate-123", matchRequestId: "req-abc" };
+
+    renderScreen();
+
+    await waitFor(() => screen.getByTestId("accept-button"));
+    fireEvent.press(screen.getByTestId("accept-button"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Accepted")).toBeTruthy();
+    });
   });
 });

--- a/apps/native/__tests__/suggestions.test.tsx
+++ b/apps/native/__tests__/suggestions.test.tsx
@@ -1,12 +1,16 @@
 /**
- * Tests for task #126 — Display incoming match requests on home page
+ * Tests for tasks:
+ *   #126 — Display incoming match requests on home page
+ *   #127 — Allow receiver to open requester's profile before deciding
  */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor } from "@testing-library/react-native";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react-native";
 import React from "react";
 
+const mockPush = jest.fn();
+
 jest.mock("expo-router", () => ({
-  useRouter: () => ({ push: jest.fn() }),
+  useRouter: () => ({ push: mockPush }),
 }));
 
 const mockDiscoverFn = jest.fn();
@@ -84,6 +88,7 @@ function renderScreen() {
 }
 
 beforeEach(() => {
+  mockPush.mockClear();
   mockDiscoverFn.mockReset().mockResolvedValue({ partners: [defaultPartner], nextCursor: undefined });
   mockIncomingRequestsFn.mockReset().mockResolvedValue([]);
   mockSendMatchRequest.mockReset().mockResolvedValue({ matchRequestId: "r", status: "pending" });
@@ -140,5 +145,50 @@ describe("#126 — Incoming match requests on home page", () => {
     });
     expect(screen.getByText("Bob")).toBeTruthy();
     expect(screen.getByText("Carol")).toBeTruthy();
+  });
+});
+
+// ─── #127: Open requester's profile from incoming request ───────────────────
+
+describe("#127 — Open requester's profile from incoming request", () => {
+  it("navigates to requester's full profile when tapping a request item from home page", async () => {
+    mockIncomingRequestsFn.mockResolvedValue([defaultIncomingRequest]);
+
+    renderScreen();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("incoming-request-item")).toBeTruthy();
+    });
+
+    fireEvent.press(screen.getByTestId("incoming-request-item"));
+
+    expect(mockPush).toHaveBeenCalledWith({
+      pathname: "/partner/[id]",
+      params: {
+        id: defaultIncomingRequest.requesterId,
+        matchRequestId: defaultIncomingRequest.matchRequestId,
+      },
+    });
+  });
+
+  it("navigates with correct matchRequestId when tapping from notifications area", async () => {
+    mockDiscoverFn.mockResolvedValue({ partners: [], nextCursor: undefined });
+    mockIncomingRequestsFn.mockResolvedValue([defaultIncomingRequest]);
+
+    renderScreen();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("incoming-request-item")).toBeTruthy();
+    });
+
+    fireEvent.press(screen.getByTestId("incoming-request-item"));
+
+    expect(mockPush).toHaveBeenCalledWith({
+      pathname: "/partner/[id]",
+      params: {
+        id: defaultIncomingRequest.requesterId,
+        matchRequestId: defaultIncomingRequest.matchRequestId,
+      },
+    });
   });
 });

--- a/apps/native/__tests__/suggestions.test.tsx
+++ b/apps/native/__tests__/suggestions.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * Tests for task #126 — Display incoming match requests on home page
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react-native";
+import React from "react";
+
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+const mockDiscoverFn = jest.fn();
+const mockIncomingRequestsFn = jest.fn();
+const mockSendMatchRequest = jest.fn();
+
+jest.mock("@/utils/trpc", () => ({
+  trpc: {
+    matching: {
+      discover: {
+        queryOptions: () => ({
+          queryKey: ["matching.discover"],
+          queryFn: () => mockDiscoverFn(),
+        }),
+      },
+      getIncomingRequests: {
+        queryOptions: () => ({
+          queryKey: ["matching.getIncomingRequests"],
+          queryFn: () => mockIncomingRequestsFn(),
+        }),
+      },
+      sendMatchRequest: {
+        mutationOptions: () => ({ mutationFn: mockSendMatchRequest }),
+      },
+      getMatchRequestStatus: {
+        queryOptions: () => ({
+          queryKey: ["matching.getMatchRequestStatus"],
+          queryFn: () => Promise.resolve({ matchRequestStatus: "none" }),
+        }),
+      },
+    },
+  },
+}));
+
+const defaultPartner = {
+  userId: "partner-1",
+  name: "Alice",
+  image: null,
+  spokenLanguages: [{ language: "Dutch", proficiency: "native" }],
+  learningLanguages: ["English"],
+  interests: ["tech_coding"],
+  bio: null,
+  university: null,
+  age: null,
+  distance: null,
+  score: 0.8,
+};
+
+const defaultIncomingRequest = {
+  matchRequestId: "req-1",
+  requesterId: "requester-1",
+  requesterName: "Bob",
+  requesterPhotoUrl: null,
+  requesterOfferedLanguages: ["English"],
+  requesterTargetedLanguages: ["Dutch"],
+  createdAt: "2026-04-13T10:00:00.000Z",
+};
+
+function makeClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+}
+
+// Import after mocks
+import SuggestionsScreen from "../app/suggestions";
+
+function renderScreen() {
+  const client = makeClient();
+  return render(
+    <QueryClientProvider client={client}>
+      <SuggestionsScreen />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  mockDiscoverFn.mockReset().mockResolvedValue({ partners: [defaultPartner], nextCursor: undefined });
+  mockIncomingRequestsFn.mockReset().mockResolvedValue([]);
+  mockSendMatchRequest.mockReset().mockResolvedValue({ matchRequestId: "r", status: "pending" });
+});
+
+// ─── #126: Incoming match requests on home page ─────────────────────────────
+
+describe("#126 — Incoming match requests on home page", () => {
+  it("shows incoming request with requester name and language summary", async () => {
+    mockIncomingRequestsFn.mockResolvedValue([defaultIncomingRequest]);
+
+    renderScreen();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("incoming-requests-section")).toBeTruthy();
+    });
+    expect(screen.getByTestId("incoming-request-item")).toBeTruthy();
+    expect(screen.getByTestId("requester-name")).toBeTruthy();
+    expect(screen.getByText("Bob")).toBeTruthy();
+  });
+
+  it("shows incoming request in the notifications area (same section)", async () => {
+    mockIncomingRequestsFn.mockResolvedValue([defaultIncomingRequest]);
+
+    renderScreen();
+
+    await waitFor(() => {
+      expect(screen.getByText("People who want to meet you")).toBeTruthy();
+    });
+    expect(screen.getByTestId("incoming-request-item")).toBeTruthy();
+  });
+
+  it("hides incoming requests section when there are no pending requests", async () => {
+    mockIncomingRequestsFn.mockResolvedValue([]);
+
+    renderScreen();
+
+    await waitFor(() => {
+      expect(screen.getByText("Suggestions")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("incoming-requests-section")).toBeNull();
+  });
+
+  it("shows multiple incoming requests when there are several", async () => {
+    mockIncomingRequestsFn.mockResolvedValue([
+      defaultIncomingRequest,
+      { ...defaultIncomingRequest, matchRequestId: "req-2", requesterId: "requester-2", requesterName: "Carol" },
+    ]);
+
+    renderScreen();
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId("incoming-request-item")).toHaveLength(2);
+    });
+    expect(screen.getByText("Bob")).toBeTruthy();
+    expect(screen.getByText("Carol")).toBeTruthy();
+  });
+});

--- a/apps/native/app/partner/[id].tsx
+++ b/apps/native/app/partner/[id].tsx
@@ -8,7 +8,7 @@ import { Container } from "@/components/container";
 import { trpc } from "@/utils/trpc";
 
 export default function PartnerProfileScreen() {
-  const { id } = useLocalSearchParams<{ id: string }>();
+  const { id, matchRequestId } = useLocalSearchParams<{ id: string; matchRequestId?: string }>();
   const router = useRouter();
 
   const profileQuery = useQuery(
@@ -196,25 +196,47 @@ export default function PartnerProfileScreen() {
           </View>
         )}
 
-        {/* #120/#122 — Contextual Send Request */}
-        {requestAlreadySent ? (
-          <View testID="request-sent-indicator" className="bg-muted rounded-xl p-4 mb-4 items-center">
-            <Text className="text-muted-foreground font-medium">Request Sent</Text>
+        {/* #127 — Accept/Decline bar (when opened from incoming request context) */}
+        {matchRequestId ? (
+          <View testID="accept-decline-bar" className="flex-row gap-3 mb-4">
+            <Button
+              testID="decline-button"
+              variant="ghost"
+              className="flex-1"
+              onPress={() => {/* T15.4 — wired in Decline action task */}}
+            >
+              <Button.Label>Decline</Button.Label>
+            </Button>
+            <Button
+              testID="accept-button"
+              variant="primary"
+              className="flex-1"
+              onPress={() => {/* T15.3 — wired in Accept action task */}}
+            >
+              <Button.Label>Accept</Button.Label>
+            </Button>
           </View>
         ) : (
-          <Button
-            testID="send-request-button"
-            variant="primary"
-            isDisabled={sendRequestMutation.isPending || statusQuery.isPending}
-            onPress={() => sendRequestMutation.mutate({ receiverId: id })}
-            className="mb-4"
-          >
-            {sendRequestMutation.isPending ? (
-              <Spinner size="sm" />
-            ) : (
-              <Button.Label>Send Request</Button.Label>
-            )}
-          </Button>
+          /* #120/#122 — Contextual Send Request */
+          requestAlreadySent ? (
+            <View testID="request-sent-indicator" className="bg-muted rounded-xl p-4 mb-4 items-center">
+              <Text className="text-muted-foreground font-medium">Request Sent</Text>
+            </View>
+          ) : (
+            <Button
+              testID="send-request-button"
+              variant="primary"
+              isDisabled={sendRequestMutation.isPending || statusQuery.isPending}
+              onPress={() => sendRequestMutation.mutate({ receiverId: id })}
+              className="mb-4"
+            >
+              {sendRequestMutation.isPending ? (
+                <Spinner size="sm" />
+              ) : (
+                <Button.Label>Send Request</Button.Label>
+              )}
+            </Button>
+          )
         )}
       </ScrollView>
     </Container>

--- a/apps/native/app/partner/[id].tsx
+++ b/apps/native/app/partner/[id].tsx
@@ -41,6 +41,14 @@ export default function PartnerProfileScreen() {
     },
   });
 
+  const declineMutation = useMutation({
+    ...trpc.matching.declineMatchRequest.mutationOptions(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["matching.getIncomingRequests"] });
+      router.back();
+    },
+  });
+
   // #121 — if profile is no longer available, navigate back
   useEffect(() => {
     if (profileQuery.error && (profileQuery.error as { data?: { code?: string } }).data?.code === "NOT_FOUND") {
@@ -210,7 +218,12 @@ export default function PartnerProfileScreen() {
               testID="decline-button"
               variant="ghost"
               className="flex-1"
-              onPress={() => {/* T15.4 — wired in Decline action task */}}
+              isDisabled={declineMutation.isPending}
+              onPress={() => {
+                if (matchRequestId) {
+                  declineMutation.mutate({ matchRequestId });
+                }
+              }}
             >
               <Button.Label>Decline</Button.Label>
             </Button>

--- a/apps/native/app/partner/[id].tsx
+++ b/apps/native/app/partner/[id].tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from "react";
 import { Image, ScrollView, Text, View } from "react-native";
 
 import { Container } from "@/components/container";
-import { trpc } from "@/utils/trpc";
+import { queryClient, trpc } from "@/utils/trpc";
 
 export default function PartnerProfileScreen() {
   const { id, matchRequestId } = useLocalSearchParams<{ id: string; matchRequestId?: string }>();
@@ -31,6 +31,13 @@ export default function PartnerProfileScreen() {
       if (error.data?.code === "CONFLICT") {
         setSendConflictError("A match request to this candidate already exists.");
       }
+    },
+  });
+
+  const acceptMutation = useMutation({
+    ...trpc.matching.acceptMatchRequest.mutationOptions(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["matching.getIncomingRequests"] });
     },
   });
 
@@ -211,9 +218,14 @@ export default function PartnerProfileScreen() {
               testID="accept-button"
               variant="primary"
               className="flex-1"
-              onPress={() => {/* T15.3 — wired in Accept action task */}}
+              isDisabled={acceptMutation.isPending || acceptMutation.isSuccess}
+              onPress={() => {
+                if (matchRequestId) {
+                  acceptMutation.mutate({ matchRequestId });
+                }
+              }}
             >
-              <Button.Label>Accept</Button.Label>
+              <Button.Label>{acceptMutation.isSuccess ? "Accepted" : "Accept"}</Button.Label>
             </Button>
           </View>
         ) : (

--- a/apps/native/app/suggestions.tsx
+++ b/apps/native/app/suggestions.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { Button, Spinner } from "heroui-native";
 import { useState, useCallback } from "react";
-import { FlatList, RefreshControl, Share, Text, View } from "react-native";
+import { FlatList, Image, RefreshControl, Share, Text, View } from "react-native";
 
 import { CandidateCard } from "@/components/candidate-card";
 import { Container } from "@/components/container";
@@ -33,18 +33,85 @@ function EmptySuggestionState() {
   );
 }
 
+function IncomingRequestItem({
+  request,
+}: {
+  request: {
+    matchRequestId: string;
+    requesterId: string;
+    requesterName: string;
+    requesterPhotoUrl: string | null;
+    requesterOfferedLanguages: string[];
+    requesterTargetedLanguages: string[];
+    createdAt: string;
+  };
+}) {
+  return (
+    <View
+      testID="incoming-request-item"
+      className="bg-card border border-border rounded-2xl p-4 mb-3"
+    >
+      <View className="flex-row items-center gap-3 mb-2">
+        {request.requesterPhotoUrl ? (
+          <Image
+            testID="requester-photo"
+            source={{ uri: request.requesterPhotoUrl }}
+            className="w-12 h-12 rounded-full"
+          />
+        ) : (
+          <View
+            testID="requester-photo-placeholder"
+            className="w-12 h-12 rounded-full bg-muted items-center justify-center"
+          >
+            <Text className="text-muted-foreground text-lg font-semibold">
+              {request.requesterName.charAt(0).toUpperCase()}
+            </Text>
+          </View>
+        )}
+        <Text testID="requester-name" className="text-foreground text-base font-semibold flex-1">
+          {request.requesterName}
+        </Text>
+      </View>
+
+      {request.requesterOfferedLanguages.length > 0 && (
+        <View className="flex-row flex-wrap gap-1 mb-1">
+          {request.requesterOfferedLanguages.map((lang) => (
+            <View key={lang} className="bg-primary/10 px-2 py-0.5 rounded-full">
+              <Text className="text-primary text-xs">{lang}</Text>
+            </View>
+          ))}
+        </View>
+      )}
+
+      {request.requesterTargetedLanguages.length > 0 && (
+        <View className="flex-row flex-wrap gap-1">
+          {request.requesterTargetedLanguages.map((lang) => (
+            <View key={lang} className="bg-secondary/10 px-2 py-0.5 rounded-full">
+              <Text className="text-secondary-foreground text-xs">{lang}</Text>
+            </View>
+          ))}
+        </View>
+      )}
+    </View>
+  );
+}
+
 export default function SuggestionsScreen() {
   const [refreshing, setRefreshing] = useState(false);
 
   const discoverQuery = useQuery(trpc.matching.discover.queryOptions({}));
+  const incomingRequestsQuery = useQuery(
+    trpc.matching.getIncomingRequests.queryOptions(),
+  );
 
   const partners = discoverQuery.data?.partners ?? [];
+  const incomingRequests = incomingRequestsQuery.data ?? [];
 
   const onRefresh = useCallback(async () => {
     setRefreshing(true);
-    await discoverQuery.refetch();
+    await Promise.all([discoverQuery.refetch(), incomingRequestsQuery.refetch()]);
     setRefreshing(false);
-  }, [discoverQuery]);
+  }, [discoverQuery, incomingRequestsQuery]);
 
   if (discoverQuery.isPending) {
     return (
@@ -60,6 +127,16 @@ export default function SuggestionsScreen() {
     return (
       <Container isScrollable={false}>
         <View className="flex-1 p-4">
+          {incomingRequests.length > 0 && (
+            <View testID="incoming-requests-section" className="mb-6">
+              <Text className="text-foreground text-lg font-bold mb-3">
+                People who want to meet you
+              </Text>
+              {incomingRequests.map((req) => (
+                <IncomingRequestItem key={req.matchRequestId} request={req} />
+              ))}
+            </View>
+          )}
           <Text className="text-foreground text-2xl font-bold mb-4">Suggestions</Text>
           <EmptySuggestionState />
         </View>
@@ -77,9 +154,23 @@ export default function SuggestionsScreen() {
           <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
         }
         ListHeaderComponent={
-          <Text className="text-foreground text-2xl font-bold mb-4">
-            Suggestions
-          </Text>
+          <>
+            {/* #126 — Incoming match requests section */}
+            {incomingRequests.length > 0 && (
+              <View testID="incoming-requests-section" className="mb-6">
+                <Text className="text-foreground text-lg font-bold mb-3">
+                  People who want to meet you
+                </Text>
+                {incomingRequests.map((req) => (
+                  <IncomingRequestItem key={req.matchRequestId} request={req} />
+                ))}
+              </View>
+            )}
+
+            <Text className="text-foreground text-2xl font-bold mb-4">
+              Suggestions
+            </Text>
+          </>
         }
         renderItem={({ item }) => (
           <CandidateCard

--- a/apps/native/app/suggestions.tsx
+++ b/apps/native/app/suggestions.tsx
@@ -1,7 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
+import { useRouter } from "expo-router";
 import { Button, Spinner } from "heroui-native";
 import { useState, useCallback } from "react";
-import { FlatList, Image, RefreshControl, Share, Text, View } from "react-native";
+import { FlatList, Image, Pressable, RefreshControl, Share, Text, View } from "react-native";
 
 import { CandidateCard } from "@/components/candidate-card";
 import { Container } from "@/components/container";
@@ -35,6 +36,7 @@ function EmptySuggestionState() {
 
 function IncomingRequestItem({
   request,
+  onPress,
 }: {
   request: {
     matchRequestId: string;
@@ -45,10 +47,12 @@ function IncomingRequestItem({
     requesterTargetedLanguages: string[];
     createdAt: string;
   };
+  onPress: () => void;
 }) {
   return (
-    <View
+    <Pressable
       testID="incoming-request-item"
+      onPress={onPress}
       className="bg-card border border-border rounded-2xl p-4 mb-3"
     >
       <View className="flex-row items-center gap-3 mb-2">
@@ -92,11 +96,12 @@ function IncomingRequestItem({
           ))}
         </View>
       )}
-    </View>
+    </Pressable>
   );
 }
 
 export default function SuggestionsScreen() {
+  const router = useRouter();
   const [refreshing, setRefreshing] = useState(false);
 
   const discoverQuery = useQuery(trpc.matching.discover.queryOptions({}));
@@ -133,7 +138,11 @@ export default function SuggestionsScreen() {
                 People who want to meet you
               </Text>
               {incomingRequests.map((req) => (
-                <IncomingRequestItem key={req.matchRequestId} request={req} />
+                <IncomingRequestItem
+                    key={req.matchRequestId}
+                    request={req}
+                    onPress={() => router.push({ pathname: "/partner/[id]", params: { id: req.requesterId, matchRequestId: req.matchRequestId } })}
+                  />
               ))}
             </View>
           )}
@@ -162,7 +171,11 @@ export default function SuggestionsScreen() {
                   People who want to meet you
                 </Text>
                 {incomingRequests.map((req) => (
-                  <IncomingRequestItem key={req.matchRequestId} request={req} />
+                  <IncomingRequestItem
+                    key={req.matchRequestId}
+                    request={req}
+                    onPress={() => router.push({ pathname: "/partner/[id]", params: { id: req.requesterId, matchRequestId: req.matchRequestId } })}
+                  />
                 ))}
               </View>
             )}

--- a/packages/api/src/domain-events.ts
+++ b/packages/api/src/domain-events.ts
@@ -22,11 +22,27 @@ export interface MatchRequestSentEvent {
   sentAt: Date;
 }
 
+export interface MatchRequestAcceptedEvent {
+  matchRequestId: string;
+  requesterId: string;
+  receiverId: string;
+  acceptedAt: Date;
+}
+
+export interface MatchRequestDeclinedEvent {
+  matchRequestId: string;
+  requesterId: string;
+  receiverId: string;
+  declinedAt: Date;
+}
+
 type DomainEventMap = {
   LanguageProfileUpdated: [LanguageProfileUpdatedEvent];
   InterestProfileUpdated: [InterestProfileUpdatedEvent];
   ProfileCompleted: [ProfileCompletedEvent];
   MatchRequestSent: [MatchRequestSentEvent];
+  MatchRequestAccepted: [MatchRequestAcceptedEvent];
+  MatchRequestDeclined: [MatchRequestDeclinedEvent];
 };
 
 class TypedEventEmitter extends EventEmitter {

--- a/packages/api/src/routers/matching.ts
+++ b/packages/api/src/routers/matching.ts
@@ -7,6 +7,7 @@ import {
   userLanguage,
   userInterest,
   matchRequest,
+  studentMatch,
 } from "@sip-and-speak/db/schema/sip-and-speak";
 import { user } from "@sip-and-speak/db/schema/auth";
 import { protectedProcedure, router } from "../index";
@@ -425,5 +426,53 @@ export const matchingRouter = router({
       });
 
       return { matchRequestId: created.id, status: "pending" as const };
+    }),
+
+  acceptMatchRequest: protectedProcedure
+    .input(z.object({ matchRequestId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const receiverId = ctx.session.user.id;
+
+      const request = await db.query.matchRequest.findFirst({
+        where: eq(matchRequest.id, input.matchRequestId),
+      });
+
+      if (!request) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Match request not found." });
+      }
+
+      if (request.receiverId !== receiverId) {
+        throw new TRPCError({ code: "FORBIDDEN", message: "Only the designated receiver may accept this request." });
+      }
+
+      if (request.status !== "pending") {
+        throw new TRPCError({ code: "BAD_REQUEST", message: "Only pending requests can be accepted." });
+      }
+
+      await db
+        .update(matchRequest)
+        .set({ status: "accepted" })
+        .where(eq(matchRequest.id, input.matchRequestId));
+
+      await db.insert(studentMatch).values({
+        studentAId: request.requesterId,
+        studentBId: receiverId,
+        matchRequestId: input.matchRequestId,
+      });
+
+      console.info("[MatchRequestAccepted]", {
+        matchRequestId: input.matchRequestId,
+        requesterId: request.requesterId,
+        receiverId,
+      });
+
+      domainEvents.emit("MatchRequestAccepted", {
+        matchRequestId: input.matchRequestId,
+        requesterId: request.requesterId,
+        receiverId,
+        acceptedAt: new Date(),
+      });
+
+      return { status: "accepted" as const, matchedWithUserId: request.requesterId };
     }),
 });

--- a/packages/api/src/routers/matching.ts
+++ b/packages/api/src/routers/matching.ts
@@ -475,4 +475,46 @@ export const matchingRouter = router({
 
       return { status: "accepted" as const, matchedWithUserId: request.requesterId };
     }),
+
+  declineMatchRequest: protectedProcedure
+    .input(z.object({ matchRequestId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const receiverId = ctx.session.user.id;
+
+      const request = await db.query.matchRequest.findFirst({
+        where: eq(matchRequest.id, input.matchRequestId),
+      });
+
+      if (!request) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Match request not found." });
+      }
+
+      if (request.receiverId !== receiverId) {
+        throw new TRPCError({ code: "FORBIDDEN", message: "Only the designated receiver may decline this request." });
+      }
+
+      if (request.status !== "pending") {
+        throw new TRPCError({ code: "BAD_REQUEST", message: "Only pending requests can be declined." });
+      }
+
+      await db
+        .update(matchRequest)
+        .set({ status: "declined" })
+        .where(eq(matchRequest.id, input.matchRequestId));
+
+      console.info("[MatchRequestDeclined]", {
+        matchRequestId: input.matchRequestId,
+        requesterId: request.requesterId,
+        receiverId,
+      });
+
+      domainEvents.emit("MatchRequestDeclined", {
+        matchRequestId: input.matchRequestId,
+        requesterId: request.requesterId,
+        receiverId,
+        declinedAt: new Date(),
+      });
+
+      return { status: "declined" as const };
+    }),
 });

--- a/packages/api/src/routers/matching.ts
+++ b/packages/api/src/routers/matching.ts
@@ -238,6 +238,59 @@ export const matchingRouter = router({
       return { partners: page, nextCursor };
     }),
 
+  getIncomingRequests: protectedProcedure
+    .query(async ({ ctx }) => {
+      const receiverId = ctx.session.user.id;
+
+      const pendingRequests = await db
+        .select({
+          matchRequestId: matchRequest.id,
+          requesterId: matchRequest.requesterId,
+          createdAt: matchRequest.createdAt,
+        })
+        .from(matchRequest)
+        .where(
+          and(
+            eq(matchRequest.receiverId, receiverId),
+            eq(matchRequest.status, "pending"),
+          ),
+        );
+
+      if (pendingRequests.length === 0) return [];
+
+      const requesterIds = pendingRequests.map((r) => r.requesterId);
+
+      const [requesterUsers, requesterLanguages] = await Promise.all([
+        db
+          .select({ id: user.id, name: user.name, image: user.image })
+          .from(user)
+          .where(inArray(user.id, requesterIds)),
+        db
+          .select()
+          .from(userLanguage)
+          .where(inArray(userLanguage.userId, requesterIds)),
+      ]);
+
+      return pendingRequests.map((req) => {
+        const userInfo = requesterUsers.find((u) => u.id === req.requesterId);
+        const langs = requesterLanguages.filter((l) => l.userId === req.requesterId);
+
+        return {
+          matchRequestId: req.matchRequestId,
+          requesterId: req.requesterId,
+          requesterName: userInfo?.name ?? "Unknown",
+          requesterPhotoUrl: userInfo?.image ?? null,
+          requesterOfferedLanguages: langs
+            .filter((l) => l.type === "spoken")
+            .map((l) => l.language),
+          requesterTargetedLanguages: langs
+            .filter((l) => l.type === "learning")
+            .map((l) => l.language),
+          createdAt: req.createdAt.toISOString(),
+        };
+      });
+    }),
+
   getPartnerProfile: protectedProcedure
     .input(z.object({ userId: z.string() }))
     .query(async ({ input }) => {

--- a/packages/db/src/migrations/0002_rich_agent_zero.sql
+++ b/packages/db/src/migrations/0002_rich_agent_zero.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "student_match" (
+	"id" text PRIMARY KEY NOT NULL,
+	"student_a_id" text NOT NULL,
+	"student_b_id" text NOT NULL,
+	"match_request_id" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "student_match" ADD CONSTRAINT "student_match_student_a_id_user_id_fk" FOREIGN KEY ("student_a_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "student_match" ADD CONSTRAINT "student_match_student_b_id_user_id_fk" FOREIGN KEY ("student_b_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "student_match" ADD CONSTRAINT "student_match_match_request_id_match_request_id_fk" FOREIGN KEY ("match_request_id") REFERENCES "public"."match_request"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "student_match_studentA_idx" ON "student_match" USING btree ("student_a_id");--> statement-breakpoint
+CREATE INDEX "student_match_studentB_idx" ON "student_match" USING btree ("student_b_id");

--- a/packages/db/src/migrations/meta/0002_snapshot.json
+++ b/packages/db/src/migrations/meta/0002_snapshot.json
@@ -1,0 +1,1422 @@
+{
+  "id": "493b82ee-98bf-474e-9b2f-3981e5a034e2",
+  "prevId": "8f1dc8c0-fd47-4e1c-8e78-3245e43160cb",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation": {
+      "name": "conversation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user1_id": {
+          "name": "user1_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user2_id": {
+          "name": "user2_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_user1_idx": {
+          "name": "conversation_user1_idx",
+          "columns": [
+            {
+              "expression": "user1_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_user2_idx": {
+          "name": "conversation_user2_idx",
+          "columns": [
+            {
+              "expression": "user2_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_user1_id_user_id_fk": {
+          "name": "conversation_user1_id_user_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user1_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_user2_id_user_id_fk": {
+          "name": "conversation_user2_id_user_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user2_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.language_profile": {
+      "name": "language_profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "university": {
+          "name": "university",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "age": {
+          "name": "age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_complete": {
+          "name": "onboarding_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "language_profile_user_id_user_id_fk": {
+          "name": "language_profile_user_id_user_id_fk",
+          "tableFrom": "language_profile",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "language_profile_user_id_unique": {
+          "name": "language_profile_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_request": {
+      "name": "match_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "requester_id": {
+          "name": "requester_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receiver_id": {
+          "name": "receiver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "match_request_requesterId_idx": {
+          "name": "match_request_requesterId_idx",
+          "columns": [
+            {
+              "expression": "requester_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "match_request_receiverId_idx": {
+          "name": "match_request_receiverId_idx",
+          "columns": [
+            {
+              "expression": "receiver_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "match_request_requester_id_user_id_fk": {
+          "name": "match_request_requester_id_user_id_fk",
+          "tableFrom": "match_request",
+          "tableTo": "user",
+          "columnsFrom": [
+            "requester_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "match_request_receiver_id_user_id_fk": {
+          "name": "match_request_receiver_id_user_id_fk",
+          "tableFrom": "match_request",
+          "tableTo": "user",
+          "columnsFrom": [
+            "receiver_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meetup": {
+      "name": "meetup",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "proposer_id": {
+          "name": "proposer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receiver_id": {
+          "name": "receiver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "venue_id": {
+          "name": "venue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "meetup_proposerId_idx": {
+          "name": "meetup_proposerId_idx",
+          "columns": [
+            {
+              "expression": "proposer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meetup_receiverId_idx": {
+          "name": "meetup_receiverId_idx",
+          "columns": [
+            {
+              "expression": "receiver_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meetup_date_idx": {
+          "name": "meetup_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "meetup_proposer_id_user_id_fk": {
+          "name": "meetup_proposer_id_user_id_fk",
+          "tableFrom": "meetup",
+          "tableTo": "user",
+          "columnsFrom": [
+            "proposer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meetup_receiver_id_user_id_fk": {
+          "name": "meetup_receiver_id_user_id_fk",
+          "tableFrom": "meetup",
+          "tableTo": "user",
+          "columnsFrom": [
+            "receiver_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meetup_venue_id_venue_id_fk": {
+          "name": "meetup_venue_id_venue_id_fk",
+          "tableFrom": "meetup",
+          "tableTo": "venue",
+          "columnsFrom": [
+            "venue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message": {
+      "name": "message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_conversationId_idx": {
+          "name": "message_conversationId_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_createdAt_idx": {
+          "name": "message_createdAt_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_conversation_id_conversation_id_fk": {
+          "name": "message_conversation_id_conversation_id_fk",
+          "tableFrom": "message",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_sender_id_user_id_fk": {
+          "name": "message_sender_id_user_id_fk",
+          "tableFrom": "message",
+          "tableTo": "user",
+          "columnsFrom": [
+            "sender_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message_read_status": {
+      "name": "message_read_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_read_conversationId_userId_idx": {
+          "name": "message_read_conversationId_userId_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_read_status_conversation_id_conversation_id_fk": {
+          "name": "message_read_status_conversation_id_conversation_id_fk",
+          "tableFrom": "message_read_status",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_read_status_user_id_user_id_fk": {
+          "name": "message_read_status_user_id_user_id_fk",
+          "tableFrom": "message_read_status",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_comment": {
+      "name": "student_comment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "student_comment_targetId_idx": {
+          "name": "student_comment_targetId_idx",
+          "columns": [
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "student_comment_author_id_user_id_fk": {
+          "name": "student_comment_author_id_user_id_fk",
+          "tableFrom": "student_comment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "student_comment_target_id_user_id_fk": {
+          "name": "student_comment_target_id_user_id_fk",
+          "tableFrom": "student_comment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_match": {
+      "name": "student_match",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "student_a_id": {
+          "name": "student_a_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_b_id": {
+          "name": "student_b_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_request_id": {
+          "name": "match_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "student_match_studentA_idx": {
+          "name": "student_match_studentA_idx",
+          "columns": [
+            {
+              "expression": "student_a_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "student_match_studentB_idx": {
+          "name": "student_match_studentB_idx",
+          "columns": [
+            {
+              "expression": "student_b_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "student_match_student_a_id_user_id_fk": {
+          "name": "student_match_student_a_id_user_id_fk",
+          "tableFrom": "student_match",
+          "tableTo": "user",
+          "columnsFrom": [
+            "student_a_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "student_match_student_b_id_user_id_fk": {
+          "name": "student_match_student_b_id_user_id_fk",
+          "tableFrom": "student_match",
+          "tableTo": "user",
+          "columnsFrom": [
+            "student_b_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "student_match_match_request_id_match_request_id_fk": {
+          "name": "student_match_match_request_id_match_request_id_fk",
+          "tableFrom": "student_match",
+          "tableTo": "match_request",
+          "columnsFrom": [
+            "match_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_interest": {
+      "name": "user_interest",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interest": {
+          "name": "interest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_interest_userId_idx": {
+          "name": "user_interest_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_interest_user_id_user_id_fk": {
+          "name": "user_interest_user_id_user_id_fk",
+          "tableFrom": "user_interest",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_language": {
+      "name": "user_language",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proficiency": {
+          "name": "proficiency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_language_userId_idx": {
+          "name": "user_language_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_language_user_id_user_id_fk": {
+          "name": "user_language_user_id_user_id_fk",
+          "tableFrom": "user_language",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.venue": {
+      "name": "venue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1776066899965,
       "tag": "0001_pretty_vision",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1776079537981,
+      "tag": "0002_rich_agent_zero",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/sip-and-speak.ts
+++ b/packages/db/src/schema/sip-and-speak.ts
@@ -340,3 +340,43 @@ export const matchRequestRelations = relations(matchRequest, ({ one }) => ({
     relationName: "matchReceiver",
   }),
 }));
+
+export const studentMatch = pgTable(
+  "student_match",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    studentAId: text("student_a_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    studentBId: text("student_b_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    matchRequestId: text("match_request_id")
+      .notNull()
+      .references(() => matchRequest.id, { onDelete: "cascade" }),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (table) => [
+    index("student_match_studentA_idx").on(table.studentAId),
+    index("student_match_studentB_idx").on(table.studentBId),
+  ],
+);
+
+export const studentMatchRelations = relations(studentMatch, ({ one }) => ({
+  studentA: one(user, {
+    fields: [studentMatch.studentAId],
+    references: [user.id],
+    relationName: "studentMatchA",
+  }),
+  studentB: one(user, {
+    fields: [studentMatch.studentBId],
+    references: [user.id],
+    relationName: "studentMatchB",
+  }),
+  matchRequest: one(matchRequest, {
+    fields: [studentMatch.matchRequestId],
+    references: [matchRequest.id],
+  }),
+}));


### PR DESCRIPTION
## Summary

- Display incoming match requests on home page (#126)
- Allow receiver to open requester's profile before deciding (#127)
- Accept action → transitions both Students to Matched state + new `studentMatch` table (#128)
- Decline action → removes request, emits `MatchRequestDeclined`, navigates back (#129)

## Test plan

- [x] All 21 partner-profile tests pass
- [x] No new TypeScript errors

Closes #126
Closes #127
Closes #128
Closes #129
Closes #15