### PR TITLE
feat(meetup): counter-propose — swap roles, increment round, notify original proposer

### DIFF
--- a/apps/server/src/__tests__/notifications-meetup-counter-proposed.test.ts
+++ b/apps/server/src/__tests__/notifications-meetup-counter-proposed.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for task #76 — Push notification on MeetupCounterProposed
+ *
+ * Covers:
+ *   - Original proposer (now the new receiver) notified when a counter-proposal arrives
+ *   - No notification sent when the new receiver has no device token
+ */
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+// ── Fetch mock ────────────────────────────────────────────────────────────────
+
+interface CapturedFetchCall {
+  url: string;
+  messages: Array<{ to: string; title?: string; body?: string; data?: Record<string, unknown> }>;
+}
+
+const fetchCalls: CapturedFetchCall[] = [];
+
+(global as unknown as { fetch: unknown }).fetch = mock(async (url: string, options: RequestInit) => {
+  fetchCalls.push({
+    url,
+    messages: JSON.parse(options.body as string) as CapturedFetchCall["messages"],
+  });
+  return {
+    json: async () => ({ data: [{ status: "ok", id: "ticket-1" }] }),
+  };
+});
+
+// ── Schema mocks ──────────────────────────────────────────────────────────────
+
+mock.module("@sip-and-speak/db/schema/sip-and-speak", () => ({
+  userDeviceToken: "userDeviceToken",
+  userLanguage: "userLanguage",
+}));
+
+mock.module("@sip-and-speak/db/schema/auth", () => ({
+  user: "user",
+}));
+
+// ── drizzle-orm mock ──────────────────────────────────────────────────────────
+
+mock.module("drizzle-orm", () => ({
+  eq: (_col: unknown, val: unknown) => ({ _val: val }),
+}));
+
+// ── DB mock ───────────────────────────────────────────────────────────────────
+
+let mockTokenRows: Array<{ id: string; token: string }> = [];
+const ORIGINAL_PROPOSER_ID = "orig-proposer-123"; // becomes newReceiverId after counter
+
+mock.module("@sip-and-speak/db", () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => Promise.resolve(mockTokenRows),
+      }),
+    }),
+  },
+}));
+
+// ── Subject under test ────────────────────────────────────────────────────────
+
+import { registerNotificationHandlers } from "../notifications";
+import { domainEvents } from "@sip-and-speak/api/domain-events";
+
+describe("handleMeetupCounterProposed", () => {
+  beforeEach(() => {
+    fetchCalls.length = 0;
+    mockTokenRows = [];
+    registerNotificationHandlers();
+  });
+
+  it("notifies the original proposer (new receiver) of the counter-proposal", async () => {
+    mockTokenRows = [{ id: "token-1", token: "ExponentPushToken[orig-proposer]" }];
+
+    domainEvents.emit("MeetupCounterProposed", {
+      meetupId: "meetup-1",
+      newProposerId: "counter-proposer-456",
+      newReceiverId: ORIGINAL_PROPOSER_ID,
+      venueName: "Vertigo",
+      date: "2026-05-15",
+      time: "10:30",
+      round: 2,
+      counterProposedAt: new Date(),
+    });
+
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(fetchCalls.length).toBe(1);
+    const msg = fetchCalls[0]!.messages[0]!;
+    expect(msg.to).toBe("ExponentPushToken[orig-proposer]");
+    expect(msg.title).toContain("round 2");
+    expect(msg.body).toContain("Vertigo");
+  });
+
+  it("sends no notification when new receiver has no device token", async () => {
+    mockTokenRows = [];
+
+    domainEvents.emit("MeetupCounterProposed", {
+      meetupId: "meetup-2",
+      newProposerId: "counter-proposer-456",
+      newReceiverId: ORIGINAL_PROPOSER_ID,
+      venueName: "Atlas",
+      date: "2026-05-16",
+      time: "11:00",
+      round: 2,
+      counterProposedAt: new Date(),
+    });
+
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(fetchCalls.length).toBe(0);
+  });
+});

