### PR TITLE
feat(notifications): deep-link decline notification to suggestion list

### DIFF
--- a/apps/native/__tests__/notification-match-declined.test.tsx
+++ b/apps/native/__tests__/notification-match-declined.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * Tests for task #137 — Suggestion list deep-link in decline notification
+ *
+ * Covers:
+ *   - Tapping the decline notification navigates to the suggestion list screen
+ *   - Decline notification tap on cold-start navigates to suggestion list
+ *   - Existing notification types are not affected (no regression)
+ */
+import { act, renderHook } from "@testing-library/react-native";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const mockPush = jest.fn();
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+let tapListener: ((response: unknown) => void) | null = null;
+const mockRemove = jest.fn();
+const mockGetLastNotificationResponseAsync = jest.fn();
+
+jest.mock("expo-notifications", () => ({
+  addNotificationResponseReceivedListener: jest.fn((cb) => {
+    tapListener = cb;
+    return { remove: mockRemove };
+  }),
+  getLastNotificationResponseAsync: (...args: unknown[]) =>
+    mockGetLastNotificationResponseAsync(...args),
+}));
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function makeNotificationResponse(data: Record<string, unknown>) {
+  return {
+    notification: {
+      request: {
+        content: { data },
+      },
+    },
+  };
+}
+
+// ── Import after mocks ─────────────────────────────────────────────────────────
+// eslint-disable-next-line import/first
+import { useNotificationTapHandler } from "../hooks/use-notification-tap-handler";
+
+beforeEach(() => {
+  tapListener = null;
+  mockPush.mockClear();
+  mockRemove.mockClear();
+  mockGetLastNotificationResponseAsync.mockResolvedValue(null);
+});
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("#137 — Suggestion list deep-link in decline notification", () => {
+  it("tapping the decline notification navigates to the suggestion list screen", async () => {
+    renderHook(() => useNotificationTapHandler());
+
+    await act(async () => {
+      tapListener?.(
+        makeNotificationResponse({
+          type: "match_declined",
+          matchRequestId: "req-789",
+        }),
+      );
+    });
+
+    expect(mockPush).toHaveBeenCalledWith("/suggestions");
+  });
+
+  it("cold-start tap on decline notification navigates to suggestion list", async () => {
+    mockGetLastNotificationResponseAsync.mockResolvedValue(
+      makeNotificationResponse({ type: "match_declined", matchRequestId: "req-cold" }),
+    );
+
+    renderHook(() => useNotificationTapHandler());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockPush).toHaveBeenCalledWith("/suggestions");
+  });
+
+  it("acceptance notification tap still navigates to scheduling screen (no regression)", async () => {
+    renderHook(() => useNotificationTapHandler());
+
+    await act(async () => {
+      tapListener?.(
+        makeNotificationResponse({ type: "match_accepted", matchedWithUserId: "partner-abc" }),
+      );
+    });
+
+    expect(mockPush).toHaveBeenCalledWith("/schedule/partner-abc");
+  });
+});

--- a/apps/native/hooks/use-notification-tap-handler.ts
+++ b/apps/native/hooks/use-notification-tap-handler.ts
@@ -15,6 +15,11 @@ export function useNotificationTapHandler() {
       return;
     }
 
+    if (type === "match_declined") {
+      router.push("/suggestions");
+      return;
+    }
+
     const matchRequestId = typeof data?.matchRequestId === "string" ? data.matchRequestId : undefined;
     const requesterId = typeof data?.requesterId === "string" ? data.requesterId : undefined;
 


### PR DESCRIPTION
## Summary

After a decline, the requester has no obvious next step — they need to go back to browsing manually. This task wires the decline notification tap directly to the suggestion list, making the recovery path frictionless.

The `match_declined` type was already included in the T17.2 payload. This task adds only the frontend routing: `type === "match_declined"` → `/suggestions`. TanStack Query's standard refetch-on-mount behaviour ensures fresh candidates are shown.

Part of Feature #17: Receive match request outcome notification.

## Changes

- **Tap handler extended** — `apps/native/hooks/use-notification-tap-handler.ts` routes `type === "match_declined"` to `/suggestions`; no backend changes required

## Test plan

- [x] Tapping decline notification navigates to `/suggestions`
- [x] Cold-start decline notification tap also navigates to `/suggestions`
- [x] Acceptance notification tap still navigates to `/schedule/{partnerId}` (no regression)

## Related

Closes #137
