### PR TITLE
feat(meetup): student can respond to a meetup proposal (#21)

### DIFF
--- a/apps/native/__tests__/respond-meetup.test.tsx
+++ b/apps/native/__tests__/respond-meetup.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * Tests for task #71 — Build proposal response UI (accept / counter-propose / decline)
+ * Tests for task #73 — Enforce max 3 counter-proposal rounds — remove counter option at round 3
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react-native";
+import React from "react";
+
+// ── Router mock ───────────────────────────────────────────────────────────────
+
+const mockBack = jest.fn();
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ back: mockBack }),
+  useLocalSearchParams: () => ({}),
+}));
+
+// ── tRPC / query mock ─────────────────────────────────────────────────────────
+
+const mockAccept = jest.fn().mockResolvedValue({ id: "m-1", status: "confirmed" });
+const mockCounter = jest.fn().mockResolvedValue({ id: "m-1" });
+const mockDecline = jest.fn().mockResolvedValue({ id: "m-1", status: "declined" });
+const mockInvalidate = jest.fn();
+
+const baseProposal = {
+  meetupId: "meetup-1",
+  round: 1,
+  canCounterPropose: true,
+  venue: { id: "v-1", name: "Atlas Building", description: null, photoUrl: null },
+  date: "2026-06-01",
+  time: "14:00",
+  proposer: { id: "proposer-1", name: "Alice", image: null },
+};
+
+let mockProposalData: typeof baseProposal | null = baseProposal;
+
+jest.mock("@/utils/trpc", () => ({
+  trpc: {
+    meetup: {
+      getPendingIncoming: {
+        queryOptions: () => ({ queryKey: ["getPendingIncoming"], queryFn: async () => mockProposalData }),
+      },
+      acceptProposal: {
+        mutationOptions: (opts: { onSuccess?: () => void; onError?: (e: Error) => void }) => ({
+          mutationFn: mockAccept,
+          onSuccess: opts.onSuccess,
+          onError: opts.onError,
+        }),
+      },
+      counterPropose: {
+        mutationOptions: (opts: { onSuccess?: () => void; onError?: (e: Error) => void }) => ({
+          mutationFn: mockCounter,
+          onSuccess: opts.onSuccess,
+          onError: opts.onError,
+        }),
+      },
+      declineProposal: {
+        mutationOptions: (opts: { onSuccess?: () => void; onError?: (e: Error) => void }) => ({
+          mutationFn: mockDecline,
+          onSuccess: opts.onSuccess,
+          onError: opts.onError,
+        }),
+      },
+      list: { queryOptions: () => ({ queryKey: ["list"] }) },
+      pendingCount: { queryOptions: () => ({ queryKey: ["pendingCount"] }) },
+      getAvailableSlots: {
+        queryOptions: () => ({ queryKey: ["slots"], queryFn: async () => [] }),
+      },
+    },
+    venue: {
+      listForPicker: {
+        queryOptions: () => ({
+          queryKey: ["venues"],
+          queryFn: async () => [{ id: "v-1", name: "Atlas Building", description: null }],
+        }),
+      },
+    },
+  },
+  queryClient: { invalidateQueries: mockInvalidate },
+}));
+
+import RespondMeetupScreen from "../app/respond-meetup";
+
+function renderWithQuery(ui: React.ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+}
+
+beforeEach(() => {
+  mockBack.mockClear();
+  mockAccept.mockClear();
+  mockCounter.mockClear();
+  mockDecline.mockClear();
+  mockInvalidate.mockClear();
+  mockProposalData = { ...baseProposal, round: 1, canCounterPropose: true };
+});
+
+// ─── Task #71: proposal details displayed ─────────────────────────────────────
+
+describe("#71 — Proposal response UI", () => {
+  it("displays the proposed location, date/time, and round number", async () => {
+    renderWithQuery(<RespondMeetupScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("round-label")).toBeTruthy();
+      expect(screen.getByTestId("proposal-venue")).toBeTruthy();
+      expect(screen.getByTestId("proposal-date")).toBeTruthy();
+      expect(screen.getByTestId("proposal-time")).toBeTruthy();
+    });
+
+    const roundChildren = screen.getByTestId("round-label").props.children;
+    const roundText = Array.isArray(roundChildren) ? roundChildren.join("") : String(roundChildren);
+    expect(roundText).toContain("Round 1");
+    expect(screen.getByTestId("proposal-venue").props.children).toBe("Atlas Building");
+    expect(screen.getByTestId("proposal-date").props.children).toBe("2026-06-01");
+    expect(screen.getByTestId("proposal-time").props.children).toBe("14:00");
+  });
+
+  it("shows Accept, Counter-propose, and Decline actions at round 1", async () => {
+    renderWithQuery(<RespondMeetupScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("accept-btn")).toBeTruthy();
+      expect(screen.getByTestId("counter-propose-btn")).toBeTruthy();
+      expect(screen.getByTestId("decline-btn")).toBeTruthy();
+    });
+  });
+
+  it("shows empty state when there is no incoming proposal", async () => {
+    mockProposalData = null;
+    renderWithQuery(<RespondMeetupScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("no-proposal-state")).toBeTruthy();
+    });
+  });
+});
+
+// ─── Task #73: round 3 hides counter-propose ──────────────────────────────────
+
+describe("#73 — Round enforcement in UI", () => {
+  it("hides Counter-propose action at round 3", async () => {
+    mockProposalData = { ...baseProposal, round: 3, canCounterPropose: false };
+
+    renderWithQuery(<RespondMeetupScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("accept-btn")).toBeTruthy();
+    });
+
+    expect(screen.queryByTestId("counter-propose-btn")).toBeNull();
+    expect(screen.getByTestId("decline-btn")).toBeTruthy();
+  });
+
+  it("shows Counter-propose action at round 2", async () => {
+    mockProposalData = { ...baseProposal, round: 2, canCounterPropose: true };
+
+    renderWithQuery(<RespondMeetupScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("counter-propose-btn")).toBeTruthy();
+    });
+  });
+});

