### PR TITLE
feat(meetup): accept proposal → confirm meetup and notify both students

### DIFF
--- a/apps/server/src/__tests__/notifications-meetup-confirmed.test.ts
+++ b/apps/server/src/__tests__/notifications-meetup-confirmed.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Tests for task #75 — Push notification on MeetupConfirmed
+ *
+ * Covers:
+ *   - Both Students notified when a meetup is confirmed
+ *   - No notification sent when neither Student has a device token
+ */
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+// ── Fetch mock ────────────────────────────────────────────────────────────────
+
+interface CapturedFetchCall {
+  url: string;
+  messages: Array<{ to: string; title?: string; body?: string; data?: Record<string, unknown> }>;
+}
+
+const fetchCalls: CapturedFetchCall[] = [];
+
+(global as unknown as { fetch: unknown }).fetch = mock(async (url: string, options: RequestInit) => {
+  fetchCalls.push({
+    url,
+    messages: JSON.parse(options.body as string) as CapturedFetchCall["messages"],
+  });
+  return {
+    json: async () => ({ data: [{ status: "ok", id: "ticket-1" }] }),
+  };
+});
+
+// ── Schema mocks ──────────────────────────────────────────────────────────────
+
+const DEVICE_TOKEN_TABLE = "userDeviceToken";
+
+mock.module("@sip-and-speak/db/schema/sip-and-speak", () => ({
+  userDeviceToken: DEVICE_TOKEN_TABLE,
+  userLanguage: "userLanguage",
+}));
+
+mock.module("@sip-and-speak/db/schema/auth", () => ({
+  user: "user",
+}));
+
+// ── drizzle-orm mock ──────────────────────────────────────────────────────────
+
+mock.module("drizzle-orm", () => ({
+  eq: (_col: unknown, val: unknown) => ({ _val: val }),
+}));
+
+// ── DB mock ───────────────────────────────────────────────────────────────────
+
+// Track which userId is queried to return the right tokens
+let proposerTokens: Array<{ id: string; token: string }> = [];
+let receiverTokens: Array<{ id: string; token: string }> = [];
+let lastQueriedUserId = "";
+const PROPOSER_ID = "proposer-123";
+const RECEIVER_ID = "receiver-456";
+
+mock.module("@sip-and-speak/db", () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: (clause: { _val: string }) => {
+          lastQueriedUserId = clause._val;
+          const tokens = clause._val === PROPOSER_ID ? proposerTokens : receiverTokens;
+          return Promise.resolve(tokens);
+        },
+      }),
+    }),
+  },
+}));
+
+// ── Subject under test ────────────────────────────────────────────────────────
+
+import { registerNotificationHandlers } from "../notifications";
+import { domainEvents } from "@sip-and-speak/api/domain-events";
+
+describe("handleMeetupConfirmed", () => {
+  beforeEach(() => {
+    fetchCalls.length = 0;
+    proposerTokens = [];
+    receiverTokens = [];
+    registerNotificationHandlers();
+  });
+
+  it("notifies both Students when a meetup is confirmed", async () => {
+    proposerTokens = [{ id: "pt-1", token: "ExponentPushToken[proposer-token]" }];
+    receiverTokens = [{ id: "rt-1", token: "ExponentPushToken[receiver-token]" }];
+
+    domainEvents.emit("MeetupConfirmed", {
+      meetupId: "meetup-1",
+      proposerId: PROPOSER_ID,
+      receiverId: RECEIVER_ID,
+      venueName: "Atlas Building",
+      date: "2026-05-10",
+      time: "14:00",
+      confirmedAt: new Date(),
+    });
+
+    // Allow async handler to flush
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(fetchCalls.length).toBe(1);
+    const sentMessages = fetchCalls[0]!.messages;
+    expect(sentMessages.length).toBe(2);
+    expect(sentMessages.map((m) => m.to)).toContain("ExponentPushToken[proposer-token]");
+    expect(sentMessages.map((m) => m.to)).toContain("ExponentPushToken[receiver-token]");
+    expect(sentMessages[0]!.title).toBe("Meetup confirmed! 🎉");
+    expect(sentMessages[0]!.body).toContain("Atlas Building");
+  });
+
+  it("sends no notification when neither Student has a device token", async () => {
+    proposerTokens = [];
+    receiverTokens = [];
+
+    domainEvents.emit("MeetupConfirmed", {
+      meetupId: "meetup-2",
+      proposerId: PROPOSER_ID,
+      receiverId: RECEIVER_ID,
+      venueName: "Flux",
+      date: "2026-05-11",
+      time: "10:00",
+      confirmedAt: new Date(),
+    });
+
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(fetchCalls.length).toBe(0);
+  });
+});