--- a/packages/api/src/routers/meetup.ts
+++ b/packages/api/src/routers/meetup.ts
@@ -217,6 +217,112 @@ export const meetupRouter = router({
       return updated;
     }),
 
+  // #76 — Counter-propose: swap roles, update details, increment round, emit MeetupCounterProposed
+  counterPropose: protectedProcedure
+    .input(
+      z.object({
+        meetupId: z.string(),
+        venueId: z.string(),
+        date: z.string(),
+        time: z.string(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+
+      const [existing] = await db
+        .select()
+        .from(meetup)
+        .innerJoin(venue, eq(meetup.venueId, venue.id))
+        .where(eq(meetup.id, input.meetupId))
+        .limit(1);
+
+      if (!existing) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Meetup not found" });
+      }
+
+      if (existing.meetup.receiverId !== userId) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "Only the current responder can counter-propose",
+        });
+      }
+
+      if (existing.meetup.status !== "pending") {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message: "This proposal has already been responded to",
+        });
+      }
+
+      // #73 — Reject counter-propose when round is already at 3
+      if (existing.meetup.round >= 3) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Maximum counter-proposal rounds reached. You can only accept or decline.",
+        });
+      }
+
+      // Reject no-op counter-proposal (same venue, date, and time)
+      if (
+        existing.meetup.venueId === input.venueId &&
+        existing.meetup.date === input.date &&
+        existing.meetup.time === input.time
+      ) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Counter-proposal must differ from the current proposal in at least one detail",
+        });
+      }
+
+      // Future date/time validation
+      const proposedDateTime = new Date(`${input.date}T${input.time}:00`);
+      if (proposedDateTime <= new Date()) {
+        throw new TRPCError({ code: "BAD_REQUEST", message: "The proposed date and time must be in the future" });
+      }
+
+      // Active venue check
+      const [newVenue] = await db
+        .select({ id: venue.id, name: venue.name, isActive: venue.isActive })
+        .from(venue)
+        .where(eq(venue.id, input.venueId))
+        .limit(1);
+      if (!newVenue) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Location not found" });
+      }
+      if (!newVenue.isActive) {
+        throw new TRPCError({ code: "BAD_REQUEST", message: "This location is no longer available. Please choose another." });
+      }
+
+      // Swap proposer/receiver so original proposer now becomes the responder
+      const newRound = existing.meetup.round + 1;
+      const [updated] = await db
+        .update(meetup)
+        .set({
+          proposerId: userId,
+          receiverId: existing.meetup.proposerId,
+          venueId: input.venueId,
+          date: input.date,
+          time: input.time,
+          round: newRound,
+        })
+        .where(eq(meetup.id, input.meetupId))
+        .returning();
+
+      domainEvents.emit("MeetupCounterProposed", {
+        meetupId: existing.meetup.id,
+        newProposerId: userId,
+        newReceiverId: existing.meetup.proposerId,
+        venueName: newVenue.name,
+        date: input.date,
+        time: input.time,
+        round: newRound,
+        counterProposedAt: new Date(),
+      });
+
+      return updated;
+    }),
+
   // #75 — Accept a pending proposal → confirm meetup, emit MeetupConfirmed
   acceptProposal: protectedProcedure
     .input(z.object({ meetupId: z.string() }))


### PR DESCRIPTION
## Summary
- Adds `counterPropose` tRPC procedure with full validation: receiver-only, pending status, max-3-rounds enforcement, no-op detection (same venue+date+time rejected), future datetime, active venue
- Swaps `proposerId`/`receiverId` so the counter-proposer becomes the new proposer and the original proposer becomes the new responder
- Emits `MeetupCounterProposed` domain event; push notification sent to the new receiver

## Test plan
- [x] Original proposer (new receiver) notified when counter-proposal arrives
- [x] No notification sent when new receiver has no device token

Closes #76