--- a/apps/native/app/_layout.tsx
+++ b/apps/native/app/_layout.tsx
@@ -115,6 +115,7 @@ function StackLayout() {
       <Stack.Screen name="chat/[conversationId]" options={{ title: "Chat" }} />
       <Stack.Screen name="map" options={{ title: "Campus Map" }} />
       <Stack.Screen name="suggestions" options={{ title: "Suggestions" }} />
+      <Stack.Screen name="respond-meetup" options={{ title: "Respond to Proposal" }} />
       <Stack.Screen name="modal" options={{ title: "Modal", presentation: "modal" }} />
     </Stack>
   );

--- a/apps/native/app/respond-meetup.tsx
+++ b/apps/native/app/respond-meetup.tsx
@@ -1,0 +1,304 @@
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { Button, Spinner } from "heroui-native";
+import { useState } from "react";
+import { Alert, ScrollView, Text, TextInput, TouchableOpacity, View } from "react-native";
+
+import { Container } from "@/components/container";
+import { trpc, queryClient } from "@/utils/trpc";
+
+export default function RespondMeetupScreen() {
+  const router = useRouter();
+  // meetupId may be passed via deep-link from a notification tap
+  const { meetupId: meetupIdParam } = useLocalSearchParams<{ meetupId?: string }>();
+
+  const [counterMode, setCounterMode] = useState(false);
+  const [selectedVenueId, setSelectedVenueId] = useState<string | null>(null);
+  const [date, setDate] = useState("");
+  const [time, setTime] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const proposalQuery = useQuery(trpc.meetup.getPendingIncoming.queryOptions());
+  const venuesQuery = useQuery(trpc.venue.listForPicker.queryOptions());
+  const slotsQuery = useQuery(
+    trpc.meetup.getAvailableSlots.queryOptions(
+      { partnerId: proposalQuery.data?.proposer.id ?? "", date },
+      { enabled: !!proposalQuery.data?.proposer.id && !!date },
+    ),
+  );
+
+  const proposal = proposalQuery.data;
+  // Prefer the deep-linked meetupId, fall back to incoming proposal from query
+  const activeMeetupId = meetupIdParam ?? proposal?.meetupId;
+
+  function invalidateAndGoBack() {
+    void queryClient.invalidateQueries(trpc.meetup.getPendingIncoming.queryOptions());
+    void queryClient.invalidateQueries(trpc.meetup.list.queryOptions({ status: "pending" }));
+    void queryClient.invalidateQueries(trpc.meetup.pendingCount.queryOptions());
+    router.back();
+  }
+
+  const acceptMutation = useMutation(
+    trpc.meetup.acceptProposal.mutationOptions({
+      onSuccess: () => {
+        Alert.alert("Meetup confirmed!", "Your meetup has been confirmed.");
+        invalidateAndGoBack();
+      },
+      onError: (err) => setError(err.message),
+    }),
+  );
+
+  const counterMutation = useMutation(
+    trpc.meetup.counterPropose.mutationOptions({
+      onSuccess: () => {
+        Alert.alert("Counter-proposal sent!", "Your counter-proposal has been sent.");
+        invalidateAndGoBack();
+      },
+      onError: (err) => setError(err.message),
+    }),
+  );
+
+  const declineMutation = useMutation(
+    trpc.meetup.declineProposal.mutationOptions({
+      onSuccess: () => {
+        Alert.alert("Proposal declined", "The proposal has been declined.");
+        invalidateAndGoBack();
+      },
+      onError: (err) => setError(err.message),
+    }),
+  );
+
+  if (proposalQuery.isPending) {
+    return (
+      <Container isScrollable={false}>
+        <View className="flex-1 items-center justify-center">
+          <Spinner />
+        </View>
+      </Container>
+    );
+  }
+
+  if (!proposal || !activeMeetupId) {
+    return (
+      <Container isScrollable={false}>
+        <View testID="no-proposal-state" className="flex-1 items-center justify-center p-6">
+          <Text className="text-foreground text-lg font-semibold text-center mb-2">
+            No incoming proposals
+          </Text>
+          <Text className="text-muted-foreground text-center">
+            There are no pending meetup proposals waiting for your response.
+          </Text>
+        </View>
+      </Container>
+    );
+  }
+
+  const isPending =
+    acceptMutation.isPending ||
+    counterMutation.isPending ||
+    declineMutation.isPending;
+
+  function handleAccept() {
+    setError(null);
+    acceptMutation.mutate({ meetupId: activeMeetupId! });
+  }
+
+  function handleDecline() {
+    setError(null);
+    Alert.alert(
+      "Decline proposal",
+      "Are you sure you want to decline this meetup proposal?",
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Decline",
+          style: "destructive",
+          onPress: () => declineMutation.mutate({ meetupId: activeMeetupId! }),
+        },
+      ],
+    );
+  }
+
+  function handleCounterSubmit() {
+    setError(null);
+    if (!selectedVenueId) { setError("Please select a location"); return; }
+    if (!date.match(/^\d{4}-\d{2}-\d{2}$/)) { setError("Enter a date in YYYY-MM-DD format"); return; }
+    if (!time.match(/^\d{2}:\d{2}$/)) { setError("Enter a time in HH:MM format"); return; }
+    const proposed = new Date(`${date}T${time}:00`);
+    if (proposed <= new Date()) { setError("Date and time must be in the future"); return; }
+    counterMutation.mutate({ meetupId: activeMeetupId!, venueId: selectedVenueId, date, time });
+  }
+
+  if (counterMode) {
+    return (
+      <Container>
+        <ScrollView contentContainerStyle={{ padding: 16 }}>
+          <Text className="text-foreground text-2xl font-bold mb-1">Counter-propose</Text>
+          <Text testID="counter-round-label" className="text-muted-foreground text-sm mb-6">
+            Round {proposal.round + 1} of 3
+          </Text>
+
+          <Text className="text-foreground font-semibold mb-2">Location</Text>
+          {venuesQuery.isPending ? (
+            <Spinner />
+          ) : (
+            <View className="flex flex-col gap-2 mb-6">
+              {(venuesQuery.data ?? []).map((v) => (
+                <TouchableOpacity
+                  key={v.id}
+                  testID="venue-option"
+                  onPress={() => setSelectedVenueId(v.id)}
+                  className={`border rounded-xl p-3 ${selectedVenueId === v.id ? "border-primary bg-primary/10" : "border-border bg-card"}`}
+                >
+                  <Text className={`font-medium ${selectedVenueId === v.id ? "text-primary" : "text-foreground"}`}>
+                    {v.name}
+                  </Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+          )}
+
+          <Text className="text-foreground font-semibold mb-2">Date (YYYY-MM-DD)</Text>
+          <TextInput
+            testID="counter-date-input"
+            value={date}
+            onChangeText={(t) => { setDate(t); setError(null); }}
+            placeholder="2026-05-01"
+            className="border border-border rounded-xl px-3 py-2 text-foreground bg-card mb-6"
+            placeholderTextColor="#888"
+          />
+
+          <Text className="text-foreground font-semibold mb-2">Time</Text>
+          {date && slotsQuery.data ? (
+            <View className="flex flex-row flex-wrap gap-2 mb-6">
+              {slotsQuery.data.map((slot) => (
+                <TouchableOpacity
+                  key={slot}
+                  testID="time-slot"
+                  onPress={() => setTime(slot)}
+                  className={`border rounded-lg px-3 py-1.5 ${time === slot ? "border-primary bg-primary/10" : "border-border bg-card"}`}
+                >
+                  <Text className={time === slot ? "text-primary font-medium" : "text-foreground"}>{slot}</Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+          ) : (
+            <TextInput
+              testID="counter-time-input"
+              value={time}
+              onChangeText={(t) => { setTime(t); setError(null); }}
+              placeholder="14:00"
+              className="border border-border rounded-xl px-3 py-2 text-foreground bg-card mb-6"
+              placeholderTextColor="#888"
+            />
+          )}
+
+          {error && (
+            <Text testID="counter-error" className="text-destructive text-sm mb-4">{error}</Text>
+          )}
+
+          <View className="flex flex-col gap-3">
+            <Button
+              testID="submit-counter-btn"
+              onPress={handleCounterSubmit}
+              isDisabled={isPending}
+            >
+              <Button.Label>
+                {counterMutation.isPending ? "Sending…" : "Send counter-proposal"}
+              </Button.Label>
+            </Button>
+            <Button
+              variant="ghost"
+              onPress={() => { setCounterMode(false); setError(null); }}
+              isDisabled={isPending}
+            >
+              <Button.Label>Back</Button.Label>
+            </Button>
+          </View>
+        </ScrollView>
+      </Container>
+    );
+  }
+
+  return (
+    <Container>
+      <ScrollView contentContainerStyle={{ padding: 16 }}>
+        <Text className="text-foreground text-2xl font-bold mb-1">Meetup proposal</Text>
+        <Text testID="round-label" className="text-muted-foreground text-sm mb-6">
+          Round {proposal.round} of 3
+        </Text>
+
+        <View className="bg-card border border-border rounded-2xl p-4 mb-6">
+          <Text testID="proposer-name" className="text-foreground font-semibold text-base mb-4">
+            From {proposal.proposer.name}
+          </Text>
+
+          <View className="flex flex-col gap-2">
+            <View className="flex-row items-center gap-2">
+              <Text className="text-muted-foreground text-sm w-20">Location</Text>
+              <Text testID="proposal-venue" className="text-foreground font-medium flex-1">
+                {proposal.venue.name}
+              </Text>
+            </View>
+            <View className="flex-row items-center gap-2">
+              <Text className="text-muted-foreground text-sm w-20">Date</Text>
+              <Text testID="proposal-date" className="text-foreground font-medium flex-1">
+                {proposal.date}
+              </Text>
+            </View>
+            <View className="flex-row items-center gap-2">
+              <Text className="text-muted-foreground text-sm w-20">Time</Text>
+              <Text testID="proposal-time" className="text-foreground font-medium flex-1">
+                {proposal.time}
+              </Text>
+            </View>
+          </View>
+        </View>
+
+        {error && (
+          <Text testID="response-error" className="text-destructive text-sm mb-4">{error}</Text>
+        )}
+
+        <View className="flex flex-col gap-3">
+          <Button
+            testID="accept-btn"
+            onPress={handleAccept}
+            isDisabled={isPending}
+          >
+            <Button.Label>
+              {acceptMutation.isPending ? "Accepting…" : "Accept"}
+            </Button.Label>
+          </Button>
+
+          {/* #73 — Counter-propose only available when round < 3 */}
+          {proposal.canCounterPropose && (
+            <Button
+              testID="counter-propose-btn"
+              variant="secondary"
+              onPress={() => {
+                setSelectedVenueId(proposal.venue.id);
+                setDate(proposal.date);
+                setTime(proposal.time);
+                setCounterMode(true);
+              }}
+              isDisabled={isPending}
+            >
+              <Button.Label>Counter-propose</Button.Label>
+            </Button>
+          )}
+
+          <Button
+            testID="decline-btn"
+            variant="ghost"
+            onPress={handleDecline}
+            isDisabled={isPending}
+          >
+            <Button.Label>
+              {declineMutation.isPending ? "Declining…" : "Decline"}
+            </Button.Label>
+          </Button>
+        </View>
+      </ScrollView>
+    </Container>
+  );
+}

--- a/apps/server/src/__tests__/notifications-meetup-confirmed.test.ts
+++ b/apps/server/src/__tests__/notifications-meetup-confirmed.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Tests for task #75 — Push notification on MeetupConfirmed
+ *
+ * Covers:
+ *   - Both Students notified when a meetup is confirmed
+ *   - No notification sent when neither Student has a device token
+ */
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+// ── Fetch mock ────────────────────────────────────────────────────────────────
+
+interface CapturedFetchCall {
+  url: string;
+  messages: Array<{ to: string; title?: string; body?: string; data?: Record<string, unknown> }>;
+}
+
+const fetchCalls: CapturedFetchCall[] = [];
+
+(global as unknown as { fetch: unknown }).fetch = mock(async (url: string, options: RequestInit) => {
+  fetchCalls.push({
+    url,
+    messages: JSON.parse(options.body as string) as CapturedFetchCall["messages"],
+  });
+  return {
+    json: async () => ({ data: [{ status: "ok", id: "ticket-1" }] }),
+  };
+});
+
+// ── Schema mocks ──────────────────────────────────────────────────────────────
+
+const DEVICE_TOKEN_TABLE = "userDeviceToken";
+
+mock.module("@sip-and-speak/db/schema/sip-and-speak", () => ({
+  userDeviceToken: DEVICE_TOKEN_TABLE,
+  userLanguage: "userLanguage",
+}));
+
+mock.module("@sip-and-speak/db/schema/auth", () => ({
+  user: "user",
+}));
+
+// ── drizzle-orm mock ──────────────────────────────────────────────────────────
+
+mock.module("drizzle-orm", () => ({
+  eq: (_col: unknown, val: unknown) => ({ _val: val }),
+}));
+
+// ── DB mock ───────────────────────────────────────────────────────────────────
+
+// Track which userId is queried to return the right tokens
+let proposerTokens: Array<{ id: string; token: string }> = [];
+let receiverTokens: Array<{ id: string; token: string }> = [];
+let lastQueriedUserId = "";
+const PROPOSER_ID = "proposer-123";
+const RECEIVER_ID = "receiver-456";
+
+mock.module("@sip-and-speak/db", () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: (clause: { _val: string }) => {
+          lastQueriedUserId = clause._val;
+          const tokens = clause._val === PROPOSER_ID ? proposerTokens : receiverTokens;
+          return Promise.resolve(tokens);
+        },
+      }),
+    }),
+  },
+}));
+
+// ── Subject under test ────────────────────────────────────────────────────────
+
+import { registerNotificationHandlers } from "../notifications";
+import { domainEvents } from "@sip-and-speak/api/domain-events";
+
+describe("handleMeetupConfirmed", () => {
+  beforeEach(() => {
+    fetchCalls.length = 0;
+    proposerTokens = [];
+    receiverTokens = [];
+    registerNotificationHandlers();
+  });
+
+  it("notifies both Students when a meetup is confirmed", async () => {
+    proposerTokens = [{ id: "pt-1", token: "ExponentPushToken[proposer-token]" }];
+    receiverTokens = [{ id: "rt-1", token: "ExponentPushToken[receiver-token]" }];
+
+    domainEvents.emit("MeetupConfirmed", {
+      meetupId: "meetup-1",
+      proposerId: PROPOSER_ID,
+      receiverId: RECEIVER_ID,
+      venueName: "Atlas Building",
+      date: "2026-05-10",
+      time: "14:00",
+      confirmedAt: new Date(),
+    });
+
+    // Allow async handler to flush
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(fetchCalls.length).toBe(1);
+    const sentMessages = fetchCalls[0]!.messages;
+    expect(sentMessages.length).toBe(2);
+    expect(sentMessages.map((m) => m.to)).toContain("ExponentPushToken[proposer-token]");
+    expect(sentMessages.map((m) => m.to)).toContain("ExponentPushToken[receiver-token]");
+    expect(sentMessages[0]!.title).toBe("Meetup confirmed! 🎉");
+    expect(sentMessages[0]!.body).toContain("Atlas Building");
+  });
+
+  it("sends no notification when neither Student has a device token", async () => {
+    proposerTokens = [];
+    receiverTokens = [];
+
+    domainEvents.emit("MeetupConfirmed", {
+      meetupId: "meetup-2",
+      proposerId: PROPOSER_ID,
+      receiverId: RECEIVER_ID,
+      venueName: "Flux",
+      date: "2026-05-11",
+      time: "10:00",
+      confirmedAt: new Date(),
+    });
+
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(fetchCalls.length).toBe(0);
+  });
+});

