### PR TITLE
feat(notifications): notify partner on reschedule proposal

### DIFF
--- a/apps/server/src/__tests__/notifications-reschedule-proposed.test.ts
+++ b/apps/server/src/__tests__/notifications-reschedule-proposed.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Tests for task #89 — Push notification on MeetupRescheduleProposed
+ */
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+
+const mockFetch = mock(async () =>
+  Response.json({ data: [{ status: "ok", id: "ticket-1" }] }),
+);
+global.fetch = mockFetch as unknown as typeof fetch;
+
+const mockDb = {
+  select: mock(() => mockDb),
+  from: mock(() => mockDb),
+  where: mock(() => Promise.resolve([])),
+};
+
+mock.module("@sip-and-speak/db", () => ({ db: mockDb }));
+mock.module("@sip-and-speak/db/schema/sip-and-speak", () => ({
+  userDeviceToken: { id: "id", token: "token", userId: "user_id" },
+  userLanguage: {},
+}));
+mock.module("@sip-and-speak/db/schema/auth", () => ({ user: { id: "id", name: "name" } }));
+mock.module("@sip-and-speak/api/routers/matching-utils", () => ({
+  buildMatchRequestNotificationBody: () => "body",
+}));
+
+import { domainEvents } from "@sip-and-speak/api/domain-events";
+import { registerNotificationHandlers } from "../notifications";
+
+describe("#89 — MeetupRescheduleProposed push notification", () => {
+  beforeEach(() => {
+    registerNotificationHandlers();
+    mockFetch.mockClear();
+  });
+
+  afterEach(() => {
+    domainEvents.removeAllListeners("MeetupRescheduleProposed");
+  });
+
+  it("sends a push notification to the receiver when a reschedule is proposed", async () => {
+    mockDb.where.mockResolvedValueOnce([{ id: "dt-1", token: "ExponentPushToken[abc]" }]);
+
+    domainEvents.emit("MeetupRescheduleProposed", {
+      meetupId: "m-1",
+      proposerId: "proposer-1",
+      receiverId: "receiver-1",
+      venueId: "v-1",
+      venueName: "Atlas Building",
+      date: "2026-06-01",
+      time: "14:00",
+      proposedAt: new Date(),
+    });
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse((mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string) as unknown[];
+    const msg = (body as Array<{ title: string; body: string; data: Record<string, unknown> }>)[0];
+    expect(msg?.title).toBe("Reschedule request");
+    expect(msg?.body).toContain("Atlas Building");
+    expect(msg?.data?.type).toBe("meetup_reschedule_proposed");
+  });
+
+  it("skips notification when receiver has no device token", async () => {
+    mockDb.where.mockResolvedValueOnce([]);
+
+    domainEvents.emit("MeetupRescheduleProposed", {
+      meetupId: "m-2",
+      proposerId: "proposer-1",
+      receiverId: "receiver-no-token",
+      venueId: "v-1",
+      venueName: "Atlas Building",
+      date: "2026-06-01",
+      time: "14:00",
+      proposedAt: new Date(),
+    });
+
+    await new Promise((r) => setTimeout(r, 10));
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/notifications.ts
+++ b/apps/server/src/notifications.ts
@@ -8,7 +8,7 @@ import { eq } from "drizzle-orm";
 import { db } from "@sip-and-speak/db";
 import { userDeviceToken, userLanguage } from "@sip-and-speak/db/schema/sip-and-speak";
 import { user } from "@sip-and-speak/db/schema/auth";
-import { domainEvents, type MatchRequestSentEvent, type MatchRequestAcceptedEvent, type MatchRequestDeclinedEvent, type MeetupProposedEvent, type MeetupConfirmedEvent, type MeetupCounterProposedEvent, type MeetupDeclinedEvent, type MeetupCancelledEvent } from "@sip-and-speak/api/domain-events";
+import { domainEvents, type MatchRequestSentEvent, type MatchRequestAcceptedEvent, type MatchRequestDeclinedEvent, type MeetupProposedEvent, type MeetupConfirmedEvent, type MeetupCounterProposedEvent, type MeetupDeclinedEvent, type MeetupCancelledEvent, type MeetupRescheduleProposedEvent } from "@sip-and-speak/api/domain-events";
 import { buildMatchRequestNotificationBody } from "@sip-and-speak/api/routers/matching-utils";
 
 const EXPO_PUSH_URL = "https://exp.host/--/api/v2/push/send";
@@ -361,6 +361,33 @@ export function registerNotificationHandlers(): void {
   domainEvents.on("MeetupCancelled", (event) => {
     void handleMeetupCancelled(event);
   });
+  domainEvents.on("MeetupRescheduleProposed", (event) => {
+    void handleMeetupRescheduleProposed(event);
+  });
+}
+
+// #89 — Notify the other Student of a reschedule proposal
+async function handleMeetupRescheduleProposed(event: MeetupRescheduleProposedEvent): Promise<void> {
+  const { meetupId, receiverId, venueName, date, time } = event;
+  const tokens = await db
+    .select({ id: userDeviceToken.id, token: userDeviceToken.token })
+    .from(userDeviceToken)
+    .where(eq(userDeviceToken.userId, receiverId));
+  if (tokens.length === 0) {
+    console.info("[push] No device token for receiver — skipping reschedule notification", { meetupId, receiverId });
+    return;
+  }
+  const messages: ExpoPushMessage[] = tokens.map(({ token }) => ({
+    to: token,
+    title: "Reschedule request",
+    body: `Your partner wants to move your meetup to ${venueName} · ${date} at ${time}`,
+    data: { meetupId, type: "meetup_reschedule_proposed" },
+  }));
+  try {
+    await sendExpoPushNotification(messages);
+  } catch (err) {
+    console.error("[push] Failed to send MeetupRescheduleProposed notification", { meetupId, err });
+  }
 }
 
 // #83 — Notify the other Student of the cancellation

--- a/packages/api/src/domain-events.ts
+++ b/packages/api/src/domain-events.ts
@@ -88,6 +88,7 @@ export interface MeetupRescheduleProposedEvent {
   proposerId: string;
   receiverId: string;
   venueId: string;
+  venueName: string;
   date: string;
   time: string;
   proposedAt: Date;

--- a/packages/api/src/routers/meetup.ts
+++ b/packages/api/src/routers/meetup.ts
@@ -765,6 +765,7 @@ export const meetupRouter = router({
         proposerId: userId,
         receiverId: existing.proposerId === userId ? existing.receiverId : existing.proposerId,
         venueId: input.venueId,
+        venueName: venueRecord.name,
         date: input.date,
         time: input.time,
         proposedAt: new Date(),


### PR DESCRIPTION
## Summary

When a Student proposes a reschedule, their partner needs an immediate push notification so they can accept or decline. This PR adds the `MeetupRescheduleProposed` domain event handler to the push notification service.

## Changes

- `MeetupRescheduleProposedEvent` gains a `venueName` field (consistent with `MeetupProposedEvent`)
- `handleMeetupRescheduleProposed` added to `notifications.ts` — notifies receiver with venue, date, time
- Handler registered in `registerNotificationHandlers`

## Test plan

- [ ] Receiver gets push notification with venue name, date, time when reschedule proposed
- [ ] No notification sent when receiver has no device token

## Related

Closes #89
