### PR TITLE
feat(meetup): cancel confirmed meetup — validation, state transition, notification

### DIFF
--- a/apps/server/src/__tests__/notifications-meetup-cancelled.test.ts
+++ b/apps/server/src/__tests__/notifications-meetup-cancelled.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Tests for task #83 — Push notification on MeetupCancelled
+ */
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+interface CapturedFetchCall {
+  url: string;
+  messages: Array<{ to: string; title?: string; body?: string; data?: Record<string, unknown> }>;
+}
+
+const fetchCalls: CapturedFetchCall[] = [];
+(global as unknown as { fetch: unknown }).fetch = mock(async (url: string, options: RequestInit) => {
+  fetchCalls.push({ url, messages: JSON.parse(options.body as string) as CapturedFetchCall["messages"] });
+  return { json: async () => ({ data: [{ status: "ok", id: "t-1" }] }) };
+});
+
+mock.module("@sip-and-speak/db/schema/sip-and-speak", () => ({ userDeviceToken: "userDeviceToken", userLanguage: "userLanguage" }));
+mock.module("@sip-and-speak/db/schema/auth", () => ({ user: "user" }));
+mock.module("drizzle-orm", () => ({ eq: (_col: unknown, val: unknown) => ({ _val: val }) }));
+
+let mockTokenRows: Array<{ id: string; token: string }> = [];
+mock.module("@sip-and-speak/db", () => ({
+  db: {
+    select: () => ({ from: () => ({ where: () => Promise.resolve(mockTokenRows) }) }),
+  },
+}));
+
+import { registerNotificationHandlers } from "../notifications";
+import { domainEvents } from "@sip-and-speak/api/domain-events";
+
+describe("handleMeetupCancelled", () => {
+  beforeEach(() => { fetchCalls.length = 0; mockTokenRows = []; registerNotificationHandlers(); });
+
+  it("notifies the other Student when a meetup is cancelled", async () => {
+    mockTokenRows = [{ id: "t-1", token: "ExponentPushToken[other]" }];
+    domainEvents.emit("MeetupCancelled", { meetupId: "m-1", cancelledById: "user-a", otherStudentId: "user-b", cancelledAt: new Date() });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(fetchCalls.length).toBe(1);
+    expect(fetchCalls[0]!.messages[0]!.title).toBe("Meetup cancelled");
+  });
+
+  it("sends no notification when the other Student has no token", async () => {
+    mockTokenRows = [];
+    domainEvents.emit("MeetupCancelled", { meetupId: "m-2", cancelledById: "user-a", otherStudentId: "user-b", cancelledAt: new Date() });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(fetchCalls.length).toBe(0);
+  });
+});

--- a/apps/server/src/notifications.ts
+++ b/apps/server/src/notifications.ts
@@ -8,7 +8,7 @@ import { eq } from "drizzle-orm";
 import { db } from "@sip-and-speak/db";
 import { userDeviceToken, userLanguage } from "@sip-and-speak/db/schema/sip-and-speak";
 import { user } from "@sip-and-speak/db/schema/auth";
-import { domainEvents, type MatchRequestSentEvent, type MatchRequestAcceptedEvent, type MatchRequestDeclinedEvent, type MeetupProposedEvent, type MeetupConfirmedEvent, type MeetupCounterProposedEvent, type MeetupDeclinedEvent } from "@sip-and-speak/api/domain-events";
+import { domainEvents, type MatchRequestSentEvent, type MatchRequestAcceptedEvent, type MatchRequestDeclinedEvent, type MeetupProposedEvent, type MeetupConfirmedEvent, type MeetupCounterProposedEvent, type MeetupDeclinedEvent, type MeetupCancelledEvent } from "@sip-and-speak/api/domain-events";
 import { buildMatchRequestNotificationBody } from "@sip-and-speak/api/routers/matching-utils";
 
 const EXPO_PUSH_URL = "https://exp.host/--/api/v2/push/send";
@@ -358,4 +358,28 @@ export function registerNotificationHandlers(): void {
   domainEvents.on("MeetupDeclined", (event) => {
     void handleMeetupDeclined(event);
   });
+  domainEvents.on("MeetupCancelled", (event) => {
+    void handleMeetupCancelled(event);
+  });
+}
+
+// #83 — Notify the other Student of the cancellation
+async function handleMeetupCancelled(event: MeetupCancelledEvent): Promise<void> {
+  const { meetupId, otherStudentId } = event;
+  const tokens = await db
+    .select({ id: userDeviceToken.id, token: userDeviceToken.token })
+    .from(userDeviceToken)
+    .where(eq(userDeviceToken.userId, otherStudentId));
+  if (tokens.length === 0) return;
+  const messages: ExpoPushMessage[] = tokens.map(({ token }) => ({
+    to: token,
+    title: "Meetup cancelled",
+    body: "Your partner cancelled the meetup — you can start a fresh proposal",
+    data: { meetupId, type: "meetup_cancelled" },
+  }));
+  try {
+    await sendExpoPushNotification(messages);
+  } catch (err) {
+    console.error("[push] Failed to send MeetupCancelled notification", { meetupId, err });
+  }
 }