--- a/apps/server/src/__tests__/notifications-meetup-counter-proposed.test.ts
+++ b/apps/server/src/__tests__/notifications-meetup-counter-proposed.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for task #76 — Push notification on MeetupCounterProposed
+ *
+ * Covers:
+ *   - Original proposer (now the new receiver) notified when a counter-proposal arrives
+ *   - No notification sent when the new receiver has no device token
+ */
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+// ── Fetch mock ────────────────────────────────────────────────────────────────
+
+interface CapturedFetchCall {
+  url: string;
+  messages: Array<{ to: string; title?: string; body?: string; data?: Record<string, unknown> }>;
+}
+
+const fetchCalls: CapturedFetchCall[] = [];
+
+(global as unknown as { fetch: unknown }).fetch = mock(async (url: string, options: RequestInit) => {
+  fetchCalls.push({
+    url,
+    messages: JSON.parse(options.body as string) as CapturedFetchCall["messages"],
+  });
+  return {
+    json: async () => ({ data: [{ status: "ok", id: "ticket-1" }] }),
+  };
+});
+
+// ── Schema mocks ──────────────────────────────────────────────────────────────
+
+mock.module("@sip-and-speak/db/schema/sip-and-speak", () => ({
+  userDeviceToken: "userDeviceToken",
+  userLanguage: "userLanguage",
+}));
+
+mock.module("@sip-and-speak/db/schema/auth", () => ({
+  user: "user",
+}));
+
+// ── drizzle-orm mock ──────────────────────────────────────────────────────────
+
+mock.module("drizzle-orm", () => ({
+  eq: (_col: unknown, val: unknown) => ({ _val: val }),
+}));
+
+// ── DB mock ───────────────────────────────────────────────────────────────────
+
+let mockTokenRows: Array<{ id: string; token: string }> = [];
+const ORIGINAL_PROPOSER_ID = "orig-proposer-123"; // becomes newReceiverId after counter
+
+mock.module("@sip-and-speak/db", () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => Promise.resolve(mockTokenRows),
+      }),
+    }),
+  },
+}));
+
+// ── Subject under test ────────────────────────────────────────────────────────
+
+import { registerNotificationHandlers } from "../notifications";
+import { domainEvents } from "@sip-and-speak/api/domain-events";
+
+describe("handleMeetupCounterProposed", () => {
+  beforeEach(() => {
+    fetchCalls.length = 0;
+    mockTokenRows = [];
+    registerNotificationHandlers();
+  });
+
+  it("notifies the original proposer (new receiver) of the counter-proposal", async () => {
+    mockTokenRows = [{ id: "token-1", token: "ExponentPushToken[orig-proposer]" }];
+
+    domainEvents.emit("MeetupCounterProposed", {
+      meetupId: "meetup-1",
+      newProposerId: "counter-proposer-456",
+      newReceiverId: ORIGINAL_PROPOSER_ID,
+      venueName: "Vertigo",
+      date: "2026-05-15",
+      time: "10:30",
+      round: 2,
+      counterProposedAt: new Date(),
+    });
+
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(fetchCalls.length).toBe(1);
+    const msg = fetchCalls[0]!.messages[0]!;
+    expect(msg.to).toBe("ExponentPushToken[orig-proposer]");
+    expect(msg.title).toContain("round 2");
+    expect(msg.body).toContain("Vertigo");
+  });
+
+  it("sends no notification when new receiver has no device token", async () => {
+    mockTokenRows = [];
+
+    domainEvents.emit("MeetupCounterProposed", {
+      meetupId: "meetup-2",
+      newProposerId: "counter-proposer-456",
+      newReceiverId: ORIGINAL_PROPOSER_ID,
+      venueName: "Atlas",
+      date: "2026-05-16",
+      time: "11:00",
+      round: 2,
+      counterProposedAt: new Date(),
+    });
+
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(fetchCalls.length).toBe(0);
+  });
+});