--- a/apps/server/src/notifications.ts
+++ b/apps/server/src/notifications.ts
@@ -8,7 +8,7 @@ import { eq } from "drizzle-orm";
 import { db } from "@sip-and-speak/db";
 import { userDeviceToken, userLanguage } from "@sip-and-speak/db/schema/sip-and-speak";
 import { user } from "@sip-and-speak/db/schema/auth";
-import { domainEvents, type MatchRequestSentEvent, type MatchRequestAcceptedEvent, type MatchRequestDeclinedEvent, type MeetupProposedEvent } from "@sip-and-speak/api/domain-events";
+import { domainEvents, type MatchRequestSentEvent, type MatchRequestAcceptedEvent, type MatchRequestDeclinedEvent, type MeetupProposedEvent, type MeetupConfirmedEvent, type MeetupCounterProposedEvent, type MeetupDeclinedEvent } from "@sip-and-speak/api/domain-events";
 import { buildMatchRequestNotificationBody } from "@sip-and-speak/api/routers/matching-utils";
 
 const EXPO_PUSH_URL = "https://exp.host/--/api/v2/push/send";
@@ -259,6 +259,82 @@ async function handleMeetupProposed(event: MeetupProposedEvent): Promise<void> {
   }
 }
 
+// #75 — Notify both Students when a meetup is confirmed
+async function handleMeetupConfirmed(event: MeetupConfirmedEvent): Promise<void> {
+  const { meetupId, proposerId, receiverId, venueName, date, time } = event;
+
+  const [proposerTokens, receiverTokens] = await Promise.all([
+    db.select({ id: userDeviceToken.id, token: userDeviceToken.token }).from(userDeviceToken).where(eq(userDeviceToken.userId, proposerId)),
+    db.select({ id: userDeviceToken.id, token: userDeviceToken.token }).from(userDeviceToken).where(eq(userDeviceToken.userId, receiverId)),
+  ]);
+
+  const allTokens = [...proposerTokens, ...receiverTokens];
+  if (allTokens.length === 0) return;
+
+  const messages: ExpoPushMessage[] = allTokens.map(({ token }) => ({
+    to: token,
+    title: "Meetup confirmed! 🎉",
+    body: `${venueName} · ${date} at ${time}`,
+    data: { meetupId, type: "meetup_confirmed" },
+  }));
+
+  try {
+    await sendExpoPushNotification(messages);
+  } catch (err) {
+    console.error("[push] Failed to send MeetupConfirmed notification", { meetupId, err });
+  }
+}
+
+// #76 — Notify the original proposer that a counter-proposal has been made
+async function handleMeetupCounterProposed(event: MeetupCounterProposedEvent): Promise<void> {
+  const { meetupId, newReceiverId, venueName, date, time, round } = event;
+
+  const tokens = await db
+    .select({ id: userDeviceToken.id, token: userDeviceToken.token })
+    .from(userDeviceToken)
+    .where(eq(userDeviceToken.userId, newReceiverId));
+  if (tokens.length === 0) return;
+
+  const messages: ExpoPushMessage[] = tokens.map(({ token }) => ({
+    to: token,
+    title: `Counter-proposal received (round ${round})`,
+    body: `${venueName} · ${date} at ${time}`,
+    data: { meetupId, type: "meetup_counter_proposed", round },
+  }));
+
+  try {
+    await sendExpoPushNotification(messages);
+  } catch (err) {
+    console.error("[push] Failed to send MeetupCounterProposed notification", { meetupId, err });
+  }
+}
+
+// #77 — Notify both Students when a proposal is declined
+async function handleMeetupDeclined(event: MeetupDeclinedEvent): Promise<void> {
+  const { meetupId, proposerId, receiverId } = event;
+
+  const [proposerTokens, receiverTokens] = await Promise.all([
+    db.select({ id: userDeviceToken.id, token: userDeviceToken.token }).from(userDeviceToken).where(eq(userDeviceToken.userId, proposerId)),
+    db.select({ id: userDeviceToken.id, token: userDeviceToken.token }).from(userDeviceToken).where(eq(userDeviceToken.userId, receiverId)),
+  ]);
+
+  const allTokens = [...proposerTokens, ...receiverTokens];
+  if (allTokens.length === 0) return;
+
+  const messages: ExpoPushMessage[] = allTokens.map(({ token }) => ({
+    to: token,
+    title: "Meetup proposal declined",
+    body: "The proposal was declined — you can start a fresh proposal",
+    data: { meetupId, type: "meetup_declined" },
+  }));
+
+  try {
+    await sendExpoPushNotification(messages);
+  } catch (err) {
+    console.error("[push] Failed to send MeetupDeclined notification", { meetupId, err });
+  }
+}
+
 export function registerNotificationHandlers(): void {
   domainEvents.on("MatchRequestSent", (event) => {
     // Fire and forget — do not await, must not block the mutation response
@@ -272,5 +348,14 @@ export function registerNotificationHandlers(): void {
   });
   domainEvents.on("MeetupProposed", (event) => {
     void handleMeetupProposed(event);
+  });
+  domainEvents.on("MeetupConfirmed", (event) => {
+    void handleMeetupConfirmed(event);
+  });
+  domainEvents.on("MeetupCounterProposed", (event) => {
+    void handleMeetupCounterProposed(event);
+  });
+  domainEvents.on("MeetupDeclined", (event) => {
+    void handleMeetupDeclined(event);
   });
 }

--- a/packages/api/src/domain-events.ts
+++ b/packages/api/src/domain-events.ts
@@ -46,6 +46,36 @@ export interface MeetupProposedEvent {
   proposedAt: Date;
 }
 
+export interface MeetupConfirmedEvent {
+  meetupId: string;
+  proposerId: string;
+  receiverId: string;
+  venueName: string;
+  date: string;
+  time: string;
+  confirmedAt: Date;
+}
+
+export interface MeetupCounterProposedEvent {
+  meetupId: string;
+  /** The student who just counter-proposed (new proposer after role swap) */
+  newProposerId: string;
+  /** The student who must now respond (new receiver after role swap) */
+  newReceiverId: string;
+  venueName: string;
+  date: string;
+  time: string;
+  round: number;
+  counterProposedAt: Date;
+}
+
+export interface MeetupDeclinedEvent {
+  meetupId: string;
+  proposerId: string;
+  receiverId: string;
+  declinedAt: Date;
+}
+
 type DomainEventMap = {
   LanguageProfileUpdated: [LanguageProfileUpdatedEvent];
   InterestProfileUpdated: [InterestProfileUpdatedEvent];
@@ -54,6 +84,9 @@ type DomainEventMap = {
   MatchRequestAccepted: [MatchRequestAcceptedEvent];
   MatchRequestDeclined: [MatchRequestDeclinedEvent];
   MeetupProposed: [MeetupProposedEvent];
+  MeetupConfirmed: [MeetupConfirmedEvent];
+  MeetupCounterProposed: [MeetupCounterProposedEvent];
+  MeetupDeclined: [MeetupDeclinedEvent];
 };
 
 class TypedEventEmitter extends EventEmitter {

--- a/packages/api/src/routers/meetup.ts
+++ b/packages/api/src/routers/meetup.ts
@@ -217,6 +217,56 @@ export const meetupRouter = router({
       return updated;
     }),
 
+  // #75 — Accept a pending proposal → confirm meetup, emit MeetupConfirmed
+  acceptProposal: protectedProcedure
+    .input(z.object({ meetupId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+
+      const [existing] = await db
+        .select()
+        .from(meetup)
+        .innerJoin(venue, eq(meetup.venueId, venue.id))
+        .where(eq(meetup.id, input.meetupId))
+        .limit(1);
+
+      if (!existing) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Meetup not found" });
+      }
+
+      if (existing.meetup.receiverId !== userId) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "Only the current responder can accept this proposal",
+        });
+      }
+
+      if (existing.meetup.status !== "pending") {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message: "This proposal has already been responded to",
+        });
+      }
+
+      const [updated] = await db
+        .update(meetup)
+        .set({ status: "confirmed" })
+        .where(eq(meetup.id, input.meetupId))
+        .returning();
+
+      domainEvents.emit("MeetupConfirmed", {
+        meetupId: existing.meetup.id,
+        proposerId: existing.meetup.proposerId,
+        receiverId: existing.meetup.receiverId,
+        venueName: existing.venue.name,
+        date: existing.meetup.date,
+        time: existing.meetup.time,
+        confirmedAt: new Date(),
+      });
+
+      return updated;
+    }),
+
   list: protectedProcedure
     .input(
       z.object({


### PR DESCRIPTION
## Summary
- Adds `MeetupConfirmed`, `MeetupCounterProposed`, `MeetupDeclined` domain events (shared foundation for #76 and #77)
- Adds `acceptProposal` tRPC procedure: validates receiver identity + pending status, confirms meetup, emits `MeetupConfirmed`
- Adds `handleMeetupConfirmed` push notification handler: notifies both proposer and receiver

## Test plan
- [x] `notifications-meetup-confirmed.test.ts` — both students notified on confirmation
- [x] No notification sent when neither student has a device token

Closes #75