### PR TITLE
feat(meetup): return pair to Matched when one or both report non-attendance

### DIFF
--- a/apps/server/src/notifications.ts
+++ b/apps/server/src/notifications.ts
@@ -8,7 +8,7 @@ import { eq } from "drizzle-orm";
 import { db } from "@sip-and-speak/db";
 import { userDeviceToken, userLanguage } from "@sip-and-speak/db/schema/sip-and-speak";
 import { user } from "@sip-and-speak/db/schema/auth";
-import { domainEvents, type MatchRequestSentEvent, type MatchRequestAcceptedEvent, type MatchRequestDeclinedEvent, type MeetupProposedEvent, type MeetupConfirmedEvent, type MeetupCounterProposedEvent, type MeetupDeclinedEvent, type MeetupCancelledEvent, type MeetupRescheduleProposedEvent, type MeetupRescheduledEvent, type MeetupRescheduleDeclinedEvent, type SipAndSpeakMomentCompletedEvent } from "@sip-and-speak/api/domain-events";
+import { domainEvents, type MatchRequestSentEvent, type MatchRequestAcceptedEvent, type MatchRequestDeclinedEvent, type MeetupProposedEvent, type MeetupConfirmedEvent, type MeetupCounterProposedEvent, type MeetupDeclinedEvent, type MeetupCancelledEvent, type MeetupRescheduleProposedEvent, type MeetupRescheduledEvent, type MeetupRescheduleDeclinedEvent, type SipAndSpeakMomentCompletedEvent, type MeetupNotAttendedEvent } from "@sip-and-speak/api/domain-events";
 import { buildMatchRequestNotificationBody } from "@sip-and-speak/api/routers/matching-utils";
 
 const EXPO_PUSH_URL = "https://exp.host/--/api/v2/push/send";
@@ -373,6 +373,9 @@ export function registerNotificationHandlers(): void {
   domainEvents.on("SipAndSpeakMomentCompleted", (event) => {
     void handleSipAndSpeakMomentCompleted(event);
   });
+  domainEvents.on("MeetupNotAttended", (event) => {
+    void handleMeetupNotAttended(event);
+  });
 }
 
 // #91 — Notify both Students when a reschedule is accepted and meetup details are updated
@@ -448,6 +451,28 @@ async function handleMeetupRescheduleProposed(event: MeetupRescheduleProposedEve
     await sendExpoPushNotification(messages);
   } catch (err) {
     console.error("[push] Failed to send MeetupRescheduleProposed notification", { meetupId, err });
+  }
+}
+
+// #101 — Notify both Students when meetup not attended; pair returns to Matched
+async function handleMeetupNotAttended(event: MeetupNotAttendedEvent): Promise<void> {
+  const { meetupId, studentAId, studentBId } = event;
+  const [tokensA, tokensB] = await Promise.all([
+    db.select({ id: userDeviceToken.id, token: userDeviceToken.token }).from(userDeviceToken).where(eq(userDeviceToken.userId, studentAId)),
+    db.select({ id: userDeviceToken.id, token: userDeviceToken.token }).from(userDeviceToken).where(eq(userDeviceToken.userId, studentBId)),
+  ]);
+  const allTokens = [...tokensA, ...tokensB];
+  if (allTokens.length === 0) return;
+  const messages: ExpoPushMessage[] = allTokens.map(({ token }) => ({
+    to: token,
+    title: "Meetup not attended",
+    body: "The meetup was marked as not attended — you can schedule a new one",
+    data: { meetupId, type: "meetup_not_attended" },
+  }));
+  try {
+    await sendExpoPushNotification(messages);
+  } catch (err) {
+    console.error("[push] Failed to send MeetupNotAttended notification", { meetupId, err });
   }
 }
 

--- a/packages/api/src/domain-events.ts
+++ b/packages/api/src/domain-events.ts
@@ -130,6 +130,13 @@ export interface SipAndSpeakMomentCompletedEvent {
   completedAt: Date;
 }
 
+export interface MeetupNotAttendedEvent {
+  meetupId: string;
+  studentAId: string;
+  studentBId: string;
+  recordedAt: Date;
+}
+
 type DomainEventMap = {
   LanguageProfileUpdated: [LanguageProfileUpdatedEvent];
   InterestProfileUpdated: [InterestProfileUpdatedEvent];
@@ -147,6 +154,7 @@ type DomainEventMap = {
   MeetupRescheduleDeclined: [MeetupRescheduleDeclinedEvent];
   AttendanceReported: [AttendanceReportedEvent];
   SipAndSpeakMomentCompleted: [SipAndSpeakMomentCompletedEvent];
+  MeetupNotAttended: [MeetupNotAttendedEvent];
 };
 
 class TypedEventEmitter extends EventEmitter {

--- a/packages/api/src/routers/meetup.ts
+++ b/packages/api/src/routers/meetup.ts
@@ -1033,6 +1033,16 @@ export const meetupRouter = router({
               completedAt: new Date(),
             });
           }
+        } else {
+          // #101 — At least one non-attendance → return pair to Matched (meetup closed)
+          await db.update(meetup).set({ status: "not_attended" }).where(eq(meetup.id, input.meetupId));
+
+          domainEvents.emit("MeetupNotAttended", {
+            meetupId: input.meetupId,
+            studentAId: existing.proposerId,
+            studentBId: existing.receiverId,
+            recordedAt: new Date(),
+          });
         }
       }
 


### PR DESCRIPTION
## Summary

Closes the non-attendance path for Feature #24. When both reports are in and at least one is not attended, the meetup is marked not_attended and both Students are notified they can reschedule.

## Changes

- reportAttendance: else branch sets meetup=not_attended, emits MeetupNotAttended
- MeetupNotAttendedEvent domain event
- handleMeetupNotAttended notification handler

## Test plan

- [ ] One attended, one not → meetup=not_attended, both notified
- [ ] Both not attended → meetup=not_attended, both notified
- [ ] After not_attended, pair can propose a new meetup

## Related

Closes #101