### PR TITLE
feat(meetup): decline proposal — reset to Matched state, notify both students

### DIFF
--- a/apps/server/src/__tests__/notifications-meetup-declined.test.ts
+++ b/apps/server/src/__tests__/notifications-meetup-declined.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Tests for task #77 — Push notification on MeetupDeclined
+ *
+ * Covers:
+ *   - Both Students notified when a proposal is declined
+ *   - No notification sent when neither Student has a device token
+ */
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+// ── Fetch mock ────────────────────────────────────────────────────────────────
+
+interface CapturedFetchCall {
+  url: string;
+  messages: Array<{ to: string; title?: string; body?: string; data?: Record<string, unknown> }>;
+}
+
+const fetchCalls: CapturedFetchCall[] = [];
+
+(global as unknown as { fetch: unknown }).fetch = mock(async (url: string, options: RequestInit) => {
+  fetchCalls.push({
+    url,
+    messages: JSON.parse(options.body as string) as CapturedFetchCall["messages"],
+  });
+  return {
+    json: async () => ({ data: [{ status: "ok", id: "ticket-1" }] }),
+  };
+});
+
+// ── Schema mocks ──────────────────────────────────────────────────────────────
+
+mock.module("@sip-and-speak/db/schema/sip-and-speak", () => ({
+  userDeviceToken: "userDeviceToken",
+  userLanguage: "userLanguage",
+}));
+
+mock.module("@sip-and-speak/db/schema/auth", () => ({
+  user: "user",
+}));
+
+// ── drizzle-orm mock ──────────────────────────────────────────────────────────
+
+mock.module("drizzle-orm", () => ({
+  eq: (_col: unknown, val: unknown) => ({ _val: val }),
+}));
+
+// ── DB mock ───────────────────────────────────────────────────────────────────
+
+let proposerTokens: Array<{ id: string; token: string }> = [];
+let receiverTokens: Array<{ id: string; token: string }> = [];
+const PROPOSER_ID = "proposer-abc";
+const RECEIVER_ID = "receiver-xyz";
+
+mock.module("@sip-and-speak/db", () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: (clause: { _val: string }) => {
+          const tokens = clause._val === PROPOSER_ID ? proposerTokens : receiverTokens;
+          return Promise.resolve(tokens);
+        },
+      }),
+    }),
+  },
+}));
+
+// ── Subject under test ────────────────────────────────────────────────────────
+
+import { registerNotificationHandlers } from "../notifications";
+import { domainEvents } from "@sip-and-speak/api/domain-events";
+
+describe("handleMeetupDeclined", () => {
+  beforeEach(() => {
+    fetchCalls.length = 0;
+    proposerTokens = [];
+    receiverTokens = [];
+    registerNotificationHandlers();
+  });
+
+  it("notifies both Students when a proposal is declined", async () => {
+    proposerTokens = [{ id: "pt-1", token: "ExponentPushToken[proposer-token]" }];
+    receiverTokens = [{ id: "rt-1", token: "ExponentPushToken[receiver-token]" }];
+
+    domainEvents.emit("MeetupDeclined", {
+      meetupId: "meetup-1",
+      proposerId: PROPOSER_ID,
+      receiverId: RECEIVER_ID,
+      declinedAt: new Date(),
+    });
+
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(fetchCalls.length).toBe(1);
+    const msgs = fetchCalls[0]!.messages;
+    expect(msgs.length).toBe(2);
+    expect(msgs.map((m) => m.to)).toContain("ExponentPushToken[proposer-token]");
+    expect(msgs.map((m) => m.to)).toContain("ExponentPushToken[receiver-token]");
+    expect(msgs[0]!.title).toBe("Meetup proposal declined");
+  });
+
+  it("sends no notification when neither Student has a device token", async () => {
+    proposerTokens = [];
+    receiverTokens = [];
+
+    domainEvents.emit("MeetupDeclined", {
+      meetupId: "meetup-2",
+      proposerId: PROPOSER_ID,
+      receiverId: RECEIVER_ID,
+      declinedAt: new Date(),
+    });
+
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(fetchCalls.length).toBe(0);
+  });
+});

--- a/packages/api/src/routers/meetup.ts
+++ b/packages/api/src/routers/meetup.ts
@@ -323,6 +323,54 @@ export const meetupRouter = router({
       return updated;
     }),
 
+  // #77 — Decline a pending proposal → reset to Matched state, emit MeetupDeclined
+  declineProposal: protectedProcedure
+    .input(z.object({ meetupId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+
+      const [existing] = await db
+        .select()
+        .from(meetup)
+        .where(eq(meetup.id, input.meetupId))
+        .limit(1);
+
+      if (!existing) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Meetup not found" });
+      }
+
+      if (existing.receiverId !== userId) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "Only the current responder can decline this proposal",
+        });
+      }
+
+      if (existing.status !== "pending") {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message: "This proposal has already been responded to",
+        });
+      }
+
+      const [updated] = await db
+        .update(meetup)
+        .set({ status: "declined" })
+        .where(eq(meetup.id, input.meetupId))
+        .returning();
+
+      // Pair returns to Matched state — no DB action needed, Matched state is
+      // derived from studentMatch record existing with no pending meetup.
+      domainEvents.emit("MeetupDeclined", {
+        meetupId: existing.id,
+        proposerId: existing.proposerId,
+        receiverId: existing.receiverId,
+        declinedAt: new Date(),
+      });
+
+      return updated;
+    }),
+
   // #75 — Accept a pending proposal → confirm meetup, emit MeetupConfirmed
   acceptProposal: protectedProcedure
     .input(z.object({ meetupId: z.string() }))


### PR DESCRIPTION
## Summary
- Adds `declineProposal` tRPC procedure: receiver-only, pending status check, transitions meetup to `declined`, emits `MeetupDeclined`
- Matched state is derived (studentMatch record with no pending meetup) — no extra DB cleanup needed
- Both students receive a push notification on decline

## Test plan
- [x] Both students notified when a proposal is declined
- [x] No notification sent when neither student has a device token

Closes #77