### PR TITLE
feat(notifications): send push notification on MatchRequestDeclined

### DIFF
--- a/.wolf/anatomy.md
+++ b/.wolf/anatomy.md
@@ -1,19 +1,22 @@
 # anatomy.md
 
-> Auto-maintained by OpenWolf. Last scanned: 2026-04-13T14:12:00.087Z
-> Files: 227 tracked | Anatomy hits: 0 | Misses: 0
+> Auto-maintained by OpenWolf. Last scanned: 2026-04-13T15:09:45.744Z
+> Files: 231 tracked | Anatomy hits: 0 | Misses: 0
 
 ## ../../../../tmp/
 
 - `pr-body-123.md` — Summary (~363 tok)
 - `pr-body-127.md` — Summary (~394 tok)
+- `pr-body-134.md` — Summary (~339 tok)
 - `task-123-body.md` — 🛠 Task: Prevent duplicate match requests to the same candidate (~1174 tok)
 - `task-123-verify.md` — 🛠 Task: Prevent duplicate match requests to the same candidate (~1198 tok)
 - `task-127-body.md` — 🛠 Task: Allow receiver to open requester's profile before deciding (~1158 tok)
 - `task-130-body.md` — 🛠 Task: Send push notification when MatchRequestSent fires (~1242 tok)
+- `task-134-body.md` — 🛠 Task: Send push notification to requester when MatchRequestAccepted fires (~1132 tok)
 - `updated-task-131.md` — 🛠 Task: Include requester name and language summary in notification payload (~998 tok)
 - `updated-task-body-test-mapping.md` — 🛠 Task: Allow receiver to open requester's profile before deciding (~1185 tok)
 - `updated-task-body.md` — 🛠 Task: Allow receiver to open requester's profile before deciding (~1169 tok)
+- `verify-134-body.md` — 🛠 Task: Send push notification to requester when MatchRequestAccepted fires (~1146 tok)
 
 ## ../../.claude/projects/-Users-sander-personal-sip-and-speak/memory/
 
@@ -363,7 +366,11 @@
 ## apps/server/src/
 
 - `index.ts` — Wire domain event → push notification handlers on server start (~768 tok)
-- `notifications.ts` — Push notification service — Expo Push Notifications (~1189 tok)
+- `notifications.ts` — Push notification service — Expo Push Notifications (~1810 tok)
+
+## apps/server/src/__tests__/
+
+- `notifications-match-accepted.test.ts` — Tests for task #134 — Push notification on MatchRequestAccepted (~1303 tok)
 
 ## apps/web/
 

--- a/.wolf/buglog.json
+++ b/.wolf/buglog.json
@@ -1186,6 +1186,38 @@
       "related_bugs": [],
       "occurrences": 1,
       "last_seen": "2026-04-13T14:03:13.736Z"
+    },
+    {
+      "id": "bug-074",
+      "timestamp": "2026-04-13T14:49:18.812Z",
+      "error_message": "Missing error handling in function",
+      "file": "apps/server/src/notifications.ts",
+      "root_cause": "Code path had no error handling — exceptions would propagate uncaught",
+      "fix": "Added try/catch block",
+      "tags": [
+        "auto-detected",
+        "error-handling",
+        "ts"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-04-13T14:49:18.812Z"
+    },
+    {
+      "id": "bug-075",
+      "timestamp": "2026-04-13T14:56:20.317Z",
+      "error_message": "Significant refactor of ",
+      "file": "../../../../tmp/task-134-body.md",
+      "root_cause": "2 lines replaced/restructured",
+      "fix": "Rewrote 5→5 lines (2 removed) | Also: - Backend: push notification handler — new event h; - Database: `userDeviceToken` table (read)",
+      "tags": [
+        "auto-detected",
+        "refactor",
+        "md"
+      ],
+      "related_bugs": [],
+      "occurrences": 2,
+      "last_seen": "2026-04-13T14:56:26.300Z"
     }
   ]
 }

