### PR TITLE
feat(meetup): add server-side reschedule proposal validation

### DIFF
--- a/packages/api/src/__tests__/reschedule-validation.test.ts
+++ b/packages/api/src/__tests__/reschedule-validation.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Tests for task #87 — Validate reschedule proposal
+ * (future date/time, active location, no-op detection)
+ *
+ * Pure-function unit tests — no DB required.
+ */
+import { describe, expect, it } from "bun:test";
+
+import { isMeetupInThePast, isRescheduleNoOp } from "../routers/meetup-utils";
+
+// ── isMeetupInThePast ─────────────────────────────────────────────────────────
+
+describe("#87 — isMeetupInThePast", () => {
+  it("returns false for a date far in the future", () => {
+    expect(isMeetupInThePast("2099-12-31", "23:59")).toBe(false);
+  });
+
+  it("returns true for a date in the past", () => {
+    expect(isMeetupInThePast("2020-01-01", "10:00")).toBe(true);
+  });
+
+  it("returns true for a date/time that has exactly passed (boundary)", () => {
+    // A fixed past timestamp is always in the past
+    expect(isMeetupInThePast("2000-06-15", "14:30")).toBe(true);
+  });
+});
+
+// ── isRescheduleNoOp ──────────────────────────────────────────────────────────
+
+describe("#87 — isRescheduleNoOp", () => {
+  const current = { venueId: "venue-1", date: "2026-06-01", time: "14:00" };
+
+  it("returns true when all three fields are identical", () => {
+    expect(isRescheduleNoOp(current, { ...current })).toBe(true);
+  });
+
+  it("returns false when only the venue changes", () => {
+    expect(isRescheduleNoOp(current, { ...current, venueId: "venue-2" })).toBe(false);
+  });
+
+  it("returns false when only the date changes", () => {
+    expect(isRescheduleNoOp(current, { ...current, date: "2026-07-01" })).toBe(false);
+  });
+
+  it("returns false when only the time changes", () => {
+    expect(isRescheduleNoOp(current, { ...current, time: "16:00" })).toBe(false);
+  });
+
+  it("returns false when all three fields change", () => {
+    expect(isRescheduleNoOp(current, { venueId: "venue-x", date: "2027-01-01", time: "09:00" })).toBe(false);
+  });
+});

--- a/packages/api/src/routers/meetup-utils.ts
+++ b/packages/api/src/routers/meetup-utils.ts
@@ -1,0 +1,27 @@
+/**
+ * Pure utility functions for meetup business logic.
+ * Kept side-effect-free so they can be unit-tested without a DB.
+ */
+
+/**
+ * Returns true if the meetup's scheduled date/time has already passed.
+ * Uses server clock as the authoritative source.
+ */
+export function isMeetupInThePast(date: string, time: string): boolean {
+  return new Date(`${date}T${time}:00`) <= new Date();
+}
+
+/**
+ * Returns true if the proposed reschedule details are identical to the
+ * currently confirmed meetup — i.e. the Student proposed a no-op.
+ */
+export function isRescheduleNoOp(
+  current: { venueId: string; date: string; time: string },
+  proposed: { venueId: string; date: string; time: string },
+): boolean {
+  return (
+    current.venueId === proposed.venueId &&
+    current.date === proposed.date &&
+    current.time === proposed.time
+  );
+}

--- a/packages/api/src/routers/meetup.ts
+++ b/packages/api/src/routers/meetup.ts
@@ -5,6 +5,7 @@ import { db } from "@sip-and-speak/db";
 import { meetup, venue, studentMatch } from "@sip-and-speak/db/schema/sip-and-speak";
 import { protectedProcedure, router } from "../index";
 import { domainEvents } from "../domain-events";
+import { isMeetupInThePast, isRescheduleNoOp } from "./meetup-utils";
 
 /** All bookable half-hour slots from 08:00 to 20:00 */
 const ALL_SLOTS = Array.from({ length: 25 }, (_, i) => {
@@ -712,7 +713,41 @@ export const meetupRouter = router({
         throw new TRPCError({ code: "BAD_REQUEST", message: "Only confirmed meetups can be rescheduled" });
       }
 
-      // #87 will add: future date check, active location check, no-op check, race condition guard
+      // #87 — Meetup has already occurred
+      if (isMeetupInThePast(existing.date, existing.time)) {
+        throw new TRPCError({ code: "BAD_REQUEST", message: "This meetup has already taken place and cannot be rescheduled" });
+      }
+
+      // #87 — Proposed date/time must be in the future
+      if (isMeetupInThePast(input.date, input.time)) {
+        throw new TRPCError({ code: "BAD_REQUEST", message: "The rescheduled date and time must be in the future" });
+      }
+
+      // #87 — No-op: proposed details identical to current confirmed meetup
+      if (isRescheduleNoOp(
+        { venueId: existing.venueId, date: existing.date, time: existing.time },
+        { venueId: input.venueId, date: input.date, time: input.time },
+      )) {
+        throw new TRPCError({ code: "BAD_REQUEST", message: "The proposed reschedule is identical to the current meetup. Please change at least one detail." });
+      }
+
+      // #87 — Race condition: another reschedule is already pending
+      if (existing.rescheduleProposerId !== null) {
+        throw new TRPCError({ code: "CONFLICT", message: "A reschedule request is already pending for this meetup. Please wait for your partner to respond." });
+      }
+
+      // #87 — Active location check
+      const [venueRecord] = await db
+        .select({ id: venue.id, isActive: venue.isActive })
+        .from(venue)
+        .where(eq(venue.id, input.venueId))
+        .limit(1);
+      if (!venueRecord) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Location not found" });
+      }
+      if (!venueRecord.isActive) {
+        throw new TRPCError({ code: "BAD_REQUEST", message: "This location is no longer available. Please choose another." });
+      }
 
       const [updated] = await db
         .update(meetup)


### PR DESCRIPTION
## Summary

The `proposeReschedule` tRPC procedure added in task #86 accepted any input. This PR adds all server-side guards: the original meetup must not have already occurred, the proposed date/time must be in the future, the proposal must differ from the current meetup details, no other reschedule can already be pending, and the chosen location must be active.

Pure validation helpers (`isMeetupInThePast`, `isRescheduleNoOp`) are extracted to `meetup-utils.ts` for testability.

## Changes

- **New file** `packages/api/src/routers/meetup-utils.ts` — pure validation helpers for meetup business rules
- **proposeReschedule**: 5 validation guards added with specific, actionable error messages per failure case

## Test plan

- [ ] Rejects reschedule if meetup has already occurred
- [ ] Rejects reschedule if proposed date/time is in the past
- [ ] Rejects if proposed details are identical to current meetup (no-op)
- [ ] Rejects if a reschedule is already pending from either student (race guard)
- [ ] Rejects if the chosen location is inactive
- [ ] `isMeetupInThePast` returns false for future dates, true for past dates
- [ ] `isRescheduleNoOp` detects identical and differing proposals correctly

## Related

Closes #87
