### PR TITLE
feat(epic3): Admin can manage the on-campus location catalog (#19)

### DIFF
--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as LoginRouteImport } from './routes/login'
 import { Route as DashboardRouteImport } from './routes/dashboard'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as PartnerIdRouteImport } from './routes/partner/$id'
+import { Route as AdminLocationsRouteImport } from './routes/admin/locations'
 
 const SuggestionsRoute = SuggestionsRouteImport.update({
   id: '/suggestions',
@@ -46,6 +47,11 @@ const PartnerIdRoute = PartnerIdRouteImport.update({
   path: '/partner/$id',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AdminLocationsRoute = AdminLocationsRouteImport.update({
+  id: '/admin/locations',
+  path: '/admin/locations',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -54,6 +60,7 @@ export interface FileRoutesByFullPath {
   '/success': typeof SuccessRoute
   '/suggestions': typeof SuggestionsRoute
   '/partner/$id': typeof PartnerIdRoute
+  '/admin/locations': typeof AdminLocationsRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -62,6 +69,7 @@ export interface FileRoutesByTo {
   '/success': typeof SuccessRoute
   '/suggestions': typeof SuggestionsRoute
   '/partner/$id': typeof PartnerIdRoute
+  '/admin/locations': typeof AdminLocationsRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -71,6 +79,7 @@ export interface FileRoutesById {
   '/success': typeof SuccessRoute
   '/suggestions': typeof SuggestionsRoute
   '/partner/$id': typeof PartnerIdRoute
+  '/admin/locations': typeof AdminLocationsRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -81,6 +90,7 @@ export interface FileRouteTypes {
     | '/success'
     | '/suggestions'
     | '/partner/$id'
+    | '/admin/locations'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -89,6 +99,7 @@ export interface FileRouteTypes {
     | '/success'
     | '/suggestions'
     | '/partner/$id'
+    | '/admin/locations'
   id:
     | '__root__'
     | '/'
@@ -97,6 +108,7 @@ export interface FileRouteTypes {
     | '/success'
     | '/suggestions'
     | '/partner/$id'
+    | '/admin/locations'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -106,6 +118,7 @@ export interface RootRouteChildren {
   SuccessRoute: typeof SuccessRoute
   SuggestionsRoute: typeof SuggestionsRoute
   PartnerIdRoute: typeof PartnerIdRoute
+  AdminLocationsRoute: typeof AdminLocationsRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -152,6 +165,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof PartnerIdRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/admin/locations': {
+      id: '/admin/locations'
+      path: '/admin/locations'
+      fullPath: '/admin/locations'
+      preLoaderRoute: typeof AdminLocationsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -162,6 +182,7 @@ const rootRouteChildren: RootRouteChildren = {
   SuccessRoute: SuccessRoute,
   SuggestionsRoute: SuggestionsRoute,
   PartnerIdRoute: PartnerIdRoute,
+  AdminLocationsRoute: AdminLocationsRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/web/src/routes/admin/locations.tsx
+++ b/apps/web/src/routes/admin/locations.tsx
@@ -1,0 +1,265 @@
+import { Button } from "@sip-and-speak/ui/components/button";
+import { Input } from "@sip-and-speak/ui/components/input";
+import { Label } from "@sip-and-speak/ui/components/label";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { useState } from "react";
+import { toast } from "sonner";
+
+import { authClient } from "@/lib/auth-client";
+import { trpc } from "@/utils/trpc";
+
+export const Route = createFileRoute("/admin/locations")({
+  component: RouteComponent,
+  beforeLoad: async () => {
+    const session = await authClient.getSession();
+    if (!session.data) {
+      redirect({ to: "/login", throw: true });
+    }
+    return { session };
+  },
+});
+
+type Venue = {
+  id: string;
+  name: string;
+  description: string | null;
+  isActive: boolean;
+};
+
+type FormMode = { type: "add" } | { type: "edit"; venue: Venue } | null;
+
+function LocationForm({
+  mode,
+  onClose,
+}: {
+  mode: FormMode;
+  onClose: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const initialVenue = mode?.type === "edit" ? mode.venue : null;
+
+  const [name, setName] = useState(initialVenue?.name ?? "");
+  const [description, setDescription] = useState(
+    initialVenue?.description ?? "",
+  );
+  const [nameError, setNameError] = useState<string | null>(null);
+
+  const invalidate = () =>
+    queryClient.invalidateQueries(trpc.adminVenue.findAll.queryOptions());
+
+  const createMutation = useMutation(
+    trpc.adminVenue.create.mutationOptions({
+      onSuccess: () => {
+        toast.success("Location added");
+        invalidate();
+        onClose();
+      },
+      onError: (err) => {
+        if (err.message.includes("already exists")) {
+          setNameError("A location with this name already exists");
+        } else {
+          toast.error(err.message);
+        }
+      },
+    }),
+  );
+
+  const updateMutation = useMutation(
+    trpc.adminVenue.update.mutationOptions({
+      onSuccess: () => {
+        toast.success("Location updated");
+        invalidate();
+        onClose();
+      },
+      onError: (err) => {
+        if (err.message.includes("already exists")) {
+          setNameError("A location with this name already exists");
+        } else {
+          toast.error(err.message);
+        }
+      },
+    }),
+  );
+
+  const isPending = createMutation.isPending || updateMutation.isPending;
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setNameError(null);
+
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      setNameError("Name is required");
+      return;
+    }
+
+    if (mode?.type === "edit") {
+      updateMutation.mutate({
+        id: mode.venue.id,
+        name: trimmedName,
+        description: description.trim() || null,
+      });
+    } else {
+      createMutation.mutate({
+        name: trimmedName,
+        description: description.trim() || undefined,
+        latitude: 51.4483, // TU/e campus default
+        longitude: 5.4903,
+      });
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-card border border-border rounded-2xl p-6 w-full max-w-md shadow-xl">
+        <h2 className="text-foreground text-xl font-semibold mb-4">
+          {mode?.type === "edit" ? "Edit location" : "Add location"}
+        </h2>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1">
+            <Label htmlFor="loc-name">Name</Label>
+            <Input
+              id="loc-name"
+              data-testid="location-name-input"
+              value={name}
+              onChange={(e) => {
+                setName(e.target.value);
+                setNameError(null);
+              }}
+              placeholder="e.g. Metaforum Cantine"
+              disabled={isPending}
+            />
+            {nameError && (
+              <p
+                data-testid="location-name-error"
+                className="text-destructive text-sm"
+              >
+                {nameError}
+              </p>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <Label htmlFor="loc-desc">Description (optional)</Label>
+            <Input
+              id="loc-desc"
+              data-testid="location-description-input"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Short description of the location"
+              disabled={isPending}
+            />
+          </div>
+
+          <div className="flex gap-2 justify-end mt-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onClose}
+              disabled={isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              data-testid="location-submit-btn"
+              disabled={isPending}
+            >
+              {mode?.type === "edit" ? "Save changes" : "Add location"}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+function RouteComponent() {
+  const [formMode, setFormMode] = useState<FormMode>(null);
+  const venuesQuery = useQuery(trpc.adminVenue.findAll.queryOptions());
+  const venues = venuesQuery.data ?? [];
+
+  return (
+    <div className="p-6 max-w-3xl mx-auto">
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-foreground text-2xl font-bold">
+          Location catalog
+        </h1>
+        <Button
+          data-testid="add-location-btn"
+          onClick={() => setFormMode({ type: "add" })}
+        >
+          Add location
+        </Button>
+      </div>
+
+      {venuesQuery.isPending ? (
+        <div className="flex items-center justify-center py-16">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
+        </div>
+      ) : venues.length === 0 ? (
+        <p
+          data-testid="empty-locations"
+          className="text-muted-foreground text-center py-16"
+        >
+          No locations yet. Add the first one.
+        </p>
+      ) : (
+        <div
+          data-testid="locations-list"
+          className="flex flex-col gap-3"
+        >
+          {venues.map((v) => (
+            <div
+              key={v.id}
+              data-testid="location-row"
+              className="flex items-start justify-between gap-4 bg-card border border-border rounded-2xl p-4"
+            >
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2 mb-1">
+                  <span
+                    data-testid="location-name"
+                    className="text-foreground font-semibold truncate"
+                  >
+                    {v.name}
+                  </span>
+                  <span
+                    data-testid="location-status"
+                    className={`text-xs px-2 py-0.5 rounded-full ${
+                      v.isActive
+                        ? "bg-green-500/10 text-green-600"
+                        : "bg-muted text-muted-foreground"
+                    }`}
+                  >
+                    {v.isActive ? "Active" : "Inactive"}
+                  </span>
+                </div>
+                {v.description && (
+                  <p
+                    data-testid="location-description"
+                    className="text-muted-foreground text-sm"
+                  >
+                    {v.description}
+                  </p>
+                )}
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                data-testid="location-edit-btn"
+                onClick={() => setFormMode({ type: "edit", venue: v })}
+              >
+                Edit
+              </Button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {formMode && (
+        <LocationForm mode={formMode} onClose={() => setFormMode(null)} />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/routes/admin/locations.tsx
+++ b/apps/web/src/routes/admin/locations.tsx
@@ -29,6 +29,12 @@ type Venue = {
 
 type FormMode = { type: "add" } | { type: "edit"; venue: Venue } | null;
 
+function useVenueListInvalidation() {
+  const queryClient = useQueryClient();
+  return () =>
+    queryClient.invalidateQueries(trpc.adminVenue.findAll.queryOptions());
+}
+
 function LocationForm({
   mode,
   onClose,
@@ -36,7 +42,7 @@ function LocationForm({
   mode: FormMode;
   onClose: () => void;
 }) {
-  const queryClient = useQueryClient();
+  const invalidate = useVenueListInvalidation();
   const initialVenue = mode?.type === "edit" ? mode.venue : null;
 
   const [name, setName] = useState(initialVenue?.name ?? "");
@@ -44,9 +50,6 @@ function LocationForm({
     initialVenue?.description ?? "",
   );
   const [nameError, setNameError] = useState<string | null>(null);
-
-  const invalidate = () =>
-    queryClient.invalidateQueries(trpc.adminVenue.findAll.queryOptions());
 
   const createMutation = useMutation(
     trpc.adminVenue.create.mutationOptions({
@@ -104,7 +107,7 @@ function LocationForm({
       createMutation.mutate({
         name: trimmedName,
         description: description.trim() || undefined,
-        latitude: 51.4483, // TU/e campus default
+        latitude: 51.4483,
         longitude: 5.4903,
       });
     }
@@ -175,6 +178,186 @@ function LocationForm({
   );
 }
 
+function DeactivateDialog({
+  venue,
+  onClose,
+}: {
+  venue: Venue;
+  onClose: () => void;
+}) {
+  const invalidate = useVenueListInvalidation();
+  const warningsQuery = useQuery(
+    trpc.adminVenue.deactivateWarnings.queryOptions({ id: venue.id }),
+  );
+
+  const deactivateMutation = useMutation(
+    trpc.adminVenue.deactivate.mutationOptions({
+      onSuccess: () => {
+        toast.success(`"${venue.name}" has been deactivated`);
+        invalidate();
+        onClose();
+      },
+      onError: (err) => {
+        toast.error(err.message);
+        onClose();
+      },
+    }),
+  );
+
+  const warnings = warningsQuery.data;
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-card border border-border rounded-2xl p-6 w-full max-w-md shadow-xl">
+        <h2 className="text-foreground text-xl font-semibold mb-2">
+          Deactivate location?
+        </h2>
+        <p className="text-muted-foreground mb-4">
+          "{venue.name}" will be hidden from the meetup proposal picker.
+        </p>
+
+        {warningsQuery.isPending ? (
+          <div className="flex items-center justify-center py-4">
+            <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-primary" />
+          </div>
+        ) : (
+          <>
+            {warnings?.hasPendingProposals && (
+              <div
+                data-testid="pending-proposals-warning"
+                className="bg-amber-500/10 border border-amber-500/20 text-amber-600 text-sm rounded-xl p-3 mb-3"
+              >
+                This location has unconfirmed meetup proposals. They will not be
+                automatically cancelled, but students won't be able to select
+                this location for new proposals.
+              </div>
+            )}
+            {warnings?.isLastActive && (
+              <div
+                data-testid="last-active-warning"
+                className="bg-destructive/10 border border-destructive/20 text-destructive text-sm rounded-xl p-3 mb-3"
+              >
+                This is the last active location. After deactivation, students
+                will be unable to create new meetup proposals.
+              </div>
+            )}
+          </>
+        )}
+
+        <div className="flex gap-2 justify-end mt-4">
+          <Button variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            data-testid="confirm-deactivate-btn"
+            disabled={deactivateMutation.isPending}
+            onClick={() => deactivateMutation.mutate({ id: venue.id })}
+          >
+            Deactivate
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function LocationRow({
+  venue,
+  onEdit,
+}: {
+  venue: Venue;
+  onEdit: (v: Venue) => void;
+}) {
+  const [showDeactivateDialog, setShowDeactivateDialog] = useState(false);
+  const invalidate = useVenueListInvalidation();
+
+  const reactivateMutation = useMutation(
+    trpc.adminVenue.reactivate.mutationOptions({
+      onSuccess: () => {
+        toast.success(`"${venue.name}" has been reactivated`);
+        invalidate();
+      },
+      onError: (err) => toast.error(err.message),
+    }),
+  );
+
+  return (
+    <>
+      <div
+        data-testid="location-row"
+        className="flex items-start justify-between gap-4 bg-card border border-border rounded-2xl p-4"
+      >
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1">
+            <span
+              data-testid="location-name"
+              className="text-foreground font-semibold truncate"
+            >
+              {venue.name}
+            </span>
+            <span
+              data-testid="location-status"
+              className={`text-xs px-2 py-0.5 rounded-full ${
+                venue.isActive
+                  ? "bg-green-500/10 text-green-600"
+                  : "bg-muted text-muted-foreground"
+              }`}
+            >
+              {venue.isActive ? "Active" : "Inactive"}
+            </span>
+          </div>
+          {venue.description && (
+            <p
+              data-testid="location-description"
+              className="text-muted-foreground text-sm"
+            >
+              {venue.description}
+            </p>
+          )}
+        </div>
+        <div className="flex gap-2 shrink-0">
+          <Button
+            variant="outline"
+            size="sm"
+            data-testid="location-edit-btn"
+            onClick={() => onEdit(venue)}
+          >
+            Edit
+          </Button>
+          {venue.isActive ? (
+            <Button
+              variant="outline"
+              size="sm"
+              data-testid="location-deactivate-btn"
+              onClick={() => setShowDeactivateDialog(true)}
+            >
+              Deactivate
+            </Button>
+          ) : (
+            <Button
+              variant="outline"
+              size="sm"
+              data-testid="location-reactivate-btn"
+              disabled={reactivateMutation.isPending}
+              onClick={() => reactivateMutation.mutate({ id: venue.id })}
+            >
+              Reactivate
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {showDeactivateDialog && (
+        <DeactivateDialog
+          venue={venue}
+          onClose={() => setShowDeactivateDialog(false)}
+        />
+      )}
+    </>
+  );
+}
+
 function RouteComponent() {
   const [formMode, setFormMode] = useState<FormMode>(null);
   const venuesQuery = useQuery(trpc.adminVenue.findAll.queryOptions());
@@ -206,53 +389,13 @@ function RouteComponent() {
           No locations yet. Add the first one.
         </p>
       ) : (
-        <div
-          data-testid="locations-list"
-          className="flex flex-col gap-3"
-        >
+        <div data-testid="locations-list" className="flex flex-col gap-3">
           {venues.map((v) => (
-            <div
+            <LocationRow
               key={v.id}
-              data-testid="location-row"
-              className="flex items-start justify-between gap-4 bg-card border border-border rounded-2xl p-4"
-            >
-              <div className="flex-1 min-w-0">
-                <div className="flex items-center gap-2 mb-1">
-                  <span
-                    data-testid="location-name"
-                    className="text-foreground font-semibold truncate"
-                  >
-                    {v.name}
-                  </span>
-                  <span
-                    data-testid="location-status"
-                    className={`text-xs px-2 py-0.5 rounded-full ${
-                      v.isActive
-                        ? "bg-green-500/10 text-green-600"
-                        : "bg-muted text-muted-foreground"
-                    }`}
-                  >
-                    {v.isActive ? "Active" : "Inactive"}
-                  </span>
-                </div>
-                {v.description && (
-                  <p
-                    data-testid="location-description"
-                    className="text-muted-foreground text-sm"
-                  >
-                    {v.description}
-                  </p>
-                )}
-              </div>
-              <Button
-                variant="outline"
-                size="sm"
-                data-testid="location-edit-btn"
-                onClick={() => setFormMode({ type: "edit", venue: v })}
-              >
-                Edit
-              </Button>
-            </div>
+              venue={v}
+              onEdit={(venue) => setFormMode({ type: "edit", venue })}
+            />
           ))}
         </div>
       )}

--- a/packages/api/src/routers/index.ts
+++ b/packages/api/src/routers/index.ts
@@ -2,6 +2,7 @@ import { protectedProcedure, publicProcedure, router } from "../index";
 import { profileRouter } from "./profile";
 import { matchingRouter } from "./matching";
 import { venueRouter } from "./venue";
+import { adminVenueRouter } from "./venue-admin";
 import { meetupRouter } from "./meetup";
 import { chatRouter } from "./chat";
 
@@ -18,6 +19,7 @@ export const appRouter = router({
   profile: profileRouter,
   matching: matchingRouter,
   venue: venueRouter,
+  adminVenue: adminVenueRouter,
   meetup: meetupRouter,
   chat: chatRouter,
 });

--- a/packages/api/src/routers/venue-admin.ts
+++ b/packages/api/src/routers/venue-admin.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
-import { eq } from "drizzle-orm";
+import { and, count, eq, ne } from "drizzle-orm";
 import { db } from "@sip-and-speak/db";
-import { venue } from "@sip-and-speak/db/schema/sip-and-speak";
+import { meetup, venue } from "@sip-and-speak/db/schema/sip-and-speak";
 import { protectedProcedure, router } from "../index";
 
 async function assertNameUnique(name: string, excludeId?: string) {
@@ -87,12 +87,51 @@ export const adminVenueRouter = router({
       return updated;
     }),
 
+  deactivateWarnings: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .query(async ({ input }) => {
+      const [pendingMeetupsResult, activeCountResult] = await Promise.all([
+        db
+          .select({ count: count() })
+          .from(meetup)
+          .where(
+            and(
+              eq(meetup.venueId, input.id),
+              eq(meetup.status, "pending"),
+            ),
+          ),
+        db
+          .select({ count: count() })
+          .from(venue)
+          .where(and(eq(venue.isActive, true), ne(venue.id, input.id))),
+      ]);
+
+      return {
+        hasPendingProposals: (pendingMeetupsResult[0]?.count ?? 0) > 0,
+        isLastActive: (activeCountResult[0]?.count ?? 0) === 0,
+      };
+    }),
+
   deactivate: protectedProcedure
     .input(z.object({ id: z.string() }))
     .mutation(async ({ input }) => {
       const [updated] = await db
         .update(venue)
         .set({ isActive: false })
+        .where(eq(venue.id, input.id))
+        .returning();
+      if (!updated) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Venue not found" });
+      }
+      return updated;
+    }),
+
+  reactivate: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .mutation(async ({ input }) => {
+      const [updated] = await db
+        .update(venue)
+        .set({ isActive: true })
         .where(eq(venue.id, input.id))
         .returning();
       if (!updated) {

--- a/packages/api/src/routers/venue-admin.ts
+++ b/packages/api/src/routers/venue-admin.ts
@@ -1,0 +1,103 @@
+import { z } from "zod";
+import { TRPCError } from "@trpc/server";
+import { eq } from "drizzle-orm";
+import { db } from "@sip-and-speak/db";
+import { venue } from "@sip-and-speak/db/schema/sip-and-speak";
+import { protectedProcedure, router } from "../index";
+
+async function assertNameUnique(name: string, excludeId?: string) {
+  const existing = await db
+    .select({ id: venue.id })
+    .from(venue)
+    .where(eq(venue.name, name));
+  const conflict = existing.find((v) => v.id !== excludeId);
+  if (conflict) {
+    throw new TRPCError({
+      code: "CONFLICT",
+      message: "A venue with this name already exists",
+    });
+  }
+}
+
+export const adminVenueRouter = router({
+  create: protectedProcedure
+    .input(
+      z.object({
+        name: z.string().min(1),
+        description: z.string().optional(),
+        latitude: z.number(),
+        longitude: z.number(),
+      }),
+    )
+    .mutation(async ({ input }) => {
+      await assertNameUnique(input.name);
+      const [created] = await db
+        .insert(venue)
+        .values({
+          name: input.name,
+          description: input.description ?? null,
+          latitude: input.latitude,
+          longitude: input.longitude,
+        })
+        .returning();
+      return created;
+    }),
+
+  findAll: protectedProcedure.query(async () => {
+    return db.select().from(venue);
+  }),
+
+  findById: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .query(async ({ input }) => {
+      const [found] = await db
+        .select()
+        .from(venue)
+        .where(eq(venue.id, input.id));
+      if (!found) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Venue not found" });
+      }
+      return found;
+    }),
+
+  update: protectedProcedure
+    .input(
+      z.object({
+        id: z.string(),
+        name: z.string().min(1).optional(),
+        description: z.string().nullable().optional(),
+      }),
+    )
+    .mutation(async ({ input }) => {
+      if (input.name) {
+        await assertNameUnique(input.name, input.id);
+      }
+      const patch: Partial<typeof venue.$inferInsert> = {};
+      if (input.name !== undefined) patch.name = input.name;
+      if (input.description !== undefined) patch.description = input.description;
+
+      const [updated] = await db
+        .update(venue)
+        .set(patch)
+        .where(eq(venue.id, input.id))
+        .returning();
+      if (!updated) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Venue not found" });
+      }
+      return updated;
+    }),
+
+  deactivate: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .mutation(async ({ input }) => {
+      const [updated] = await db
+        .update(venue)
+        .set({ isActive: false })
+        .where(eq(venue.id, input.id))
+        .returning();
+      if (!updated) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Venue not found" });
+      }
+      return updated;
+    }),
+});

--- a/packages/api/src/routers/venue.ts
+++ b/packages/api/src/routers/venue.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { eq } from "drizzle-orm";
 import { db } from "@sip-and-speak/db";
 import { venue } from "@sip-and-speak/db/schema/sip-and-speak";
 import { protectedProcedure, router } from "../index";
@@ -18,7 +19,10 @@ export const venueRouter = router({
       }),
     )
     .query(async ({ input }) => {
-      const allVenues = await db.select().from(venue);
+      const allVenues = await db
+        .select()
+        .from(venue)
+        .where(eq(venue.isActive, true));
 
       // Filter by tags if provided
       let filtered = allVenues;
@@ -58,7 +62,10 @@ export const venueRouter = router({
       }),
     )
     .query(async ({ input }) => {
-      const allVenues = await db.select().from(venue);
+      const allVenues = await db
+        .select()
+        .from(venue)
+        .where(eq(venue.isActive, true));
 
       let radiusKm = input.radiusKm;
       let expandedSearch = false;
@@ -90,4 +97,14 @@ export const venueRouter = router({
 
       return { venues, expandedSearch, radiusKm };
     }),
+
+  // Used by the proposal form to gate entry: if false, no proposals can be created
+  hasActiveLocations: protectedProcedure.query(async () => {
+    const result = await db
+      .select({ id: venue.id })
+      .from(venue)
+      .where(eq(venue.isActive, true))
+      .limit(1);
+    return result.length > 0;
+  }),
 });

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -17,7 +17,9 @@
     "db:start": "docker compose up -d",
     "db:watch": "docker compose up",
     "db:stop": "docker compose stop",
-    "db:down": "docker compose down"
+    "db:down": "docker compose down",
+    "db:seed:venues": "bun run src/seed/venues.ts",
+    "db:seed:tue-locations": "bun run src/seed/tue-locations.ts"
   },
   "dependencies": {
     "@sip-and-speak/env": "workspace:*",

--- a/packages/db/src/migrations/0003_funny_wolverine.sql
+++ b/packages/db/src/migrations/0003_funny_wolverine.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "user_device_token" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"token" text NOT NULL,
+	"platform" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "venue" ADD COLUMN "is_active" boolean DEFAULT true NOT NULL;--> statement-breakpoint
+ALTER TABLE "venue" ADD COLUMN "updated_at" timestamp DEFAULT now() NOT NULL;--> statement-breakpoint
+ALTER TABLE "user_device_token" ADD CONSTRAINT "user_device_token_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "user_device_token_userId_token_idx" ON "user_device_token" USING btree ("user_id","token");--> statement-breakpoint
+CREATE UNIQUE INDEX "venue_name_idx" ON "venue" USING btree ("name");

--- a/packages/db/src/migrations/meta/0003_snapshot.json
+++ b/packages/db/src/migrations/meta/0003_snapshot.json
@@ -1,0 +1,1539 @@
+{
+  "id": "c243e644-6dec-4225-a631-956f2f4eda15",
+  "prevId": "493b82ee-98bf-474e-9b2f-3981e5a034e2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation": {
+      "name": "conversation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user1_id": {
+          "name": "user1_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user2_id": {
+          "name": "user2_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_user1_idx": {
+          "name": "conversation_user1_idx",
+          "columns": [
+            {
+              "expression": "user1_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_user2_idx": {
+          "name": "conversation_user2_idx",
+          "columns": [
+            {
+              "expression": "user2_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_user1_id_user_id_fk": {
+          "name": "conversation_user1_id_user_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user1_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_user2_id_user_id_fk": {
+          "name": "conversation_user2_id_user_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user2_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.language_profile": {
+      "name": "language_profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "university": {
+          "name": "university",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "age": {
+          "name": "age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_complete": {
+          "name": "onboarding_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "language_profile_user_id_user_id_fk": {
+          "name": "language_profile_user_id_user_id_fk",
+          "tableFrom": "language_profile",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "language_profile_user_id_unique": {
+          "name": "language_profile_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_request": {
+      "name": "match_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "requester_id": {
+          "name": "requester_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receiver_id": {
+          "name": "receiver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "match_request_requesterId_idx": {
+          "name": "match_request_requesterId_idx",
+          "columns": [
+            {
+              "expression": "requester_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "match_request_receiverId_idx": {
+          "name": "match_request_receiverId_idx",
+          "columns": [
+            {
+              "expression": "receiver_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "match_request_requester_id_user_id_fk": {
+          "name": "match_request_requester_id_user_id_fk",
+          "tableFrom": "match_request",
+          "tableTo": "user",
+          "columnsFrom": [
+            "requester_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "match_request_receiver_id_user_id_fk": {
+          "name": "match_request_receiver_id_user_id_fk",
+          "tableFrom": "match_request",
+          "tableTo": "user",
+          "columnsFrom": [
+            "receiver_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meetup": {
+      "name": "meetup",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "proposer_id": {
+          "name": "proposer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receiver_id": {
+          "name": "receiver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "venue_id": {
+          "name": "venue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "meetup_proposerId_idx": {
+          "name": "meetup_proposerId_idx",
+          "columns": [
+            {
+              "expression": "proposer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meetup_receiverId_idx": {
+          "name": "meetup_receiverId_idx",
+          "columns": [
+            {
+              "expression": "receiver_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meetup_date_idx": {
+          "name": "meetup_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "meetup_proposer_id_user_id_fk": {
+          "name": "meetup_proposer_id_user_id_fk",
+          "tableFrom": "meetup",
+          "tableTo": "user",
+          "columnsFrom": [
+            "proposer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meetup_receiver_id_user_id_fk": {
+          "name": "meetup_receiver_id_user_id_fk",
+          "tableFrom": "meetup",
+          "tableTo": "user",
+          "columnsFrom": [
+            "receiver_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meetup_venue_id_venue_id_fk": {
+          "name": "meetup_venue_id_venue_id_fk",
+          "tableFrom": "meetup",
+          "tableTo": "venue",
+          "columnsFrom": [
+            "venue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message": {
+      "name": "message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_conversationId_idx": {
+          "name": "message_conversationId_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_createdAt_idx": {
+          "name": "message_createdAt_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_conversation_id_conversation_id_fk": {
+          "name": "message_conversation_id_conversation_id_fk",
+          "tableFrom": "message",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_sender_id_user_id_fk": {
+          "name": "message_sender_id_user_id_fk",
+          "tableFrom": "message",
+          "tableTo": "user",
+          "columnsFrom": [
+            "sender_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message_read_status": {
+      "name": "message_read_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_read_conversationId_userId_idx": {
+          "name": "message_read_conversationId_userId_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_read_status_conversation_id_conversation_id_fk": {
+          "name": "message_read_status_conversation_id_conversation_id_fk",
+          "tableFrom": "message_read_status",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_read_status_user_id_user_id_fk": {
+          "name": "message_read_status_user_id_user_id_fk",
+          "tableFrom": "message_read_status",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_comment": {
+      "name": "student_comment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "student_comment_targetId_idx": {
+          "name": "student_comment_targetId_idx",
+          "columns": [
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "student_comment_author_id_user_id_fk": {
+          "name": "student_comment_author_id_user_id_fk",
+          "tableFrom": "student_comment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "student_comment_target_id_user_id_fk": {
+          "name": "student_comment_target_id_user_id_fk",
+          "tableFrom": "student_comment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_match": {
+      "name": "student_match",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "student_a_id": {
+          "name": "student_a_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_b_id": {
+          "name": "student_b_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_request_id": {
+          "name": "match_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "student_match_studentA_idx": {
+          "name": "student_match_studentA_idx",
+          "columns": [
+            {
+              "expression": "student_a_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "student_match_studentB_idx": {
+          "name": "student_match_studentB_idx",
+          "columns": [
+            {
+              "expression": "student_b_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "student_match_student_a_id_user_id_fk": {
+          "name": "student_match_student_a_id_user_id_fk",
+          "tableFrom": "student_match",
+          "tableTo": "user",
+          "columnsFrom": [
+            "student_a_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "student_match_student_b_id_user_id_fk": {
+          "name": "student_match_student_b_id_user_id_fk",
+          "tableFrom": "student_match",
+          "tableTo": "user",
+          "columnsFrom": [
+            "student_b_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "student_match_match_request_id_match_request_id_fk": {
+          "name": "student_match_match_request_id_match_request_id_fk",
+          "tableFrom": "student_match",
+          "tableTo": "match_request",
+          "columnsFrom": [
+            "match_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_device_token": {
+      "name": "user_device_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_device_token_userId_token_idx": {
+          "name": "user_device_token_userId_token_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_device_token_user_id_user_id_fk": {
+          "name": "user_device_token_user_id_user_id_fk",
+          "tableFrom": "user_device_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_interest": {
+      "name": "user_interest",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interest": {
+          "name": "interest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_interest_userId_idx": {
+          "name": "user_interest_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_interest_user_id_user_id_fk": {
+          "name": "user_interest_user_id_user_id_fk",
+          "tableFrom": "user_interest",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_language": {
+      "name": "user_language",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proficiency": {
+          "name": "proficiency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_language_userId_idx": {
+          "name": "user_language_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_language_user_id_user_id_fk": {
+          "name": "user_language_user_id_user_id_fk",
+          "tableFrom": "user_language",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.venue": {
+      "name": "venue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "venue_name_idx": {
+          "name": "venue_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1776079537981,
       "tag": "0002_rich_agent_zero",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1776095865882,
+      "tag": "0003_funny_wolverine",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/sip-and-speak.ts
+++ b/packages/db/src/schema/sip-and-speak.ts
@@ -74,18 +74,27 @@ export const userInterest = pgTable(
   (table) => [index("user_interest_userId_idx").on(table.userId)],
 );
 
-export const venue = pgTable("venue", {
-  id: text("id")
-    .primaryKey()
-    .$defaultFn(() => crypto.randomUUID()),
-  name: text("name").notNull(),
-  description: text("description"),
-  photoUrl: text("photo_url"),
-  latitude: doublePrecision("latitude").notNull(),
-  longitude: doublePrecision("longitude").notNull(),
-  tags: text("tags").array().notNull().default([]),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
-});
+export const venue = pgTable(
+  "venue",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    name: text("name").notNull(),
+    description: text("description"),
+    photoUrl: text("photo_url"),
+    latitude: doublePrecision("latitude").notNull(),
+    longitude: doublePrecision("longitude").notNull(),
+    tags: text("tags").array().notNull().default([]),
+    isActive: boolean("is_active").default(true).notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at")
+      .defaultNow()
+      .$onUpdate(() => new Date())
+      .notNull(),
+  },
+  (table) => [uniqueIndex("venue_name_idx").on(table.name)],
+);
 
 export const meetup = pgTable(
   "meetup",

--- a/packages/db/src/seed/tue-locations.ts
+++ b/packages/db/src/seed/tue-locations.ts
@@ -1,0 +1,68 @@
+import { eq } from "drizzle-orm";
+import { db } from "../index";
+import { venue } from "../schema";
+
+const tueCampusLocations = [
+  {
+    name: "Metaforum Cantine",
+    description:
+      "The main cantine in TU/e's Metaforum building — spacious, central, and always busy. Great for a relaxed Sip&Speak over lunch.",
+    latitude: 51.4478,
+    longitude: 5.4873,
+    tags: ["campus", "vibrant"] as string[],
+    isActive: true,
+  },
+  {
+    name: "Atlas Brownies&Downies",
+    description:
+      "An inclusive café on the ground floor of the Atlas building, run by people with and without Down's syndrome. Warm atmosphere, excellent brownies.",
+    latitude: 51.4492,
+    longitude: 5.4848,
+    tags: ["campus", "quiet_zone"] as string[],
+    isActive: true,
+  },
+  {
+    name: "Atlas Coffee&Co",
+    description:
+      "The coffee corner inside Atlas — quick service and a cosy seating area, perfect for a short Sip&Speak session between classes.",
+    latitude: 51.449,
+    longitude: 5.485,
+    tags: ["campus", "wifi"] as string[],
+    isActive: true,
+  },
+];
+
+async function seed() {
+  console.log("🌱 Seeding TU/e on-campus locations...");
+
+  let inserted = 0;
+  let skipped = 0;
+
+  for (const location of tueCampusLocations) {
+    const existing = await db
+      .select({ id: venue.id })
+      .from(venue)
+      .where(eq(venue.name, location.name))
+      .limit(1);
+
+    if (existing.length > 0) {
+      console.log(`⏭️  "${location.name}" already exists, skipping.`);
+      skipped++;
+    } else {
+      await db.insert(venue).values(location);
+      console.log(`✅ Inserted "${location.name}".`);
+      inserted++;
+    }
+  }
+
+  console.log(
+    `Done — ${inserted} inserted, ${skipped} skipped (idempotent).`,
+  );
+}
+
+seed()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error("❌ Seed failed:", err);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary

- Add `isActive` / `updatedAt` fields and unique-name constraint to `venue` table (migration 0003)
- Add `adminVenueRouter` with `create`, `findAll`, `findById`, `update`, `deactivate`, `reactivate`, `deactivateWarnings` procedures
- Build `/admin/locations` web route: full CRUD list, add/edit form, deactivate/reactivate with confirmation + warnings
- Filter student-facing `venue.list` and `venue.mapData` to `isActive = true` only; add `hasActiveLocations` gate query
- Seed TU/e on-campus locations (Metaforum Cantine, Atlas Brownies&Downies, Atlas Coffee&Co) — idempotent

## Test plan

- [ ] Run `bun run db:seed:tue-locations` — all 3 locations inserted; second run skips (idempotent)
- [ ] Navigate to `/admin/locations` — list shows all venues with Active/Inactive badge
- [ ] Add a location — appears in list as Active
- [ ] Edit a location name/description — list updates
- [ ] Add location with duplicate name — inline error shown, form not submitted
- [ ] Deactivate a location — confirmation dialog shown; after confirm, badge changes to Inactive
- [ ] Reactivate a location — badge changes back to Active
- [ ] Verify student venue list (e.g. meetup form) no longer includes inactive venues

Closes #60
Closes #61
Closes #62
Closes #63
Closes #64
Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)