### PR TITLE
feat(messaging): send opt-in push to both Students after meetup completion

### DIFF
--- a/apps/server/src/__tests__/notifications-messaging-opt-in.test.ts
+++ b/apps/server/src/__tests__/notifications-messaging-opt-in.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Tests for task #138 — Send opt-in push notification to both Students after meetup is completed
+ *
+ * Covers:
+ *   - Both Students receive an opt-in prompt when their meetup is completed
+ *   - No notification sent when neither Student has a device token
+ */
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+// ── Fetch mock ────────────────────────────────────────────────────────────────
+
+interface CapturedFetchCall {
+  url: string;
+  messages: Array<{ to: string; title?: string; body?: string; data?: Record<string, unknown> }>;
+}
+
+const fetchCalls: CapturedFetchCall[] = [];
+
+(global as unknown as { fetch: unknown }).fetch = mock(async (url: string, options: RequestInit) => {
+  fetchCalls.push({
+    url,
+    messages: JSON.parse(options.body as string) as CapturedFetchCall["messages"],
+  });
+  return {
+    json: async () => ({ data: [{ status: "ok", id: "ticket-1" }] }),
+  };
+});
+
+// ── Schema mocks ──────────────────────────────────────────────────────────────
+
+const USER_TABLE = "user";
+const DEVICE_TOKEN_TABLE = "userDeviceToken";
+
+mock.module("@sip-and-speak/db/schema/sip-and-speak", () => ({
+  userDeviceToken: DEVICE_TOKEN_TABLE,
+  userLanguage: "userLanguage",
+}));
+
+mock.module("@sip-and-speak/db/schema/auth", () => ({
+  user: USER_TABLE,
+}));
+
+// ── drizzle-orm mock ──────────────────────────────────────────────────────────
+
+mock.module("drizzle-orm", () => ({
+  eq: (_col: unknown, val: unknown) => ({ _val: val }),
+  or: (...args: unknown[]) => args,
+}));
+
+// ── DB mock ───────────────────────────────────────────────────────────────────
+
+const STUDENT_A_ID = "student-a-id";
+const STUDENT_B_ID = "student-b-id";
+
+let mockStudentATokens: Array<{ id: string; token: string }> = [];
+let mockStudentBTokens: Array<{ id: string; token: string }> = [];
+
+const STUDENT_A_NAME = [{ name: "Alice" }];
+const STUDENT_B_NAME = [{ name: "Bob" }];
+
+mock.module("@sip-and-speak/db", () => ({
+  db: {
+    select: (fields: Record<string, unknown>) => {
+      const isNameQuery = "name" in fields;
+      return {
+        from: (_table: unknown) => ({
+          where: (clause: { _val: string }) => {
+            if (isNameQuery) {
+              const rows = clause._val === STUDENT_A_ID ? STUDENT_A_NAME : STUDENT_B_NAME;
+              return { limit: (_n: number) => Promise.resolve(rows) };
+            }
+            const rows = clause._val === STUDENT_A_ID ? mockStudentATokens : mockStudentBTokens;
+            return Promise.resolve(rows);
+          },
+        }),
+      };
+    },
+  },
+}));
+
+// ── Domain events mock ────────────────────────────────────────────────────────
+
+mock.module("@sip-and-speak/api/domain-events", () => ({
+  domainEvents: { on: mock((_evt: string, _fn: unknown) => undefined), emit: mock(() => undefined) },
+}));
+
+// ── Import under test (after mocks) ──────────────────────────────────────────
+
+// eslint-disable-next-line import/first
+import { handleMessagingOptInPrompted } from "../notifications";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeOptInEvent(
+  overrides: Partial<{ meetupId: string; studentAId: string; studentBId: string }> = {},
+) {
+  return {
+    meetupId: overrides.meetupId ?? "meetup-1",
+    studentAId: overrides.studentAId ?? STUDENT_A_ID,
+    studentBId: overrides.studentBId ?? STUDENT_B_ID,
+    promptedAt: new Date(),
+  };
+}
+
+beforeEach(() => {
+  fetchCalls.length = 0;
+  mockStudentATokens = [];
+  mockStudentBTokens = [];
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("#138 — Send opt-in push notification to both Students after meetup is completed", () => {
+  it("sends an opt-in push to both Students when their meetup is completed", async () => {
+    mockStudentATokens = [{ id: "tok-a", token: "ExponentPushToken[alice]" }];
+    mockStudentBTokens = [{ id: "tok-b", token: "ExponentPushToken[bob]" }];
+
+    await handleMessagingOptInPrompted(makeOptInEvent());
+
+    expect(fetchCalls).toHaveLength(1);
+
+    const call = fetchCalls[0];
+    if (!call) throw new Error("Expected a fetch call");
+
+    expect(call.messages).toHaveLength(2);
+
+    const tokens = call.messages.map((m) => m.to);
+    expect(tokens).toContain("ExponentPushToken[alice]");
+    expect(tokens).toContain("ExponentPushToken[bob]");
+
+    // Student A (Alice) sees Bob's name
+    const aliceMsg = call.messages.find((m) => m.to === "ExponentPushToken[alice]");
+    expect(aliceMsg?.title).toBe("Want to keep in touch?");
+    expect(aliceMsg?.body).toContain("Bob");
+    expect(aliceMsg?.data?.type).toBe("messaging_opt_in");
+    expect(aliceMsg?.data?.meetupId).toBe("meetup-1");
+
+    // Student B (Bob) sees Alice's name
+    const bobMsg = call.messages.find((m) => m.to === "ExponentPushToken[bob]");
+    expect(bobMsg?.title).toBe("Want to keep in touch?");
+    expect(bobMsg?.body).toContain("Alice");
+    expect(bobMsg?.data?.type).toBe("messaging_opt_in");
+    expect(bobMsg?.data?.meetupId).toBe("meetup-1");
+  });
+
+  it("sends no notification when neither Student has a registered device token", async () => {
+    mockStudentATokens = [];
+    mockStudentBTokens = [];
+
+    await handleMessagingOptInPrompted(makeOptInEvent());
+
+    expect(fetchCalls).toHaveLength(0);
+  });
+});

--- a/apps/server/src/notifications.ts
+++ b/apps/server/src/notifications.ts
@@ -8,7 +8,7 @@ import { eq } from "drizzle-orm";
 import { db } from "@sip-and-speak/db";
 import { userDeviceToken, userLanguage } from "@sip-and-speak/db/schema/sip-and-speak";
 import { user } from "@sip-and-speak/db/schema/auth";
-import { domainEvents, type MatchRequestSentEvent, type MatchRequestAcceptedEvent, type MatchRequestDeclinedEvent, type MeetupProposedEvent, type MeetupConfirmedEvent, type MeetupCounterProposedEvent, type MeetupDeclinedEvent, type MeetupCancelledEvent, type MeetupRescheduleProposedEvent, type MeetupRescheduledEvent, type MeetupRescheduleDeclinedEvent, type SipAndSpeakMomentCompletedEvent, type MeetupNotAttendedEvent } from "@sip-and-speak/api/domain-events";
+import { domainEvents, type MatchRequestSentEvent, type MatchRequestAcceptedEvent, type MatchRequestDeclinedEvent, type MeetupProposedEvent, type MeetupConfirmedEvent, type MeetupCounterProposedEvent, type MeetupDeclinedEvent, type MeetupCancelledEvent, type MeetupRescheduleProposedEvent, type MeetupRescheduledEvent, type MeetupRescheduleDeclinedEvent, type SipAndSpeakMomentCompletedEvent, type MeetupNotAttendedEvent, type MessagingOptInPromptedEvent } from "@sip-and-speak/api/domain-events";
 import { buildMatchRequestNotificationBody } from "@sip-and-speak/api/routers/matching-utils";
 
 const EXPO_PUSH_URL = "https://exp.host/--/api/v2/push/send";
@@ -376,6 +376,9 @@ export function registerNotificationHandlers(): void {
   domainEvents.on("MeetupNotAttended", (event) => {
     void handleMeetupNotAttended(event);
   });
+  domainEvents.on("MessagingOptInPrompted", (event) => {
+    void handleMessagingOptInPrompted(event);
+  });
 }
 
 // #91 — Notify both Students when a reschedule is accepted and meetup details are updated
@@ -495,6 +498,60 @@ async function handleSipAndSpeakMomentCompleted(event: SipAndSpeakMomentComplete
     await sendExpoPushNotification(messages);
   } catch (err) {
     console.error("[push] Failed to send SipAndSpeakMomentCompleted notification", { meetupId, err });
+  }
+}
+
+// #138 — Prompt both Students to opt in to messaging after a completed meetup
+export async function handleMessagingOptInPrompted(event: MessagingOptInPromptedEvent): Promise<void> {
+  const { meetupId, studentAId, studentBId } = event;
+
+  const [studentAResult, studentBResult, tokensA, tokensB] = await Promise.all([
+    db.select({ name: user.name }).from(user).where(eq(user.id, studentAId)).limit(1),
+    db.select({ name: user.name }).from(user).where(eq(user.id, studentBId)).limit(1),
+    db
+      .select({ id: userDeviceToken.id, token: userDeviceToken.token })
+      .from(userDeviceToken)
+      .where(eq(userDeviceToken.userId, studentAId)),
+    db
+      .select({ id: userDeviceToken.id, token: userDeviceToken.token })
+      .from(userDeviceToken)
+      .where(eq(userDeviceToken.userId, studentBId)),
+  ]);
+
+  const studentAName = studentAResult[0]?.name ?? "Your match";
+  const studentBName = studentBResult[0]?.name ?? "Your match";
+
+  const messages: ExpoPushMessage[] = [];
+
+  for (const { token } of tokensA) {
+    messages.push({
+      to: token,
+      title: "Want to keep in touch?",
+      body: `${studentBName} completed a S&S moment with you — would you like to message them?`,
+      data: { meetupId, type: "messaging_opt_in", deepLink: `/messaging/opt-in/${meetupId}` },
+    });
+  }
+
+  for (const { token } of tokensB) {
+    messages.push({
+      to: token,
+      title: "Want to keep in touch?",
+      body: `${studentAName} completed a S&S moment with you — would you like to message them?`,
+      data: { meetupId, type: "messaging_opt_in", deepLink: `/messaging/opt-in/${meetupId}` },
+    });
+  }
+
+  if (messages.length === 0) {
+    console.info("[push] No device tokens for either student — skipping opt-in notification", { meetupId });
+    return;
+  }
+
+  console.info("[push] Sending MessagingOptInPrompted notification", { meetupId, tokenCount: messages.length });
+
+  try {
+    await sendExpoPushNotification(messages);
+  } catch (err) {
+    console.error("[push] Failed to send MessagingOptInPrompted notification", { meetupId, err });
   }
 }
 

--- a/packages/api/src/domain-events.ts
+++ b/packages/api/src/domain-events.ts
@@ -137,6 +137,13 @@ export interface MeetupNotAttendedEvent {
   recordedAt: Date;
 }
 
+export interface MessagingOptInPromptedEvent {
+  meetupId: string;
+  studentAId: string;
+  studentBId: string;
+  promptedAt: Date;
+}
+
 type DomainEventMap = {
   LanguageProfileUpdated: [LanguageProfileUpdatedEvent];
   InterestProfileUpdated: [InterestProfileUpdatedEvent];
@@ -155,6 +162,7 @@ type DomainEventMap = {
   AttendanceReported: [AttendanceReportedEvent];
   SipAndSpeakMomentCompleted: [SipAndSpeakMomentCompletedEvent];
   MeetupNotAttended: [MeetupNotAttendedEvent];
+  MessagingOptInPrompted: [MessagingOptInPromptedEvent];
 };
 
 class TypedEventEmitter extends EventEmitter {

--- a/packages/api/src/routers/meetup.ts
+++ b/packages/api/src/routers/meetup.ts
@@ -1032,6 +1032,14 @@ export const meetupRouter = router({
               studentBId: existing.receiverId,
               completedAt: new Date(),
             });
+
+            // #138 — Prompt both Students to opt in to messaging after a completed meetup
+            domainEvents.emit("MessagingOptInPrompted", {
+              meetupId: input.meetupId,
+              studentAId: existing.proposerId,
+              studentBId: existing.receiverId,
+              promptedAt: new Date(),
+            });
           }
         } else {
           // #101 — At least one non-attendance → return pair to Matched (meetup closed)


### PR DESCRIPTION
## Summary

After a S&S meetup is marked completed, neither student had a way to start the opt-in process for messaging. This task triggers that flow: when both students confirm attendance, a `MessagingOptInPrompted` domain event is emitted and each student receives a personalised push notification asking if they'd like to exchange messages with their match.

Without this notification, the messaging feature (Feature #25) has no entry point — students would never be prompted to accept or decline a conversation channel.

## Changes

- **New domain event** (`packages/api/src/domain-events.ts`): `MessagingOptInPromptedEvent` + `DomainEventMap` registration
- **Meetup router** (`packages/api/src/routers/meetup.ts`): emits `MessagingOptInPrompted` alongside `SipAndSpeakMomentCompleted` when both students attend
- **Notification handler** (`apps/server/src/notifications.ts`): `handleMessagingOptInPrompted` — fetches both students' names and device tokens in parallel, sends a personalised "Want to keep in touch?" push to each device; registered in `registerNotificationHandlers`

## Test plan

- [x] Both Students receive an opt-in prompt when their meetup is completed (`notifications-messaging-opt-in.test.ts`)
- [x] No notification sent when neither Student has a registered device token
- [x] Opt-in push cannot fire twice — the `reportAttendance` guard (`status !== "confirmed"`) prevents re-completion

## Related

Closes #138