--- a/apps/server/src/__tests__/notifications-meetup-declined.test.ts
+++ b/apps/server/src/__tests__/notifications-meetup-declined.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Tests for task #77 — Push notification on MeetupDeclined
+ *
+ * Covers:
+ *   - Both Students notified when a proposal is declined
+ *   - No notification sent when neither Student has a device token
+ */
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+// ── Fetch mock ────────────────────────────────────────────────────────────────
+
+interface CapturedFetchCall {
+  url: string;
+  messages: Array<{ to: string; title?: string; body?: string; data?: Record<string, unknown> }>;
+}
+
+const fetchCalls: CapturedFetchCall[] = [];
+
+(global as unknown as { fetch: unknown }).fetch = mock(async (url: string, options: RequestInit) => {
+  fetchCalls.push({
+    url,
+    messages: JSON.parse(options.body as string) as CapturedFetchCall["messages"],
+  });
+  return {
+    json: async () => ({ data: [{ status: "ok", id: "ticket-1" }] }),
+  };
+});
+
+// ── Schema mocks ──────────────────────────────────────────────────────────────
+
+mock.module("@sip-and-speak/db/schema/sip-and-speak", () => ({
+  userDeviceToken: "userDeviceToken",
+  userLanguage: "userLanguage",
+}));
+
+mock.module("@sip-and-speak/db/schema/auth", () => ({
+  user: "user",
+}));
+
+// ── drizzle-orm mock ──────────────────────────────────────────────────────────
+
+mock.module("drizzle-orm", () => ({
+  eq: (_col: unknown, val: unknown) => ({ _val: val }),
+}));
+
+// ── DB mock ───────────────────────────────────────────────────────────────────
+
+let proposerTokens: Array<{ id: string; token: string }> = [];
+let receiverTokens: Array<{ id: string; token: string }> = [];
+const PROPOSER_ID = "proposer-abc";
+const RECEIVER_ID = "receiver-xyz";
+
+mock.module("@sip-and-speak/db", () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: (clause: { _val: string }) => {
+          const tokens = clause._val === PROPOSER_ID ? proposerTokens : receiverTokens;
+          return Promise.resolve(tokens);
+        },
+      }),
+    }),
+  },
+}));
+
+// ── Subject under test ────────────────────────────────────────────────────────
+
+import { registerNotificationHandlers } from "../notifications";
+import { domainEvents } from "@sip-and-speak/api/domain-events";
+
+describe("handleMeetupDeclined", () => {
+  beforeEach(() => {
+    fetchCalls.length = 0;
+    proposerTokens = [];
+    receiverTokens = [];
+    registerNotificationHandlers();
+  });
+
+  it("notifies both Students when a proposal is declined", async () => {
+    proposerTokens = [{ id: "pt-1", token: "ExponentPushToken[proposer-token]" }];
+    receiverTokens = [{ id: "rt-1", token: "ExponentPushToken[receiver-token]" }];
+
+    domainEvents.emit("MeetupDeclined", {
+      meetupId: "meetup-1",
+      proposerId: PROPOSER_ID,
+      receiverId: RECEIVER_ID,
+      declinedAt: new Date(),
+    });
+
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(fetchCalls.length).toBe(1);
+    const msgs = fetchCalls[0]!.messages;
+    expect(msgs.length).toBe(2);
+    expect(msgs.map((m) => m.to)).toContain("ExponentPushToken[proposer-token]");
+    expect(msgs.map((m) => m.to)).toContain("ExponentPushToken[receiver-token]");
+    expect(msgs[0]!.title).toBe("Meetup proposal declined");
+  });
+
+  it("sends no notification when neither Student has a device token", async () => {
+    proposerTokens = [];
+    receiverTokens = [];
+
+    domainEvents.emit("MeetupDeclined", {
+      meetupId: "meetup-2",
+      proposerId: PROPOSER_ID,
+      receiverId: RECEIVER_ID,
+      declinedAt: new Date(),
+    });
+
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(fetchCalls.length).toBe(0);
+  });
+});

