### PR TITLE
feat(notifications): add Connect Now CTA to acceptance notification

### DIFF
--- a/apps/native/__tests__/notification-match-accepted.test.tsx
+++ b/apps/native/__tests__/notification-match-accepted.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * Tests for task #136 — "Connect Now" CTA in acceptance notification
+ *
+ * Covers:
+ *   - Tapping the acceptance notification navigates to the scheduling flow
+ *   - "Connect Now" action tap also navigates to the scheduling flow
+ *   - Existing match-request-sent notification tap behaviour is not regressed
+ */
+import { act, renderHook } from "@testing-library/react-native";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const mockPush = jest.fn();
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+let tapListener: ((response: unknown) => void) | null = null;
+const mockRemove = jest.fn();
+const mockGetLastNotificationResponseAsync = jest.fn();
+const mockSetNotificationCategoryAsync = jest.fn();
+
+jest.mock("expo-notifications", () => ({
+  addNotificationResponseReceivedListener: jest.fn((cb) => {
+    tapListener = cb;
+    return { remove: mockRemove };
+  }),
+  getLastNotificationResponseAsync: (...args: unknown[]) =>
+    mockGetLastNotificationResponseAsync(...args),
+  setNotificationCategoryAsync: (...args: unknown[]) =>
+    mockSetNotificationCategoryAsync(...args),
+}));
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function makeNotificationResponse(data: Record<string, unknown>) {
+  return {
+    notification: {
+      request: {
+        content: { data },
+      },
+    },
+  };
+}
+
+// ── Import after mocks ─────────────────────────────────────────────────────────
+// eslint-disable-next-line import/first
+import { useNotificationTapHandler } from "../hooks/use-notification-tap-handler";
+
+beforeEach(() => {
+  tapListener = null;
+  mockPush.mockClear();
+  mockRemove.mockClear();
+  mockGetLastNotificationResponseAsync.mockResolvedValue(null);
+  mockSetNotificationCategoryAsync.mockResolvedValue(undefined);
+});
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("#136 — Connect Now CTA in acceptance notification", () => {
+  it("tapping the acceptance notification navigates to the scheduling flow", async () => {
+    renderHook(() => useNotificationTapHandler());
+
+    await act(async () => {
+      tapListener?.(
+        makeNotificationResponse({
+          type: "match_accepted",
+          matchedWithUserId: "partner-abc",
+          matchRequestId: "req-123",
+        }),
+      );
+    });
+
+    expect(mockPush).toHaveBeenCalledWith("/schedule/partner-abc");
+  });
+
+  it("tapping Connect Now action navigates to the scheduling flow (same listener path)", async () => {
+    // iOS action buttons trigger the same addNotificationResponseReceivedListener
+    // with the action identifier in the response — the navigation logic is identical
+    renderHook(() => useNotificationTapHandler());
+
+    await act(async () => {
+      tapListener?.(
+        makeNotificationResponse({
+          type: "match_accepted",
+          matchedWithUserId: "partner-xyz",
+          matchRequestId: "req-456",
+        }),
+      );
+    });
+
+    expect(mockPush).toHaveBeenCalledWith("/schedule/partner-xyz");
+  });
+
+  it("does not navigate when matchedWithUserId is missing from acceptance notification", async () => {
+    renderHook(() => useNotificationTapHandler());
+
+    await act(async () => {
+      tapListener?.(makeNotificationResponse({ type: "match_accepted" }));
+    });
+
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("existing match-request-sent notification still navigates to partner profile", async () => {
+    renderHook(() => useNotificationTapHandler());
+
+    await act(async () => {
+      tapListener?.(
+        makeNotificationResponse({ matchRequestId: "req-old", requesterId: "user-old" }),
+      );
+    });
+
+    expect(mockPush).toHaveBeenCalledWith("/partner/user-old?matchRequestId=req-old");
+  });
+});

--- a/apps/native/app/_layout.tsx
+++ b/apps/native/app/_layout.tsx
@@ -35,6 +35,14 @@ export const unstable_settings = {
   initialRouteName: "(drawer)",
 };
 
+function useNotificationCategories() {
+  useEffect(() => {
+    void Notifications.setNotificationCategoryAsync("match_accepted", [
+      { identifier: "connect_now", buttonTitle: "Connect Now" },
+    ]);
+  }, []);
+}
+
 function useDeviceTokenRegistration(isLoggedIn: boolean) {
   const registerToken = useMutation(trpc.profile.registerDeviceToken.mutationOptions());
 
@@ -60,6 +68,7 @@ function AuthGuard() {
   const router = useRouter();
   const segments = useSegments();
 
+  useNotificationCategories();
   useDeviceTokenRegistration(!!session);
   useNotificationTapHandler();
 

--- a/apps/native/hooks/use-notification-tap-handler.ts
+++ b/apps/native/hooks/use-notification-tap-handler.ts
@@ -7,6 +7,14 @@ export function useNotificationTapHandler() {
 
   function handleNotificationResponse(response: Notifications.NotificationResponse) {
     const data = response.notification.request.content.data as Record<string, unknown> | undefined;
+    const type = typeof data?.type === "string" ? data.type : undefined;
+
+    if (type === "match_accepted") {
+      const matchedWithUserId = typeof data?.matchedWithUserId === "string" ? data.matchedWithUserId : undefined;
+      if (matchedWithUserId) router.push(`/schedule/${matchedWithUserId}`);
+      return;
+    }
+
     const matchRequestId = typeof data?.matchRequestId === "string" ? data.matchRequestId : undefined;
     const requesterId = typeof data?.requesterId === "string" ? data.requesterId : undefined;
 

--- a/apps/server/src/notifications.ts
+++ b/apps/server/src/notifications.ts
@@ -18,6 +18,7 @@ interface ExpoPushMessage {
   title?: string;
   body?: string;
   data?: Record<string, unknown>;
+  categoryIdentifier?: string;
 }
 
 interface ExpoPushTicket {
@@ -140,7 +141,8 @@ export async function handleMatchRequestAccepted(event: MatchRequestAcceptedEven
     to: token,
     title: "Your match request was accepted!",
     body: `${receiverName} accepted your request`,
-    data: { matchRequestId, type: "match_accepted" },
+    data: { matchRequestId, matchedWithUserId: receiverId, type: "match_accepted" },
+    categoryIdentifier: "match_accepted",
   }));
 
   console.info("[push] Sending MatchRequestAccepted notification", {


### PR DESCRIPTION
## Summary

After a match request is accepted, the requester gets a push notification but has no direct path to schedule their meetup — they have to find their way there manually. This task adds a "Connect Now" action button to the acceptance notification and wires the tap handler to navigate directly to the scheduling screen.

The notification category `match_accepted` is registered on app init so iOS shows the action button. Both a direct notification tap and the action button trigger the same `addNotificationResponseReceivedListener` path, routing to `/schedule/{matchedWithUserId}`.

Part of Feature #17: Receive match request outcome notification.

## Changes

- **Backend payload extended** — `handleMatchRequestAccepted` now includes `matchedWithUserId` (= receiverId) and `categoryIdentifier: "match_accepted"` in the Expo Push message
- **Notification category registered** — `useNotificationCategories` hook added to `apps/native/app/_layout.tsx`, calls `setNotificationCategoryAsync` on mount to register the "Connect Now" action button
- **Tap handler extended** — `apps/native/hooks/use-notification-tap-handler.ts` now checks `data.type === "match_accepted"` first and navigates to `/schedule/${matchedWithUserId}`; existing match-request-sent routing unchanged

## Test plan

- [x] Tapping the acceptance notification navigates to the scheduling flow (`/schedule/{partnerId}`)
- [x] "Connect Now" action tap navigates to the scheduling flow
- [x] Missing `matchedWithUserId` in payload → no navigation (graceful fallback)
- [x] Existing match-request-sent notification tap still navigates to partner profile (no regression)

## Related

Closes #136
