### PR TITLE
feat(meetup): accept reschedule proposal and notify both students

### DIFF
--- a/apps/server/src/notifications.ts
+++ b/apps/server/src/notifications.ts
@@ -8,7 +8,7 @@ import { eq } from "drizzle-orm";
 import { db } from "@sip-and-speak/db";
 import { userDeviceToken, userLanguage } from "@sip-and-speak/db/schema/sip-and-speak";
 import { user } from "@sip-and-speak/db/schema/auth";
-import { domainEvents, type MatchRequestSentEvent, type MatchRequestAcceptedEvent, type MatchRequestDeclinedEvent, type MeetupProposedEvent, type MeetupConfirmedEvent, type MeetupCounterProposedEvent, type MeetupDeclinedEvent, type MeetupCancelledEvent, type MeetupRescheduleProposedEvent } from "@sip-and-speak/api/domain-events";
+import { domainEvents, type MatchRequestSentEvent, type MatchRequestAcceptedEvent, type MatchRequestDeclinedEvent, type MeetupProposedEvent, type MeetupConfirmedEvent, type MeetupCounterProposedEvent, type MeetupDeclinedEvent, type MeetupCancelledEvent, type MeetupRescheduleProposedEvent, type MeetupRescheduledEvent } from "@sip-and-speak/api/domain-events";
 import { buildMatchRequestNotificationBody } from "@sip-and-speak/api/routers/matching-utils";
 
 const EXPO_PUSH_URL = "https://exp.host/--/api/v2/push/send";
@@ -364,6 +364,35 @@ export function registerNotificationHandlers(): void {
   domainEvents.on("MeetupRescheduleProposed", (event) => {
     void handleMeetupRescheduleProposed(event);
   });
+  domainEvents.on("MeetupRescheduled", (event) => {
+    void handleMeetupRescheduled(event);
+  });
+}
+
+// #91 — Notify both Students when a reschedule is accepted and meetup details are updated
+async function handleMeetupRescheduled(event: MeetupRescheduledEvent): Promise<void> {
+  const { meetupId, proposerId, receiverId, venueName, newDate, newTime } = event;
+
+  const [proposerTokens, receiverTokens] = await Promise.all([
+    db.select({ id: userDeviceToken.id, token: userDeviceToken.token }).from(userDeviceToken).where(eq(userDeviceToken.userId, proposerId)),
+    db.select({ id: userDeviceToken.id, token: userDeviceToken.token }).from(userDeviceToken).where(eq(userDeviceToken.userId, receiverId)),
+  ]);
+
+  const allTokens = [...proposerTokens, ...receiverTokens];
+  if (allTokens.length === 0) return;
+
+  const messages: ExpoPushMessage[] = allTokens.map(({ token }) => ({
+    to: token,
+    title: "Meetup rescheduled",
+    body: `New details: ${venueName} · ${newDate} at ${newTime}`,
+    data: { meetupId, type: "meetup_rescheduled" },
+  }));
+
+  try {
+    await sendExpoPushNotification(messages);
+  } catch (err) {
+    console.error("[push] Failed to send MeetupRescheduled notification", { meetupId, err });
+  }
 }
 
 // #89 — Notify the other Student of a reschedule proposal

--- a/packages/api/src/domain-events.ts
+++ b/packages/api/src/domain-events.ts
@@ -94,6 +94,16 @@ export interface MeetupRescheduleProposedEvent {
   proposedAt: Date;
 }
 
+export interface MeetupRescheduledEvent {
+  meetupId: string;
+  proposerId: string;
+  receiverId: string;
+  venueName: string;
+  newDate: string;
+  newTime: string;
+  rescheduledAt: Date;
+}
+
 type DomainEventMap = {
   LanguageProfileUpdated: [LanguageProfileUpdatedEvent];
   InterestProfileUpdated: [InterestProfileUpdatedEvent];
@@ -107,6 +117,7 @@ type DomainEventMap = {
   MeetupDeclined: [MeetupDeclinedEvent];
   MeetupCancelled: [MeetupCancelledEvent];
   MeetupRescheduleProposed: [MeetupRescheduleProposedEvent];
+  MeetupRescheduled: [MeetupRescheduledEvent];
 };
 
 class TypedEventEmitter extends EventEmitter {

--- a/packages/api/src/routers/meetup.ts
+++ b/packages/api/src/routers/meetup.ts
@@ -681,6 +681,80 @@ export const meetupRouter = router({
     }));
   }),
 