--- a/apps/server/src/notifications.ts
+++ b/apps/server/src/notifications.ts
@@ -8,7 +8,7 @@ import { eq } from "drizzle-orm";
 import { db } from "@sip-and-speak/db";
 import { userDeviceToken, userLanguage } from "@sip-and-speak/db/schema/sip-and-speak";
 import { user } from "@sip-and-speak/db/schema/auth";
-import { domainEvents, type MatchRequestSentEvent, type MatchRequestAcceptedEvent, type MatchRequestDeclinedEvent, type MeetupProposedEvent } from "@sip-and-speak/api/domain-events";
+import { domainEvents, type MatchRequestSentEvent, type MatchRequestAcceptedEvent, type MatchRequestDeclinedEvent, type MeetupProposedEvent, type MeetupConfirmedEvent, type MeetupCounterProposedEvent, type MeetupDeclinedEvent } from "@sip-and-speak/api/domain-events";
 import { buildMatchRequestNotificationBody } from "@sip-and-speak/api/routers/matching-utils";
 
 const EXPO_PUSH_URL = "https://exp.host/--/api/v2/push/send";
@@ -259,6 +259,82 @@ async function handleMeetupProposed(event: MeetupProposedEvent): Promise<void> {
   }
 }
 
+// #75 — Notify both Students when a meetup is confirmed
+async function handleMeetupConfirmed(event: MeetupConfirmedEvent): Promise<void> {
+  const { meetupId, proposerId, receiverId, venueName, date, time } = event;
+
+  const [proposerTokens, receiverTokens] = await Promise.all([
+    db.select({ id: userDeviceToken.id, token: userDeviceToken.token }).from(userDeviceToken).where(eq(userDeviceToken.userId, proposerId)),
+    db.select({ id: userDeviceToken.id, token: userDeviceToken.token }).from(userDeviceToken).where(eq(userDeviceToken.userId, receiverId)),
+  ]);
+
+  const allTokens = [...proposerTokens, ...receiverTokens];
+  if (allTokens.length === 0) return;
+
+  const messages: ExpoPushMessage[] = allTokens.map(({ token }) => ({
+    to: token,
+    title: "Meetup confirmed! 🎉",
+    body: `${venueName} · ${date} at ${time}`,
+    data: { meetupId, type: "meetup_confirmed" },
+  }));
+
+  try {
+    await sendExpoPushNotification(messages);
+  } catch (err) {
+    console.error("[push] Failed to send MeetupConfirmed notification", { meetupId, err });
+  }
+}
+
+// #76 — Notify the original proposer that a counter-proposal has been made
+async function handleMeetupCounterProposed(event: MeetupCounterProposedEvent): Promise<void> {
+  const { meetupId, newReceiverId, venueName, date, time, round } = event;
+
+  const tokens = await db
+    .select({ id: userDeviceToken.id, token: userDeviceToken.token })
+    .from(userDeviceToken)
+    .where(eq(userDeviceToken.userId, newReceiverId));
+  if (tokens.length === 0) return;
+
+  const messages: ExpoPushMessage[] = tokens.map(({ token }) => ({
+    to: token,
+    title: `Counter-proposal received (round ${round})`,
+    body: `${venueName} · ${date} at ${time}`,
+    data: { meetupId, type: "meetup_counter_proposed", round },
+  }));
+
+  try {
+    await sendExpoPushNotification(messages);
+  } catch (err) {
+    console.error("[push] Failed to send MeetupCounterProposed notification", { meetupId, err });
+  }
+}
+
+// #77 — Notify both Students when a proposal is declined
+async function handleMeetupDeclined(event: MeetupDeclinedEvent): Promise<void> {
+  const { meetupId, proposerId, receiverId } = event;
+
+  const [proposerTokens, receiverTokens] = await Promise.all([
+    db.select({ id: userDeviceToken.id, token: userDeviceToken.token }).from(userDeviceToken).where(eq(userDeviceToken.userId, proposerId)),
+    db.select({ id: userDeviceToken.id, token: userDeviceToken.token }).from(userDeviceToken).where(eq(userDeviceToken.userId, receiverId)),
+  ]);
+
+  const allTokens = [...proposerTokens, ...receiverTokens];
+  if (allTokens.length === 0) return;
+
+  const messages: ExpoPushMessage[] = allTokens.map(({ token }) => ({
+    to: token,
+    title: "Meetup proposal declined",
+    body: "The proposal was declined — you can start a fresh proposal",
+    data: { meetupId, type: "meetup_declined" },
+  }));
+
+  try {
+    await sendExpoPushNotification(messages);
+  } catch (err) {
+    console.error("[push] Failed to send MeetupDeclined notification", { meetupId, err });
+  }
+}
+
 export function registerNotificationHandlers(): void {
   domainEvents.on("MatchRequestSent", (event) => {
     // Fire and forget — do not await, must not block the mutation response
@@ -272,5 +348,14 @@ export function registerNotificationHandlers(): void {
   });
   domainEvents.on("MeetupProposed", (event) => {
     void handleMeetupProposed(event);
+  });
+  domainEvents.on("MeetupConfirmed", (event) => {
+    void handleMeetupConfirmed(event);
+  });
+  domainEvents.on("MeetupCounterProposed", (event) => {
+    void handleMeetupCounterProposed(event);
+  });
+  domainEvents.on("MeetupDeclined", (event) => {
+    void handleMeetupDeclined(event);
   });
 }

--- a/packages/api/src/__tests__/meetup-rounds.test.ts
+++ b/packages/api/src/__tests__/meetup-rounds.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Tests for task #73 — Enforce max 3 counter-proposal rounds
+ *
+ * Covers:
+ *   - canCounterPropose flag correctly derived from round number
+ *   - Counter-propose is only allowed when round < 3
+ */
+import { describe, it, expect } from "bun:test";
+
+/** Pure helper — mirrors the canCounterPropose logic in meetup.getPendingIncoming */
+function canCounterPropose(round: number): boolean {
+  return round < 3;
+}
+
+describe("#73 — round enforcement", () => {
+  it("allows counter-propose at round 1", () => {
+    expect(canCounterPropose(1)).toBe(true);
+  });
+
+  it("allows counter-propose at round 2", () => {
+    expect(canCounterPropose(2)).toBe(true);
+  });
+
+  it("blocks counter-propose at round 3 (maximum reached)", () => {
+    expect(canCounterPropose(3)).toBe(false);
+  });
+
+  it("blocks counter-propose beyond round 3", () => {
+    expect(canCounterPropose(4)).toBe(false);
+  });
+});

--- a/packages/api/src/domain-events.ts
+++ b/packages/api/src/domain-events.ts
@@ -46,6 +46,36 @@ export interface MeetupProposedEvent {
   proposedAt: Date;
 }
 
+export interface MeetupConfirmedEvent {
+  meetupId: string;
+  proposerId: string;
+  receiverId: string;
+  venueName: string;
+  date: string;
+  time: string;
+  confirmedAt: Date;
+}
+
+export interface MeetupCounterProposedEvent {
+  meetupId: string;
+  /** The student who just counter-proposed (new proposer after role swap) */
+  newProposerId: string;
+  /** The student who must now respond (new receiver after role swap) */
+  newReceiverId: string;
+  venueName: string;
+  date: string;
+  time: string;
+  round: number;
+  counterProposedAt: Date;
+}
+
+export interface MeetupDeclinedEvent {
+  meetupId: string;
+  proposerId: string;
+  receiverId: string;
+  declinedAt: Date;
+}
+
 type DomainEventMap = {
   LanguageProfileUpdated: [LanguageProfileUpdatedEvent];
   InterestProfileUpdated: [InterestProfileUpdatedEvent];
@@ -54,6 +84,9 @@ type DomainEventMap = {
   MatchRequestAccepted: [MatchRequestAcceptedEvent];
   MatchRequestDeclined: [MatchRequestDeclinedEvent];
   MeetupProposed: [MeetupProposedEvent];
+  MeetupConfirmed: [MeetupConfirmedEvent];
+  MeetupCounterProposed: [MeetupCounterProposedEvent];
+  MeetupDeclined: [MeetupDeclinedEvent];
 };
 
 class TypedEventEmitter extends EventEmitter {

--- a/packages/api/src/routers/meetup.ts
+++ b/packages/api/src/routers/meetup.ts
@@ -217,6 +217,56 @@ export const meetupRouter = router({
       return updated;
     }),
 
+  // #75 — Accept a pending proposal → confirm meetup, emit MeetupConfirmed
+  acceptProposal: protectedProcedure
+    .input(z.object({ meetupId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+
+      const [existing] = await db
+        .select()
+        .from(meetup)
+        .innerJoin(venue, eq(meetup.venueId, venue.id))
+        .where(eq(meetup.id, input.meetupId))
+        .limit(1);
+
+      if (!existing) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Meetup not found" });
+      }
+
+      if (existing.meetup.receiverId !== userId) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "Only the current responder can accept this proposal",
+        });
+      }
+
+      if (existing.meetup.status !== "pending") {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message: "This proposal has already been responded to",
+        });
+      }
+
+      const [updated] = await db
+        .update(meetup)
+        .set({ status: "confirmed" })
+        .where(eq(meetup.id, input.meetupId))
+        .returning();
+
+      domainEvents.emit("MeetupConfirmed", {
+        meetupId: existing.meetup.id,
+        proposerId: existing.meetup.proposerId,
+        receiverId: existing.meetup.receiverId,
+        venueName: existing.venue.name,
+        date: existing.meetup.date,
+        time: existing.meetup.time,
+        confirmedAt: new Date(),
+      });
+
+      return updated;
+    }),
+
   list: protectedProcedure
     .input(
       z.object({

--- a/packages/api/src/routers/meetup.ts
+++ b/packages/api/src/routers/meetup.ts
@@ -323,6 +323,54 @@ export const meetupRouter = router({
       return updated;
     }),
 
+  // #77 — Decline a pending proposal → reset to Matched state, emit MeetupDeclined
+  declineProposal: protectedProcedure
+    .input(z.object({ meetupId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+
+      const [existing] = await db
+        .select()
+        .from(meetup)
+        .where(eq(meetup.id, input.meetupId))
+        .limit(1);
+
+      if (!existing) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Meetup not found" });
+      }
+
+      if (existing.receiverId !== userId) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "Only the current responder can decline this proposal",
+        });
+      }
+
+      if (existing.status !== "pending") {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message: "This proposal has already been responded to",
+        });
+      }
+
+      const [updated] = await db
+        .update(meetup)
+        .set({ status: "declined" })
+        .where(eq(meetup.id, input.meetupId))
+        .returning();
+
+      // Pair returns to Matched state — no DB action needed, Matched state is
+      // derived from studentMatch record existing with no pending meetup.
+      domainEvents.emit("MeetupDeclined", {
+        meetupId: existing.id,
+        proposerId: existing.proposerId,
+        receiverId: existing.receiverId,
+        declinedAt: new Date(),
+      });
+
+      return updated;
+    }),
+
   // #75 — Accept a pending proposal → confirm meetup, emit MeetupConfirmed
   acceptProposal: protectedProcedure
     .input(z.object({ meetupId: z.string() }))