--- a/packages/api/src/domain-events.ts
+++ b/packages/api/src/domain-events.ts
@@ -76,6 +76,13 @@ export interface MeetupDeclinedEvent {
   declinedAt: Date;
 }
 
+export interface MeetupCancelledEvent {
+  meetupId: string;
+  cancelledById: string;
+  otherStudentId: string;
+  cancelledAt: Date;
+}
+
 type DomainEventMap = {
   LanguageProfileUpdated: [LanguageProfileUpdatedEvent];
   InterestProfileUpdated: [InterestProfileUpdatedEvent];
@@ -87,6 +94,7 @@ type DomainEventMap = {
   MeetupConfirmed: [MeetupConfirmedEvent];
   MeetupCounterProposed: [MeetupCounterProposedEvent];
   MeetupDeclined: [MeetupDeclinedEvent];
+  MeetupCancelled: [MeetupCancelledEvent];
 };
 
 class TypedEventEmitter extends EventEmitter {

--- a/packages/api/src/routers/meetup.ts
+++ b/packages/api/src/routers/meetup.ts
@@ -574,4 +574,99 @@ export const meetupRouter = router({
 
     return result?.count ?? 0;
   }),
+
+  // #81/#85 — Cancel a confirmed meetup → cancelled status, emit MeetupCancelled
+  cancelMeetup: protectedProcedure
+    .input(z.object({ meetupId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+
+      const [existing] = await db
+        .select()
+        .from(meetup)
+        .where(eq(meetup.id, input.meetupId))
+        .limit(1);
+
+      if (!existing) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Meetup not found" });
+      }
+
+      const isParticipant =
+        existing.proposerId === userId || existing.receiverId === userId;
+      if (!isParticipant) {
+        throw new TRPCError({ code: "FORBIDDEN", message: "You are not a participant in this meetup" });
+      }
+
+      if (existing.status !== "confirmed") {
+        throw new TRPCError({ code: "BAD_REQUEST", message: "Only confirmed meetups can be cancelled" });
+      }
+
+      // #81 — meetup must not have already occurred
+      const meetupDateTime = new Date(`${existing.date}T${existing.time}:00`);
+      if (meetupDateTime <= new Date()) {
+        throw new TRPCError({ code: "BAD_REQUEST", message: "This meetup has already taken place and cannot be cancelled" });
+      }
+
+      const [updated] = await db
+        .update(meetup)
+        .set({ status: "cancelled" })
+        .where(eq(meetup.id, input.meetupId))
+        .returning();
+
+      const otherStudentId =
+        existing.proposerId === userId ? existing.receiverId : existing.proposerId;
+
+      domainEvents.emit("MeetupCancelled", {
+        meetupId: existing.id,
+        cancelledById: userId,
+        otherStudentId,
+        cancelledAt: new Date(),
+      });
+
+      return updated;
+    }),
+
+  // Query confirmed meetups for the current user
+  getConfirmed: protectedProcedure.query(async ({ ctx }) => {
+    const userId = ctx.session.user.id;
+
+    const rows = await db
+      .select({
+        meetup: meetup,
+        venue: {
+          id: venue.id,
+          name: venue.name,
+          description: venue.description,
+          photoUrl: venue.photoUrl,
+        },
+        partner: {
+          id: sql<string>`partner.id`.as("gc_partner_id"),
+          name: sql<string>`partner.name`.as("gc_partner_name"),
+          image: sql<string | null>`partner.image`.as("gc_partner_image"),
+        },
+      })
+      .from(meetup)
+      .innerJoin(venue, eq(meetup.venueId, venue.id))
+      .innerJoin(
+        sql`"user" as partner`,
+        sql`partner.id = CASE WHEN ${meetup.proposerId} = ${userId} THEN ${meetup.receiverId} ELSE ${meetup.proposerId} END`,
+      )
+      .where(
+        and(
+          eq(meetup.status, "confirmed"),
+          or(eq(meetup.proposerId, userId), eq(meetup.receiverId, userId)),
+        ),
+      )
+      .orderBy(meetup.date, meetup.time);
+
+    return rows.map((row) => ({
+      meetupId: row.meetup.id,
+      date: row.meetup.date,
+      time: row.meetup.time,
+      status: row.meetup.status,
+      isPast: new Date(`${row.meetup.date}T${row.meetup.time}:00`) <= new Date(),
+      venue: row.venue,
+      partner: row.partner,
+    }));
+  }),
 });


### PR DESCRIPTION
## Summary
- Adds `cancelMeetup` tRPC procedure: participant-only, confirmed-status check, future-time validation (#81), emits `MeetupCancelled`
- Adds `getConfirmed` query for the cancel/reschedule UI
- Notifies the other student immediately on cancellation (#83) — pair returns to Matched state derived from no confirmed meetup (#85)

Closes #79
Closes #81
Closes #83
Closes #85