### PR TITLE
feat(meetup): prevent attendance self-report before meetup time passes

### DIFF
--- a/packages/api/src/routers/meetup.ts
+++ b/packages/api/src/routers/meetup.ts
@@ -950,7 +950,11 @@ export const meetupRouter = router({
         throw new TRPCError({ code: "BAD_REQUEST", message: "Only confirmed meetups can receive attendance reports" });
       }
 
-      // #96 — Time guard will be added in task #96
+      // #96 — Reject self-report before the meetup's scheduled time has passed
+      if (!isMeetupInThePast(existing.date, existing.time)) {
+        throw new TRPCError({ code: "BAD_REQUEST", message: "You can only report attendance after the meetup's scheduled time has passed" });
+      }
+
       // Check for duplicate report
       const [existingReport] = await db
         .select({ id: attendanceReport.id })


### PR DESCRIPTION
## Summary

Adds the server-side time guard for attendance self-reports (Feature #24). Reuses the existing `isMeetupInThePast` helper — the server clock is authoritative, so client clock skew cannot bypass the guard.

## Changes

- **`reportAttendance` guard** — `isMeetupInThePast` check rejects submissions with `BAD_REQUEST` if the meetup's scheduled date/time has not yet passed

## Test plan

- [ ] Calling `reportAttendance` before meetup time returns BAD_REQUEST with a clear message
- [ ] Calling after meetup time succeeds (time guard passes, other validations run normally)

## Related

Closes #96