--- a/.wolf/cron-state.json
+++ b/.wolf/cron-state.json
@@ -1,5 +1,5 @@
 {
-  "last_heartbeat": "2026-04-13T13:59:07.963Z",
+  "last_heartbeat": "2026-04-13T14:59:08.009Z",
   "engine_status": "running",
   "execution_log": [
     {

--- a/.wolf/hooks/_session.json
+++ b/.wolf/hooks/_session.json
@@ -1,12 +1,95 @@
 {
   "session_id": "session-2026-04-13-1612",
   "started": "2026-04-13T14:12:15.486Z",
-  "files_read": {},
-  "files_written": [],
-  "edit_counts": {},
-  "anatomy_hits": 0,
-  "anatomy_misses": 0,
-  "repeated_reads_warned": 0,
+  "files_read": {
+    "/tmp/task-134-body.md": {
+      "count": 3,
+      "tokens": 0,
+      "first_read": "2026-04-13T14:47:07.716Z"
+    },
+    "/Users/sander/personal/sip-and-speak/apps/server/src/__tests__/notifications-match-accepted.test.ts": {
+      "count": 1,
+      "tokens": 1445,
+      "first_read": "2026-04-13T14:49:44.094Z"
+    },
+    "/tmp/verify-134-body.md": {
+      "count": 1,
+      "tokens": 0,
+      "first_read": "2026-04-13T15:08:28.712Z"
+    }
+  },
+  "files_written": [
+    {
+      "file": "/Users/sander/personal/sip-and-speak/apps/server/src/__tests__/notifications-match-accepted.test.ts",
+      "action": "create",
+      "tokens": 1445,
+      "at": "2026-04-13T14:48:53.451Z"
+    },
+    {
+      "file": "/Users/sander/personal/sip-and-speak/apps/server/src/notifications.ts",
+      "action": "edit",
+      "tokens": 63,
+      "at": "2026-04-13T14:49:06.602Z"
+    },
+    {
+      "file": "/Users/sander/personal/sip-and-speak/apps/server/src/notifications.ts",
+      "action": "edit",
+      "tokens": 678,
+      "at": "2026-04-13T14:49:18.811Z"
+    },
+    {
+      "file": "/Users/sander/personal/sip-and-speak/apps/server/src/__tests__/notifications-match-accepted.test.ts",
+      "action": "create",
+      "tokens": 1303,
+      "at": "2026-04-13T14:49:57.092Z"
+    },
+    {
+      "file": "/tmp/task-134-body.md",
+      "action": "edit",
+      "tokens": 164,
+      "at": "2026-04-13T14:56:20.316Z"
+    },
+    {
+      "file": "/tmp/task-134-body.md",
+      "action": "edit",
+      "tokens": 109,
+      "at": "2026-04-13T14:56:26.299Z"
+    },
+    {
+      "file": "/tmp/task-134-body.md",
+      "action": "edit",
+      "tokens": 69,
+      "at": "2026-04-13T14:56:30.016Z"
+    },
+    {
+      "file": "/tmp/verify-134-body.md",
+      "action": "edit",
+      "tokens": 61,
+      "at": "2026-04-13T15:08:34.255Z"
+    },
+    {
+      "file": "/tmp/verify-134-body.md",
+      "action": "edit",
+      "tokens": 114,
+      "at": "2026-04-13T15:08:39.915Z"
+    },
+    {
+      "file": "/tmp/pr-body-134.md",
+      "action": "create",
+      "tokens": 388,
+      "at": "2026-04-13T15:09:45.751Z"
+    }
+  ],
+  "edit_counts": {
+    "apps/server/src/__tests__/notifications-match-accepted.test.ts": 2,
+    "apps/server/src/notifications.ts": 2,
+    "../../../../tmp/task-134-body.md": 3,
+    "../../../../tmp/verify-134-body.md": 2,
+    "../../../../tmp/pr-body-134.md": 1
+  },
+  "anatomy_hits": 1,
+  "anatomy_misses": 2,
+  "repeated_reads_warned": 2,
   "cerebrum_warnings": 0,
   "stop_count": 0
 }

--- a/.wolf/memory.md
+++ b/.wolf/memory.md
@@ -417,3 +417,13 @@
 
 | Time | Action | File(s) | Outcome | ~Tokens |
 |------|--------|---------|---------|--------|
+| 16:48 | Created apps/server/src/__tests__/notifications-match-accepted.test.ts | — | ~1445 |
+| 16:49 | Edited apps/server/src/notifications.ts | 2→2 lines | ~63 |
+| 16:49 | Edited apps/server/src/notifications.ts | added error handling | ~678 |
+| 16:49 | Created apps/server/src/__tests__/notifications-match-accepted.test.ts | — | ~1303 |
+| 16:56 | Edited ../../../../tmp/task-134-body.md | 5→5 lines | ~154 |
+| 16:56 | Edited ../../../../tmp/task-134-body.md | 7→7 lines | ~102 |
+| 16:56 | Edited ../../../../tmp/task-134-body.md | 2→2 lines | ~65 |
+| 17:08 | Edited ../../../../tmp/verify-134-body.md | 7→7 lines | ~57 |
+| 17:08 | Edited ../../../../tmp/verify-134-body.md | 6→9 lines | ~107 |
+| 17:09 | Created ../../../../tmp/pr-body-134.md | — | ~362 |

--- a/apps/server/src/__tests__/notifications-match-declined.test.ts
+++ b/apps/server/src/__tests__/notifications-match-declined.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Tests for task #135 — Push notification on MatchRequestDeclined
+ *
+ * Covers:
+ *   - Notification sent to requester when their match request is declined
+ *   - Notification body does not identify the declining receiver
+ *   - No notification sent when requester has no registered device token
+ */
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+// ── Fetch mock ────────────────────────────────────────────────────────────────
+
+interface CapturedFetchCall {
+  url: string;
+  messages: Array<{ to: string; title?: string; body?: string; data?: Record<string, unknown> }>;
+}
+
+const fetchCalls: CapturedFetchCall[] = [];
+
+(global as unknown as { fetch: unknown }).fetch = mock(async (url: string, options: RequestInit) => {
+  fetchCalls.push({
+    url,
+    messages: JSON.parse(options.body as string) as CapturedFetchCall["messages"],
+  });
+  return {
+    json: async () => ({ data: [{ status: "ok", id: "ticket-1" }] }),
+  };
+});
+
+// ── Schema mocks ──────────────────────────────────────────────────────────────
+
+const DEVICE_TOKEN_TABLE = "userDeviceToken";
+
+mock.module("@sip-and-speak/db/schema/sip-and-speak", () => ({
+  userDeviceToken: DEVICE_TOKEN_TABLE,
+  userLanguage: "userLanguage",
+}));
+
+mock.module("@sip-and-speak/db/schema/auth", () => ({
+  user: "user",
+}));
+
+// ── drizzle-orm mock ──────────────────────────────────────────────────────────
+
+mock.module("drizzle-orm", () => ({
+  eq: (_col: unknown, val: unknown) => ({ _val: val }),
+}));
+
+// ── DB mock ───────────────────────────────────────────────────────────────────
+
+let mockTokenRows: Array<{ id: string; token: string }> = [];
+
+mock.module("@sip-and-speak/db", () => ({
+  db: {
+    select: (_fields: Record<string, unknown>) => ({
+      from: (_table: unknown) => ({
+        where: (_cond: unknown) => ({
+          limit: (_n: number) => Promise.resolve(mockTokenRows),
+          then: (
+            resolve: (v: unknown) => unknown,
+            reject?: (e: unknown) => unknown,
+          ) => Promise.resolve(mockTokenRows).then(resolve, reject),
+        }),
+      }),
+    }),
+    delete: (_table: unknown) => ({
+      where: (_cond: unknown) => Promise.resolve(),
+    }),
+  },
+}));
+
+// ── Domain events mock ────────────────────────────────────────────────────────
+
+mock.module("@sip-and-speak/api/domain-events", () => ({
+  domainEvents: { on: mock((_evt: string, _fn: unknown) => undefined), emit: mock(() => undefined) },
+}));
+
+// ── Import under test (after mocks) ──────────────────────────────────────────
+
+// eslint-disable-next-line import/first
+import { handleMatchRequestDeclined } from "../notifications";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeDeclinedEvent(
+  overrides: Partial<{ requesterId: string; receiverId: string; matchRequestId: string }> = {},
+) {
+  return {
+    matchRequestId: overrides.matchRequestId ?? "req-456",
+    requesterId: overrides.requesterId ?? "requester-id",
+    receiverId: overrides.receiverId ?? "receiver-id",
+    declinedAt: new Date(),
+  };
+}
+
+beforeEach(() => {
+  fetchCalls.length = 0;
+  mockTokenRows = [];
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("#135 — Push notification on MatchRequestDeclined", () => {
+  it("sends a push notification to the requester when their request is declined", async () => {
+    mockTokenRows = [{ id: "tok-2", token: "ExponentPushToken[def]" }];
+
+    await handleMatchRequestDeclined(makeDeclinedEvent());
+
+    expect(fetchCalls).toHaveLength(1);
+
+    const call = fetchCalls[0];
+    if (!call) throw new Error("Expected a fetch call");
+
+    expect(call.url).toBe("https://exp.host/--/api/v2/push/send");
+    expect(call.messages).toHaveLength(1);
+
+    const msg = call.messages[0];
+    if (!msg) throw new Error("Expected a message");
+
+    expect(msg.to).toBe("ExponentPushToken[def]");
+    expect(msg.title).toBe("Your match request was not accepted");
+    expect(msg.data?.type).toBe("match_declined");
+    expect(msg.data?.matchRequestId).toBe("req-456");
+  });
+
+  it("does not include the receiver's name in the notification body", async () => {
+    mockTokenRows = [{ id: "tok-2", token: "ExponentPushToken[def]" }];
+
+    await handleMatchRequestDeclined(makeDeclinedEvent({ receiverId: "receiver-xyz" }));
+
+    const msg = fetchCalls[0]?.messages[0];
+    if (!msg) throw new Error("Expected a message");
+
+    // Body must not reference the receiver identity — privacy invariant
+    expect(msg.body).not.toContain("receiver-xyz");
+    expect(msg.body).toBeTruthy();
+  });
+
+  it("does not send a push notification when the requester has no registered device token", async () => {
+    mockTokenRows = [];
+
+    await handleMatchRequestDeclined(makeDeclinedEvent());
+
+    expect(fetchCalls).toHaveLength(0);
+  });
+});

--- a/apps/server/src/notifications.ts
+++ b/apps/server/src/notifications.ts
@@ -8,7 +8,7 @@ import { eq } from "drizzle-orm";
 import { db } from "@sip-and-speak/db";
 import { userDeviceToken, userLanguage } from "@sip-and-speak/db/schema/sip-and-speak";
 import { user } from "@sip-and-speak/db/schema/auth";
-import { domainEvents, type MatchRequestSentEvent, type MatchRequestAcceptedEvent } from "@sip-and-speak/api/domain-events";
+import { domainEvents, type MatchRequestSentEvent, type MatchRequestAcceptedEvent, type MatchRequestDeclinedEvent } from "@sip-and-speak/api/domain-events";
 import { buildMatchRequestNotificationBody } from "@sip-and-speak/api/routers/matching-utils";
 
 const EXPO_PUSH_URL = "https://exp.host/--/api/v2/push/send";
@@ -179,6 +179,62 @@ export async function handleMatchRequestAccepted(event: MatchRequestAcceptedEven
   }
 }
 
+export async function handleMatchRequestDeclined(event: MatchRequestDeclinedEvent): Promise<void> {
+  const { matchRequestId, requesterId } = event;
+
+  const tokens = await db
+    .select({ id: userDeviceToken.id, token: userDeviceToken.token })
+    .from(userDeviceToken)
+    .where(eq(userDeviceToken.userId, requesterId));
+
+  if (tokens.length === 0) {
+    console.info("[push] No device token for requester — skipping", { matchRequestId, requesterId });
+    return;
+  }
+
+  const messages: ExpoPushMessage[] = tokens.map(({ token }) => ({
+    to: token,
+    title: "Your match request was not accepted",
+    body: "Keep exploring — there are more compatible Students waiting",
+    data: { matchRequestId, type: "match_declined" },
+  }));
+
+  console.info("[push] Sending MatchRequestDeclined notification", {
+    matchRequestId,
+    requesterId,
+    tokenCount: messages.length,
+  });
+
+  try {
+    const tickets = await sendExpoPushNotification(messages);
+
+    const staleTokenIds: string[] = [];
+    for (let i = 0; i < tickets.length; i++) {
+      const ticket = tickets[i];
+      if (ticket?.status === "error" && ticket.details?.error === "DeviceNotRegistered") {
+        const staleId = tokens[i]?.id;
+        if (staleId) staleTokenIds.push(staleId);
+      }
+    }
+
+    if (staleTokenIds.length > 0) {
+      await Promise.all(
+        staleTokenIds.map((id) =>
+          db.delete(userDeviceToken).where(eq(userDeviceToken.id, id)),
+        ),
+      );
+      console.info("[push] Removed stale device tokens", { staleTokenIds });
+    }
+
+    console.info("[push] MatchRequestDeclined notification delivery complete", {
+      matchRequestId,
+      tickets: tickets.map((t) => ({ status: t.status, id: t.id })),
+    });
+  } catch (err) {
+    console.error("[push] Failed to send MatchRequestDeclined notification", { matchRequestId, err });
+  }
+}
+
 export function registerNotificationHandlers(): void {
   domainEvents.on("MatchRequestSent", (event) => {
     // Fire and forget — do not await, must not block the mutation response
@@ -186,5 +242,8 @@ export function registerNotificationHandlers(): void {
   });
   domainEvents.on("MatchRequestAccepted", (event) => {
     void handleMatchRequestAccepted(event);
+  });
+  domainEvents.on("MatchRequestDeclined", (event) => {
+    void handleMatchRequestDeclined(event);
   });
 }


### PR DESCRIPTION
## Summary

When a student's match request is declined, they receive no feedback — leaving them wondering whether to wait or move on. This task wires `MatchRequestDeclined` to Expo Push so the requester is notified immediately and redirected back to exploring.

Privacy invariant: the notification body deliberately omits the receiver's identity — decline outcomes are private. The copy is encouraging ("Keep exploring…") rather than blunt.

Part of Feature #17: Receive match request outcome notification.

## Changes

- **New push handler** — `handleMatchRequestDeclined` in `apps/server/src/notifications.ts`: looks up the requester's device tokens, sends Expo Push with `data.type = "match_declined"` and neutral body copy that does not name the declining receiver
- **Event wiring** — `registerNotificationHandlers` now subscribes to `MatchRequestDeclined` (fire-and-forget)
- **Tests** — Bun test suite at `apps/server/src/__tests__/notifications-match-declined.test.ts` covering all 3 scenarios including the privacy invariant

## Test plan

- [x] Requester receives a push notification when their request is declined (device token present)
- [x] Notification body does not contain the receiver's identity (privacy invariant)
- [x] No notification sent when requester has no registered device token

## Related

Closes #135
