### PR TITLE
feat(meetup): decline reschedule proposal and notify both students

### DIFF
--- a/apps/server/src/notifications.ts
+++ b/apps/server/src/notifications.ts
@@ -8,7 +8,7 @@ import { eq } from "drizzle-orm";
 import { db } from "@sip-and-speak/db";
 import { userDeviceToken, userLanguage } from "@sip-and-speak/db/schema/sip-and-speak";
 import { user } from "@sip-and-speak/db/schema/auth";
-import { domainEvents, type MatchRequestSentEvent, type MatchRequestAcceptedEvent, type MatchRequestDeclinedEvent, type MeetupProposedEvent, type MeetupConfirmedEvent, type MeetupCounterProposedEvent, type MeetupDeclinedEvent, type MeetupCancelledEvent, type MeetupRescheduleProposedEvent, type MeetupRescheduledEvent } from "@sip-and-speak/api/domain-events";
+import { domainEvents, type MatchRequestSentEvent, type MatchRequestAcceptedEvent, type MatchRequestDeclinedEvent, type MeetupProposedEvent, type MeetupConfirmedEvent, type MeetupCounterProposedEvent, type MeetupDeclinedEvent, type MeetupCancelledEvent, type MeetupRescheduleProposedEvent, type MeetupRescheduledEvent, type MeetupRescheduleDeclinedEvent } from "@sip-and-speak/api/domain-events";
 import { buildMatchRequestNotificationBody } from "@sip-and-speak/api/routers/matching-utils";
 
 const EXPO_PUSH_URL = "https://exp.host/--/api/v2/push/send";
@@ -367,6 +367,9 @@ export function registerNotificationHandlers(): void {
   domainEvents.on("MeetupRescheduled", (event) => {
     void handleMeetupRescheduled(event);
   });
+  domainEvents.on("MeetupRescheduleDeclined", (event) => {
+    void handleMeetupRescheduleDeclined(event);
+  });
 }
 
 // #91 — Notify both Students when a reschedule is accepted and meetup details are updated
@@ -392,6 +395,32 @@ async function handleMeetupRescheduled(event: MeetupRescheduledEvent): Promise<v
     await sendExpoPushNotification(messages);
   } catch (err) {
     console.error("[push] Failed to send MeetupRescheduled notification", { meetupId, err });
+  }
+}
+
+// #93 — Notify both Students when a reschedule is declined; confirm original details still in effect
+async function handleMeetupRescheduleDeclined(event: MeetupRescheduleDeclinedEvent): Promise<void> {
+  const { meetupId, proposerId, receiverId, venueName, originalDate, originalTime } = event;
+
+  const [proposerTokens, receiverTokens] = await Promise.all([
+    db.select({ id: userDeviceToken.id, token: userDeviceToken.token }).from(userDeviceToken).where(eq(userDeviceToken.userId, proposerId)),
+    db.select({ id: userDeviceToken.id, token: userDeviceToken.token }).from(userDeviceToken).where(eq(userDeviceToken.userId, receiverId)),
+  ]);
+
+  const allTokens = [...proposerTokens, ...receiverTokens];
+  if (allTokens.length === 0) return;
+
+  const messages: ExpoPushMessage[] = allTokens.map(({ token }) => ({
+    to: token,
+    title: "Reschedule declined",
+    body: `Original meetup stands: ${venueName} · ${originalDate} at ${originalTime}`,
+    data: { meetupId, type: "meetup_reschedule_declined" },
+  }));
+
+  try {
+    await sendExpoPushNotification(messages);
+  } catch (err) {
+    console.error("[push] Failed to send MeetupRescheduleDeclined notification", { meetupId, err });
   }
 }
 

--- a/packages/api/src/domain-events.ts
+++ b/packages/api/src/domain-events.ts
@@ -104,6 +104,16 @@ export interface MeetupRescheduledEvent {
   rescheduledAt: Date;
 }
 