--- a/packages/api/src/routers/meetup.ts
+++ b/packages/api/src/routers/meetup.ts
@@ -520,6 +520,45 @@ export const meetupRouter = router({
       return ALL_SLOTS.filter((slot) => !busyTimes.has(slot));
     }),
 
+  // #73 — Get the pending incoming proposal for me (where I am the current receiverId)
+  getPendingIncoming: protectedProcedure.query(async ({ ctx }) => {
+    const userId = ctx.session.user.id;
+
+    const [row] = await db
+      .select({
+        meetup: meetup,
+        venue: {
+          id: venue.id,
+          name: venue.name,
+          description: venue.description,
+          photoUrl: venue.photoUrl,
+        },
+        proposer: {
+          id: sql<string>`proposer.id`.as("pi_proposer_id"),
+          name: sql<string>`proposer.name`.as("pi_proposer_name"),
+          image: sql<string | null>`proposer.image`.as("pi_proposer_image"),
+        },
+      })
+      .from(meetup)
+      .innerJoin(venue, eq(meetup.venueId, venue.id))
+      .innerJoin(sql`"user" as proposer`, sql`proposer.id = ${meetup.proposerId}`)
+      .where(and(eq(meetup.receiverId, userId), eq(meetup.status, "pending")))
+      .orderBy(meetup.createdAt)
+      .limit(1);
+
+    if (!row) return null;
+
+    return {
+      meetupId: row.meetup.id,
+      round: row.meetup.round,
+      canCounterPropose: row.meetup.round < 3,
+      venue: row.venue,
+      date: row.meetup.date,
+      time: row.meetup.time,
+      proposer: row.proposer,
+    };
+  }),
+
   pendingCount: protectedProcedure.query(async ({ ctx }) => {
     const userId = ctx.session.user.id;
 

--- a/packages/api/src/routers/meetup.ts
+++ b/packages/api/src/routers/meetup.ts
@@ -217,6 +217,112 @@ export const meetupRouter = router({
       return updated;
     }),
 
+  // #76 — Counter-propose: swap roles, update details, increment round, emit MeetupCounterProposed
+  counterPropose: protectedProcedure
+    .input(
+      z.object({
+        meetupId: z.string(),
+        venueId: z.string(),
+        date: z.string(),
+        time: z.string(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+
+      const [existing] = await db
+        .select()
+        .from(meetup)
+        .innerJoin(venue, eq(meetup.venueId, venue.id))
+        .where(eq(meetup.id, input.meetupId))
+        .limit(1);
+
+      if (!existing) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Meetup not found" });
+      }
+
+      if (existing.meetup.receiverId !== userId) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "Only the current responder can counter-propose",
+        });
+      }
+
+      if (existing.meetup.status !== "pending") {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message: "This proposal has already been responded to",
+        });
+      }
+
+      // #73 — Reject counter-propose when round is already at 3
+      if (existing.meetup.round >= 3) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Maximum counter-proposal rounds reached. You can only accept or decline.",
+        });
+      }
+
+      // Reject no-op counter-proposal (same venue, date, and time)
+      if (
+        existing.meetup.venueId === input.venueId &&
+        existing.meetup.date === input.date &&
+        existing.meetup.time === input.time
+      ) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Counter-proposal must differ from the current proposal in at least one detail",
+        });
+      }
+
+      // Future date/time validation
+      const proposedDateTime = new Date(`${input.date}T${input.time}:00`);
+      if (proposedDateTime <= new Date()) {
+        throw new TRPCError({ code: "BAD_REQUEST", message: "The proposed date and time must be in the future" });
+      }
+
+      // Active venue check
+      const [newVenue] = await db
+        .select({ id: venue.id, name: venue.name, isActive: venue.isActive })
+        .from(venue)
+        .where(eq(venue.id, input.venueId))
+        .limit(1);
+      if (!newVenue) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Location not found" });
+      }
+      if (!newVenue.isActive) {
+        throw new TRPCError({ code: "BAD_REQUEST", message: "This location is no longer available. Please choose another." });
+      }
+
+      // Swap proposer/receiver so original proposer now becomes the responder
+      const newRound = existing.meetup.round + 1;
+      const [updated] = await db
+        .update(meetup)
+        .set({
+          proposerId: userId,
+          receiverId: existing.meetup.proposerId,
+          venueId: input.venueId,
+          date: input.date,
+          time: input.time,
+          round: newRound,
+        })
+        .where(eq(meetup.id, input.meetupId))
+        .returning();
+
+      domainEvents.emit("MeetupCounterProposed", {
+        meetupId: existing.meetup.id,
+        newProposerId: userId,
+        newReceiverId: existing.meetup.proposerId,
+        venueName: newVenue.name,
+        date: input.date,
+        time: input.time,
+        round: newRound,
+        counterProposedAt: new Date(),
+      });
+
+      return updated;
+    }),
+
   // #75 — Accept a pending proposal → confirm meetup, emit MeetupConfirmed
   acceptProposal: protectedProcedure
     .input(z.object({ meetupId: z.string() }))


### PR DESCRIPTION
## Summary
- Students can accept, counter-propose, or decline an incoming meetup proposal
- Counter-proposals increment the round counter (max 3); server enforces the limit
- Role swap on counter-propose: counter-proposer becomes new proposer, original proposer becomes responder
- Both students notified on accept (confirmed) and decline; new responder notified on counter-propose
- New `respond-meetup` native screen with round visibility and conditional counter-propose action

## Tasks included
- #75 — Handle proposal acceptance → confirm meetup, notify both students
- #76 — Handle counter-proposal → swap roles, increment round, notify original proposer
- #77 — Handle proposal decline → reset to Matched state, notify both students
- #73 — Enforce max 3 counter-proposal rounds (server + UI)
- #71 — Build proposal response UI (accept / counter-propose / decline)

## New API procedures
- `trpc.meetup.acceptProposal` — confirms meetup
- `trpc.meetup.counterPropose` — full validation, role swap, round increment
- `trpc.meetup.declineProposal` — transitions to declined
- `trpc.meetup.getPendingIncoming` — query for response screen

## New domain events
- `MeetupConfirmed`, `MeetupCounterProposed`, `MeetupDeclined`

Closes #21
Closes #71
Closes #73
Closes #75
Closes #76
Closes #77