### PR TITLE
feat(notifications): notification tap deep-links to requester profile (#132)

### DIFF
--- a/apps/native/__tests__/notification-deep-link.test.tsx
+++ b/apps/native/__tests__/notification-deep-link.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * Tests for task #132 — Deep-link notification tap to requester's full profile
+ *
+ * Covers:
+ *   - Background/foreground tap listener navigates to requester profile
+ *   - Cold-start tap handler navigates to requester profile
+ *   - Malformed payload (missing matchRequestId) is silently ignored
+ *   - Listener is cleaned up on unmount
+ */
+import { act, renderHook } from "@testing-library/react-native";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const mockPush = jest.fn();
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+let tapListener: ((response: unknown) => void) | null = null;
+const mockRemove = jest.fn();
+const mockGetLastNotificationResponseAsync = jest.fn();
+
+jest.mock("expo-notifications", () => ({
+  addNotificationResponseReceivedListener: jest.fn((cb) => {
+    tapListener = cb;
+    return { remove: mockRemove };
+  }),
+  getLastNotificationResponseAsync: (...args: unknown[]) =>
+    mockGetLastNotificationResponseAsync(...args),
+}));
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function makeNotificationResponse(data: Record<string, unknown>) {
+  return {
+    notification: {
+      request: {
+        content: { data },
+      },
+    },
+  };
+}
+
+// ── Import after mocks ─────────────────────────────────────────────────────────
+// eslint-disable-next-line import/first
+import { useNotificationTapHandler } from "../hooks/use-notification-tap-handler";
+
+beforeEach(() => {
+  tapListener = null;
+  mockPush.mockClear();
+  mockRemove.mockClear();
+  mockGetLastNotificationResponseAsync.mockResolvedValue(null);
+});
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("#132 — Notification tap deep-links to requester profile", () => {
+  it("navigates to requester profile when notification with matchRequestId is tapped (background/foreground)", async () => {
+    renderHook(() => useNotificationTapHandler());
+
+    await act(async () => {
+      tapListener?.(
+        makeNotificationResponse({ matchRequestId: "req-xyz", requesterId: "user-abc" }),
+      );
+    });
+
+    expect(mockPush).toHaveBeenCalledWith("/partner/user-abc?matchRequestId=req-xyz");
+  });
+
+  it("navigates to requester profile on cold-start tap", async () => {
+    mockGetLastNotificationResponseAsync.mockResolvedValue(
+      makeNotificationResponse({ matchRequestId: "req-cold", requesterId: "user-cold" }),
+    );
+
+    renderHook(() => useNotificationTapHandler());
+
+    // Wait for getLastNotificationResponseAsync promise to resolve
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockPush).toHaveBeenCalledWith("/partner/user-cold?matchRequestId=req-cold");
+  });
+
+  it("does not navigate when matchRequestId is missing from payload", async () => {
+    renderHook(() => useNotificationTapHandler());
+
+    await act(async () => {
+      tapListener?.(makeNotificationResponse({ requesterId: "user-abc" }));
+    });
+
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("does not navigate when requesterId is missing from payload", async () => {
+    renderHook(() => useNotificationTapHandler());
+
+    await act(async () => {
+      tapListener?.(makeNotificationResponse({ matchRequestId: "req-xyz" }));
+    });
+
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("removes the listener on unmount", () => {
+    const { unmount } = renderHook(() => useNotificationTapHandler());
+    unmount();
+    expect(mockRemove).toHaveBeenCalled();
+  });
+});

--- a/apps/native/app/_layout.tsx
+++ b/apps/native/app/_layout.tsx
@@ -27,6 +27,7 @@ import { useMutation } from "@tanstack/react-query";
 import { authClient } from "@/lib/auth-client";
 import { AppThemeProvider } from "@/contexts/app-theme-context";
 import { queryClient, trpc } from "@/utils/trpc";
+import { useNotificationTapHandler } from "@/hooks/use-notification-tap-handler";
 
 SplashScreen.preventAutoHideAsync();
 
@@ -60,6 +61,7 @@ function AuthGuard() {
   const segments = useSegments();
 
   useDeviceTokenRegistration(!!session);
+  useNotificationTapHandler();
 
   const onboardingQuery = useQuery({
     ...trpc.profile.getOnboardingStatus.queryOptions(),

--- a/apps/native/hooks/use-notification-tap-handler.ts
+++ b/apps/native/hooks/use-notification-tap-handler.ts
@@ -1,0 +1,30 @@
+import * as Notifications from "expo-notifications";
+import { useRouter } from "expo-router";
+import { useEffect } from "react";
+
+export function useNotificationTapHandler() {
+  const router = useRouter();
+
+  function handleNotificationResponse(response: Notifications.NotificationResponse) {
+    const data = response.notification.request.content.data as Record<string, unknown> | undefined;
+    const matchRequestId = typeof data?.matchRequestId === "string" ? data.matchRequestId : undefined;
+    const requesterId = typeof data?.requesterId === "string" ? data.requesterId : undefined;
+
+    if (!matchRequestId || !requesterId) return;
+
+    router.push(`/partner/${requesterId}?matchRequestId=${matchRequestId}`);
+  }
+
+  useEffect(() => {
+    // Background / foreground tap listener
+    const subscription = Notifications.addNotificationResponseReceivedListener(handleNotificationResponse);
+
+    // Cold-start: check if the app was opened by a notification tap
+    void Notifications.getLastNotificationResponseAsync().then((response) => {
+      if (response) handleNotificationResponse(response);
+    });
+
+    return () => subscription.remove();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}

--- a/apps/native/jest-mocks/style-mock.ts
+++ b/apps/native/jest-mocks/style-mock.ts
@@ -1,0 +1,2 @@
+// Stub for CSS imports in Jest — not needed in tests
+export default {};

--- a/apps/native/jest.config.ts
+++ b/apps/native/jest.config.ts
@@ -7,6 +7,7 @@ const config: Config = {
     "node_modules/(?!(jest-)?react-native|@react-native(-community)?|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|heroui-native|@gorhom|nativewind|expo-router|@trpc|@tanstack|.bun)",
   ],
   moduleNameMapper: {
+    "\\.css$": "<rootDir>/jest-mocks/style-mock.ts",
     "^@/(.*)$": "<rootDir>/$1",
     "^react-native-reanimated$": "<rootDir>/jest-mocks/react-native-reanimated.ts",
     "^react-native-worklets$": "<rootDir>/jest-mocks/react-native-worklets.ts",


### PR DESCRIPTION
## Summary

- `useNotificationTapHandler` hook registers `addNotificationResponseReceivedListener` (foreground/background)
- Cold-start handling via `getLastNotificationResponseAsync` on mount
- Parses `matchRequestId` + `requesterId` from notification `data` payload
- Navigates to `/partner/[requesterId]?matchRequestId=[id]` — opens profile with Accept/Decline bar
- Malformed payloads (missing fields) silently ignored
- CSS stub added to `jest-mocks/` + `jest.config.ts` updated for layout test isolation

## Test plan

- [x] 5 new #132 scenarios pass (background tap, cold-start, missing field guards, cleanup)
- [x] All 29 tests pass across all suites

Closes #132