+export interface MeetupRescheduleDeclinedEvent {
+  meetupId: string;
+  proposerId: string;
+  receiverId: string;
+  venueName: string;
+  originalDate: string;
+  originalTime: string;
+  declinedAt: Date;
+}
+
 type DomainEventMap = {
   LanguageProfileUpdated: [LanguageProfileUpdatedEvent];
   InterestProfileUpdated: [InterestProfileUpdatedEvent];
@@ -118,6 +128,7 @@ type DomainEventMap = {
   MeetupCancelled: [MeetupCancelledEvent];
   MeetupRescheduleProposed: [MeetupRescheduleProposedEvent];
   MeetupRescheduled: [MeetupRescheduledEvent];
+  MeetupRescheduleDeclined: [MeetupRescheduleDeclinedEvent];
 };
 
 class TypedEventEmitter extends EventEmitter {

--- a/packages/api/src/routers/meetup.ts
+++ b/packages/api/src/routers/meetup.ts
@@ -755,6 +755,70 @@ export const meetupRouter = router({
       return updated;
     }),
 
+  // #93 — Decline a reschedule proposal → retain original details, emit MeetupRescheduleDeclined, notify both
+  declineReschedule: protectedProcedure
+    .input(z.object({ meetupId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+
+      const [existing] = await db
+        .select()
+        .from(meetup)
+        .innerJoin(venue, eq(meetup.venueId, venue.id))
+        .where(eq(meetup.id, input.meetupId))
+        .limit(1);
+
+      if (!existing) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Meetup not found" });
+      }
+
+      const isParticipant =
+        existing.meetup.proposerId === userId || existing.meetup.receiverId === userId;
+      if (!isParticipant) {
+        throw new TRPCError({ code: "FORBIDDEN", message: "You are not a participant in this meetup" });
+      }
+
+      if (existing.meetup.status !== "confirmed") {
+        throw new TRPCError({ code: "BAD_REQUEST", message: "Only confirmed meetups can have a reschedule declined" });
+      }
+
+      if (existing.meetup.rescheduleProposerId === null) {
+        throw new TRPCError({ code: "BAD_REQUEST", message: "No reschedule proposal is pending for this meetup" });
+      }
+
+      if (existing.meetup.rescheduleProposerId === userId) {
+        throw new TRPCError({ code: "FORBIDDEN", message: "You cannot decline your own reschedule proposal" });
+      }
+
+      // Atomic update: only clears reschedule columns if rescheduleProposerId is still set
+      const [updated] = await db
+        .update(meetup)
+        .set({
+          rescheduleProposerId: null,
+          rescheduleVenueId: null,
+          rescheduleDate: null,
+          rescheduleTime: null,
+        })
+        .where(and(eq(meetup.id, input.meetupId), sql`${meetup.rescheduleProposerId} IS NOT NULL`))
+        .returning();
+
+      if (!updated) {
+        throw new TRPCError({ code: "CONFLICT", message: "The reschedule proposal was already handled by another request" });
+      }
+
+      domainEvents.emit("MeetupRescheduleDeclined", {
+        meetupId: existing.meetup.id,
+        proposerId: existing.meetup.proposerId,
+        receiverId: existing.meetup.receiverId,
+        venueName: existing.venue.name,
+        originalDate: existing.meetup.date,
+        originalTime: existing.meetup.time,
+        declinedAt: new Date(),
+      });
+
+      return updated;
+    }),
+
   // #86 — Propose a reschedule for a confirmed meetup
   proposeReschedule: protectedProcedure
     .input(


### PR DESCRIPTION
## Summary

Completes the reschedule decline flow for confirmed meetups (Feature #23). When a Student declines a partner's reschedule proposal, the original meetup details are preserved unchanged, both Students are notified that the original details stand, and the reschedule state is cleared so either party can propose a new reschedule independently.

Uses the same atomic conditional update pattern as the accept flow — clears reschedule columns only `WHERE rescheduleProposerId IS NOT NULL` to guard against concurrent requests.

## Changes

- **`declineReschedule` tRPC procedure** — validates participant, confirmed status, pending reschedule, and non-proposer guard; atomically clears all four reschedule columns
- **`MeetupRescheduleDeclinedEvent`** — new domain event type added to the typed event emitter
- **`handleMeetupRescheduleDeclined` notification handler** — fetches tokens for both students and sends push notifications confirming the original meetup details

## Test plan

- [ ] Partner (non-proposer) can decline a pending reschedule — meetup details unchanged, reschedule columns cleared
- [ ] Reschedule proposer cannot decline their own proposal — receives FORBIDDEN
- [ ] Decline with no pending reschedule returns BAD_REQUEST
- [ ] Both students receive push notification with original meetup details after decline
- [ ] After decline, either student can propose a new reschedule independently

## Related

Closes #93