+  // #91 — Accept a reschedule proposal → update meetup details, emit MeetupRescheduled, notify both
+  acceptReschedule: protectedProcedure
+    .input(z.object({ meetupId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+
+      const [existing] = await db
+        .select()
+        .from(meetup)
+        .innerJoin(venue, eq(meetup.venueId, venue.id))
+        .where(eq(meetup.id, input.meetupId))
+        .limit(1);
+
+      if (!existing) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Meetup not found" });
+      }
+
+      const isParticipant =
+        existing.meetup.proposerId === userId || existing.meetup.receiverId === userId;
+      if (!isParticipant) {
+        throw new TRPCError({ code: "FORBIDDEN", message: "You are not a participant in this meetup" });
+      }
+
+      if (existing.meetup.status !== "confirmed") {
+        throw new TRPCError({ code: "BAD_REQUEST", message: "Only confirmed meetups can have a reschedule accepted" });
+      }
+
+      if (existing.meetup.rescheduleProposerId === null) {
+        throw new TRPCError({ code: "BAD_REQUEST", message: "No reschedule proposal is pending for this meetup" });
+      }
+
+      if (existing.meetup.rescheduleProposerId === userId) {
+        throw new TRPCError({ code: "FORBIDDEN", message: "You cannot accept your own reschedule proposal" });
+      }
+
+      // Fetch the reschedule venue for the notification body
+      const [rescheduleVenue] = await db
+        .select({ id: venue.id, name: venue.name })
+        .from(venue)
+        .where(eq(venue.id, existing.meetup.rescheduleVenueId!))
+        .limit(1);
+
+      // Atomic update: only succeeds if rescheduleProposerId is still set (race-condition guard)
+      const [updated] = await db
+        .update(meetup)
+        .set({
+          venueId: existing.meetup.rescheduleVenueId!,
+          date: existing.meetup.rescheduleDate!,
+          time: existing.meetup.rescheduleTime!,
+          rescheduleProposerId: null,
+          rescheduleVenueId: null,
+          rescheduleDate: null,
+          rescheduleTime: null,
+        })
+        .where(and(eq(meetup.id, input.meetupId), sql`${meetup.rescheduleProposerId} IS NOT NULL`))
+        .returning();
+
+      if (!updated) {
+        throw new TRPCError({ code: "CONFLICT", message: "The reschedule proposal was already handled by another request" });
+      }
+
+      domainEvents.emit("MeetupRescheduled", {
+        meetupId: existing.meetup.id,
+        proposerId: existing.meetup.proposerId,
+        receiverId: existing.meetup.receiverId,
+        venueName: rescheduleVenue?.name ?? existing.venue.name,
+        newDate: existing.meetup.rescheduleDate!,
+        newTime: existing.meetup.rescheduleTime!,
+        rescheduledAt: new Date(),
+      });
+
+      return updated;
+    }),
+
   // #86 — Propose a reschedule for a confirmed meetup
   proposeReschedule: protectedProcedure
     .input(
@@ -738,7 +812,7 @@ export const meetupRouter = router({
 
       // #87 — Active location check
       const [venueRecord] = await db
-        .select({ id: venue.id, isActive: venue.isActive })
+        .select({ id: venue.id, name: venue.name, isActive: venue.isActive })
         .from(venue)
         .where(eq(venue.id, input.venueId))
         .limit(1);


### PR DESCRIPTION
## Summary

Completes the reschedule acceptance flow for confirmed meetups (Feature #23). When a Student accepts a partner's reschedule proposal, the meetup's venue, date, and time are updated atomically, both Students are notified of the new details, and the pending reschedule state is cleared.

The atomic conditional update (`WHERE rescheduleProposerId IS NOT NULL`) guards against concurrent accept/propose race conditions without a separate read-then-write cycle.

## Changes

- **`acceptReschedule` tRPC procedure** — validates participant membership, confirmed status, pending reschedule, and that the accepter is not the reschedule proposer; performs atomic update clearing all four reschedule columns
- **`MeetupRescheduledEvent`** — new domain event type added to the typed event emitter
- **`handleMeetupRescheduled` notification handler** — fetches device tokens for both students and sends push notifications with the new meetup details
- **Fix** — `proposeReschedule` venueRecord select was missing `name` field (pre-existing type error exposed by cache miss)

## Test plan

- [ ] Partner (non-proposer) can accept a pending reschedule — meetup venue/date/time update to proposed values, reschedule columns cleared
- [ ] Reschedule proposer cannot accept their own proposal — receives FORBIDDEN
- [ ] Accept with no pending reschedule returns BAD_REQUEST
- [ ] Both students receive push notification with new meetup details after acceptance
- [ ] Concurrent accept: second request returns CONFLICT (atomic guard)

## Related

Closes #91
