### PR TITLE
feat(messaging): open conversation channel when both Students accept

### DIFF
--- a/apps/server/src/__tests__/notifications-conversation-opened.test.ts
+++ b/apps/server/src/__tests__/notifications-conversation-opened.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Tests for task #141 — Open conversation channel and notify both Students when both accept
+ *
+ * Covers:
+ *   - Both Students receive a "messaging is now open" push notification
+ *   - No notification sent when neither Student has a device token
+ */
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+// ── Fetch mock ────────────────────────────────────────────────────────────────
+
+interface CapturedFetchCall {
+  url: string;
+  messages: Array<{ to: string; title?: string; body?: string; data?: Record<string, unknown> }>;
+}
+
+const fetchCalls: CapturedFetchCall[] = [];
+
+(global as unknown as { fetch: unknown }).fetch = mock(async (url: string, options: RequestInit) => {
+  fetchCalls.push({
+    url,
+    messages: JSON.parse(options.body as string) as CapturedFetchCall["messages"],
+  });
+  return {
+    json: async () => ({ data: [{ status: "ok", id: "ticket-1" }] }),
+  };
+});
+
+// ── Schema mocks ──────────────────────────────────────────────────────────────
+
+const USER_TABLE = "user";
+const DEVICE_TOKEN_TABLE = "userDeviceToken";
+
+mock.module("@sip-and-speak/db/schema/sip-and-speak", () => ({
+  userDeviceToken: DEVICE_TOKEN_TABLE,
+  userLanguage: "userLanguage",
+}));
+
+mock.module("@sip-and-speak/db/schema/auth", () => ({
+  user: USER_TABLE,
+}));
+
+// ── drizzle-orm mock ──────────────────────────────────────────────────────────
+
+mock.module("drizzle-orm", () => ({
+  eq: (_col: unknown, val: unknown) => ({ _val: val }),
+  or: (...args: unknown[]) => args,
+}));
+
+// ── DB mock ───────────────────────────────────────────────────────────────────
+
+const STUDENT_A_ID = "student-a-id";
+const STUDENT_B_ID = "student-b-id";
+
+let mockStudentATokens: Array<{ id: string; token: string }> = [];
+let mockStudentBTokens: Array<{ id: string; token: string }> = [];
+
+const STUDENT_A_NAME = [{ name: "Alice" }];
+const STUDENT_B_NAME = [{ name: "Bob" }];
+
+mock.module("@sip-and-speak/db", () => ({
+  db: {
+    select: (fields: Record<string, unknown>) => {
+      const isNameQuery = "name" in fields;
+      return {
+        from: (_table: unknown) => ({
+          where: (clause: { _val: string }) => {
+            if (isNameQuery) {
+              const rows = clause._val === STUDENT_A_ID ? STUDENT_A_NAME : STUDENT_B_NAME;
+              return { limit: (_n: number) => Promise.resolve(rows) };
+            }
+            const rows =
+              clause._val === STUDENT_A_ID ? mockStudentATokens : mockStudentBTokens;
+            return Promise.resolve(rows);
+          },
+        }),
+      };
+    },
+  },
+}));
+
+// ── Domain events mock ────────────────────────────────────────────────────────
+
+mock.module("@sip-and-speak/api/domain-events", () => ({
+  domainEvents: { on: mock((_evt: string, _fn: unknown) => undefined), emit: mock(() => undefined) },
+}));
+
+// ── Import under test (after mocks) ──────────────────────────────────────────
+
+// eslint-disable-next-line import/first
+import { handleConversationOpened } from "../notifications";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeConversationOpenedEvent(
+  overrides: Partial<{
+    conversationId: string;
+    meetupId: string;
+    studentAId: string;
+    studentBId: string;
+  }> = {},
+) {
+  return {
+    conversationId: overrides.conversationId ?? "conv-1",
+    meetupId: overrides.meetupId ?? "meetup-1",
+    studentAId: overrides.studentAId ?? STUDENT_A_ID,
+    studentBId: overrides.studentBId ?? STUDENT_B_ID,
+    openedAt: new Date(),
+  };
+}
+
+beforeEach(() => {
+  fetchCalls.length = 0;
+  mockStudentATokens = [];
+  mockStudentBTokens = [];
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("#141 — Notify both Students when conversation channel opens", () => {
+  it("sends a push to both Students with partner name and conversation deep link", async () => {
+    mockStudentATokens = [{ id: "tok-a", token: "ExponentPushToken[alice]" }];
+    mockStudentBTokens = [{ id: "tok-b", token: "ExponentPushToken[bob]" }];
+
+    await handleConversationOpened(makeConversationOpenedEvent());
+
+    expect(fetchCalls).toHaveLength(1);
+
+    const call = fetchCalls[0];
+    if (!call) throw new Error("Expected a fetch call");
+
+    expect(call.messages).toHaveLength(2);
+
+    const aliceMsg = call.messages.find((m) => m.to === "ExponentPushToken[alice]");
+    const bobMsg = call.messages.find((m) => m.to === "ExponentPushToken[bob]");
+
+    expect(aliceMsg?.title).toBe("Your messaging channel is open!");
+    expect(aliceMsg?.body).toContain("Bob");
+    expect(aliceMsg?.data?.type).toBe("conversation_opened");
+    expect(aliceMsg?.data?.conversationId).toBe("conv-1");
+    expect(aliceMsg?.data?.deepLink).toBe("/conversations/conv-1");
+
+    expect(bobMsg?.title).toBe("Your messaging channel is open!");
+    expect(bobMsg?.body).toContain("Alice");
+    expect(bobMsg?.data?.conversationId).toBe("conv-1");
+  });
+
+  it("sends no notification when neither Student has a registered device token", async () => {
+    mockStudentATokens = [];
+    mockStudentBTokens = [];
+
+    await handleConversationOpened(makeConversationOpenedEvent());
+
+    expect(fetchCalls).toHaveLength(0);
+  });
+});

--- a/apps/server/src/notifications.ts
+++ b/apps/server/src/notifications.ts
@@ -8,7 +8,7 @@ import { eq } from "drizzle-orm";
 import { db } from "@sip-and-speak/db";
 import { userDeviceToken, userLanguage } from "@sip-and-speak/db/schema/sip-and-speak";
 import { user } from "@sip-and-speak/db/schema/auth";
-import { domainEvents, type MatchRequestSentEvent, type MatchRequestAcceptedEvent, type MatchRequestDeclinedEvent, type MeetupProposedEvent, type MeetupConfirmedEvent, type MeetupCounterProposedEvent, type MeetupDeclinedEvent, type MeetupCancelledEvent, type MeetupRescheduleProposedEvent, type MeetupRescheduledEvent, type MeetupRescheduleDeclinedEvent, type SipAndSpeakMomentCompletedEvent, type MeetupNotAttendedEvent, type MessagingOptInPromptedEvent, type MessagingNudgeNeededEvent } from "@sip-and-speak/api/domain-events";
+import { domainEvents, type MatchRequestSentEvent, type MatchRequestAcceptedEvent, type MatchRequestDeclinedEvent, type MeetupProposedEvent, type MeetupConfirmedEvent, type MeetupCounterProposedEvent, type MeetupDeclinedEvent, type MeetupCancelledEvent, type MeetupRescheduleProposedEvent, type MeetupRescheduledEvent, type MeetupRescheduleDeclinedEvent, type SipAndSpeakMomentCompletedEvent, type MeetupNotAttendedEvent, type MessagingOptInPromptedEvent, type MessagingNudgeNeededEvent, type ConversationOpenedEvent } from "@sip-and-speak/api/domain-events";
 import { buildMatchRequestNotificationBody } from "@sip-and-speak/api/routers/matching-utils";
 
 const EXPO_PUSH_URL = "https://exp.host/--/api/v2/push/send";
@@ -382,6 +382,9 @@ export function registerNotificationHandlers(): void {
   domainEvents.on("MessagingNudgeNeeded", (event) => {
     void handleMessagingNudge(event);
   });
+  domainEvents.on("ConversationOpened", (event) => {
+    void handleConversationOpened(event);
+  });
 }
 
 // #91 — Notify both Students when a reschedule is accepted and meetup details are updated
@@ -593,6 +596,63 @@ export async function handleMessagingNudge(event: MessagingNudgeNeededEvent): Pr
     await sendExpoPushNotification(messages);
   } catch (err) {
     console.error("[push] Failed to send MessagingNudge notification", { meetupId, pendingStudentId, err });
+  }
+}
+
+// #141 — Notify both Students when their conversation channel is opened
+export async function handleConversationOpened(event: ConversationOpenedEvent): Promise<void> {
+  const { conversationId, meetupId, studentAId, studentBId } = event;
+
+  const [studentAResult, studentBResult, tokensA, tokensB] = await Promise.all([
+    db.select({ name: user.name }).from(user).where(eq(user.id, studentAId)).limit(1),
+    db.select({ name: user.name }).from(user).where(eq(user.id, studentBId)).limit(1),
+    db
+      .select({ id: userDeviceToken.id, token: userDeviceToken.token })
+      .from(userDeviceToken)
+      .where(eq(userDeviceToken.userId, studentAId)),
+    db
+      .select({ id: userDeviceToken.id, token: userDeviceToken.token })
+      .from(userDeviceToken)
+      .where(eq(userDeviceToken.userId, studentBId)),
+  ]);
+
+  const studentAName = studentAResult[0]?.name ?? "Your match";
+  const studentBName = studentBResult[0]?.name ?? "Your match";
+
+  const messages: ExpoPushMessage[] = [];
+
+  for (const { token } of tokensA) {
+    messages.push({
+      to: token,
+      title: "Your messaging channel is open!",
+      body: `${studentBName} also accepted — you can now message each other.`,
+      data: { conversationId, meetupId, type: "conversation_opened", deepLink: `/conversations/${conversationId}` },
+    });
+  }
+
+  for (const { token } of tokensB) {
+    messages.push({
+      to: token,
+      title: "Your messaging channel is open!",
+      body: `${studentAName} also accepted — you can now message each other.`,
+      data: { conversationId, meetupId, type: "conversation_opened", deepLink: `/conversations/${conversationId}` },
+    });
+  }
+
+  if (messages.length === 0) {
+    console.info("[push] No device tokens for either student — skipping conversation-opened notification", {
+      conversationId,
+      meetupId,
+    });
+    return;
+  }
+
+  console.info("[push] Sending ConversationOpened notification", { conversationId, meetupId, tokenCount: messages.length });
+
+  try {
+    await sendExpoPushNotification(messages);
+  } catch (err) {
+    console.error("[push] Failed to send ConversationOpened notification", { conversationId, meetupId, err });
   }
 }
 

--- a/packages/api/src/__tests__/messaging-conversation.test.ts
+++ b/packages/api/src/__tests__/messaging-conversation.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Tests for task #141 — Open conversation channel when both Students accept
+ *
+ * Covers:
+ *   - bothAccepted returns true only when both responses are "accept"
+ *   - Decline by either student prevents conversation opening
+ */
+import { describe, it, expect } from "bun:test";
+
+import { bothAccepted } from "../routers/messaging-utils";
+
+describe("#141 — bothAccepted", () => {
+  it("returns true when both Students have accepted", () => {
+    expect(
+      bothAccepted([{ response: "accept" }, { response: "accept" }]),
+    ).toBe(true);
+  });
+
+  it("returns false when only one Student has accepted", () => {
+    expect(bothAccepted([{ response: "accept" }])).toBe(false);
+  });
+
+  it("returns false when first Student declined", () => {
+    expect(
+      bothAccepted([{ response: "decline" }, { response: "accept" }]),
+    ).toBe(false);
+  });
+
+  it("returns false when second Student declined", () => {
+    expect(
+      bothAccepted([{ response: "accept" }, { response: "decline" }]),
+    ).toBe(false);
+  });
+
+  it("returns false when both Students declined", () => {
+    expect(
+      bothAccepted([{ response: "decline" }, { response: "decline" }]),
+    ).toBe(false);
+  });
+
+  it("returns false when no responses yet", () => {
+    expect(bothAccepted([])).toBe(false);
+  });
+});

--- a/packages/api/src/domain-events.ts
+++ b/packages/api/src/domain-events.ts
@@ -158,6 +158,14 @@ export interface MessagingDeclinedEvent {
   respondedAt: Date;
 }
 
+export interface ConversationOpenedEvent {
+  conversationId: string;
+  meetupId: string;
+  studentAId: string;
+  studentBId: string;
+  openedAt: Date;
+}
+
 export interface MessagingNudgeNeededEvent {
   meetupId: string;
   /** The student who accepted and triggered the nudge */
@@ -188,6 +196,7 @@ type DomainEventMap = {
   MessagingAccepted: [MessagingAcceptedEvent];
   MessagingDeclined: [MessagingDeclinedEvent];
   MessagingNudgeNeeded: [MessagingNudgeNeededEvent];
+  ConversationOpened: [ConversationOpenedEvent];
 };
 
 class TypedEventEmitter extends EventEmitter {

--- a/packages/api/src/routers/messaging-utils.ts
+++ b/packages/api/src/routers/messaging-utils.ts
@@ -25,6 +25,16 @@ export function shouldSendNudge(
 }
 
 /**
+ * Returns true when both Students have responded with "accept".
+ * Used to determine whether a conversation channel should be opened.
+ */
+export function bothAccepted(
+  responses: Array<{ response: "accept" | "decline" }>,
+): boolean {
+  return responses.length === 2 && responses.every((r) => r.response === "accept");
+}
+
+/**
  * Derives the partner's ID from a meetup's proposer/receiver pair.
  */
 export function getPartnerId(

--- a/packages/api/src/routers/messaging.ts
+++ b/packages/api/src/routers/messaging.ts
@@ -5,8 +5,8 @@ import { and, eq, isNull } from "drizzle-orm";
 import { protectedProcedure, router } from "../index";
 import { domainEvents } from "../domain-events";
 import { db } from "@sip-and-speak/db";
-import { meetup, messagingOptIn } from "@sip-and-speak/db/schema/sip-and-speak";
-import { hasAlreadyResponded, getPartnerId, shouldSendNudge } from "./messaging-utils";
+import { meetup, messagingOptIn, conversation } from "@sip-and-speak/db/schema/sip-and-speak";
+import { hasAlreadyResponded, getPartnerId, shouldSendNudge, bothAccepted } from "./messaging-utils";
 
 export const messagingRouter = router({
   /**
@@ -125,6 +125,38 @@ export const messagingRouter = router({
               meetupId: input.meetupId,
               acceptingStudentId: studentId,
               pendingStudentId: partnerId,
+            });
+          }
+        }
+
+        // #141 — Check if both Students have now accepted; if so, open the conversation
+        const allResponses = await db
+          .select({ response: messagingOptIn.response })
+          .from(messagingOptIn)
+          .where(eq(messagingOptIn.meetupId, input.meetupId));
+
+        if (bothAccepted(allResponses)) {
+          // Use INSERT ... ON CONFLICT DO NOTHING to guard against race conditions
+          const [newConversation] = await db
+            .insert(conversation)
+            .values({
+              user1Id: studentId,
+              user2Id: partnerId,
+              meetupId: input.meetupId,
+            })
+            .onConflictDoNothing({ target: conversation.meetupId })
+            .returning();
+
+          if (newConversation) {
+            console.log(
+              `[messaging] conversation opened conversationId=${newConversation.id} meetupId=${input.meetupId}`,
+            );
+            domainEvents.emit("ConversationOpened", {
+              conversationId: newConversation.id,
+              meetupId: input.meetupId,
+              studentAId: studentId,
+              studentBId: partnerId,
+              openedAt: newConversation.createdAt,
             });
           }
         }

--- a/packages/db/src/migrations/0010_kind_reaper.sql
+++ b/packages/db/src/migrations/0010_kind_reaper.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "conversation" ADD COLUMN "meetup_id" text;--> statement-breakpoint
+ALTER TABLE "conversation" ADD CONSTRAINT "conversation_meetup_id_meetup_id_fk" FOREIGN KEY ("meetup_id") REFERENCES "public"."meetup"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "conversation_meetupId_idx" ON "conversation" USING btree ("meetup_id");

--- a/packages/db/src/migrations/meta/0010_snapshot.json
+++ b/packages/db/src/migrations/meta/0010_snapshot.json
@@ -1,0 +1,1835 @@
+{
+  "id": "53b2ab22-e030-4692-88dd-ece690cacf98",
+  "prevId": "17ae2773-82ec-411c-bac9-2025d66bdf1c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attendance_report": {
+      "name": "attendance_report",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "meetup_id": {
+          "name": "meetup_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attended": {
+          "name": "attended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reported_at": {
+          "name": "reported_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "attendance_report_meetupId_idx": {
+          "name": "attendance_report_meetupId_idx",
+          "columns": [
+            {
+              "expression": "meetup_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attendance_report_meetup_id_meetup_id_fk": {
+          "name": "attendance_report_meetup_id_meetup_id_fk",
+          "tableFrom": "attendance_report",
+          "tableTo": "meetup",
+          "columnsFrom": [
+            "meetup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attendance_report_student_id_user_id_fk": {
+          "name": "attendance_report_student_id_user_id_fk",
+          "tableFrom": "attendance_report",
+          "tableTo": "user",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "attendance_report_meetup_student_unique": {
+          "name": "attendance_report_meetup_student_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "meetup_id",
+            "student_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation": {
+      "name": "conversation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user1_id": {
+          "name": "user1_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user2_id": {
+          "name": "user2_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meetup_id": {
+          "name": "meetup_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_user1_idx": {
+          "name": "conversation_user1_idx",
+          "columns": [
+            {
+              "expression": "user1_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_user2_idx": {
+          "name": "conversation_user2_idx",
+          "columns": [
+            {
+              "expression": "user2_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_meetupId_idx": {
+          "name": "conversation_meetupId_idx",
+          "columns": [
+            {
+              "expression": "meetup_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_user1_id_user_id_fk": {
+          "name": "conversation_user1_id_user_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user1_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_user2_id_user_id_fk": {
+          "name": "conversation_user2_id_user_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user2_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_meetup_id_meetup_id_fk": {
+          "name": "conversation_meetup_id_meetup_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "meetup",
+          "columnsFrom": [
+            "meetup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.language_profile": {
+      "name": "language_profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "university": {
+          "name": "university",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "age": {
+          "name": "age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_complete": {
+          "name": "onboarding_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "language_profile_user_id_user_id_fk": {
+          "name": "language_profile_user_id_user_id_fk",
+          "tableFrom": "language_profile",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "language_profile_user_id_unique": {
+          "name": "language_profile_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_request": {
+      "name": "match_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "requester_id": {
+          "name": "requester_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receiver_id": {
+          "name": "receiver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "match_request_requesterId_idx": {
+          "name": "match_request_requesterId_idx",
+          "columns": [
+            {
+              "expression": "requester_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "match_request_receiverId_idx": {
+          "name": "match_request_receiverId_idx",
+          "columns": [
+            {
+              "expression": "receiver_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "match_request_requester_id_user_id_fk": {
+          "name": "match_request_requester_id_user_id_fk",
+          "tableFrom": "match_request",
+          "tableTo": "user",
+          "columnsFrom": [
+            "requester_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "match_request_receiver_id_user_id_fk": {
+          "name": "match_request_receiver_id_user_id_fk",
+          "tableFrom": "match_request",
+          "tableTo": "user",
+          "columnsFrom": [
+            "receiver_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meetup": {
+      "name": "meetup",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "proposer_id": {
+          "name": "proposer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receiver_id": {
+          "name": "receiver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "venue_id": {
+          "name": "venue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "reschedule_proposer_id": {
+          "name": "reschedule_proposer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reschedule_venue_id": {
+          "name": "reschedule_venue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reschedule_date": {
+          "name": "reschedule_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reschedule_time": {
+          "name": "reschedule_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "meetup_proposerId_idx": {
+          "name": "meetup_proposerId_idx",
+          "columns": [
+            {
+              "expression": "proposer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meetup_receiverId_idx": {
+          "name": "meetup_receiverId_idx",
+          "columns": [
+            {
+              "expression": "receiver_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meetup_date_idx": {
+          "name": "meetup_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "meetup_proposer_id_user_id_fk": {
+          "name": "meetup_proposer_id_user_id_fk",
+          "tableFrom": "meetup",
+          "tableTo": "user",
+          "columnsFrom": [
+            "proposer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meetup_receiver_id_user_id_fk": {
+          "name": "meetup_receiver_id_user_id_fk",
+          "tableFrom": "meetup",
+          "tableTo": "user",
+          "columnsFrom": [
+            "receiver_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meetup_venue_id_venue_id_fk": {
+          "name": "meetup_venue_id_venue_id_fk",
+          "tableFrom": "meetup",
+          "tableTo": "venue",
+          "columnsFrom": [
+            "venue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meetup_reschedule_proposer_id_user_id_fk": {
+          "name": "meetup_reschedule_proposer_id_user_id_fk",
+          "tableFrom": "meetup",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reschedule_proposer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "meetup_reschedule_venue_id_venue_id_fk": {
+          "name": "meetup_reschedule_venue_id_venue_id_fk",
+          "tableFrom": "meetup",
+          "tableTo": "venue",
+          "columnsFrom": [
+            "reschedule_venue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message": {
+      "name": "message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_conversationId_idx": {
+          "name": "message_conversationId_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_createdAt_idx": {
+          "name": "message_createdAt_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_conversation_id_conversation_id_fk": {
+          "name": "message_conversation_id_conversation_id_fk",
+          "tableFrom": "message",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_sender_id_user_id_fk": {
+          "name": "message_sender_id_user_id_fk",
+          "tableFrom": "message",
+          "tableTo": "user",
+          "columnsFrom": [
+            "sender_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message_read_status": {
+      "name": "message_read_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_read_conversationId_userId_idx": {
+          "name": "message_read_conversationId_userId_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_read_status_conversation_id_conversation_id_fk": {
+          "name": "message_read_status_conversation_id_conversation_id_fk",
+          "tableFrom": "message_read_status",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_read_status_user_id_user_id_fk": {
+          "name": "message_read_status_user_id_user_id_fk",
+          "tableFrom": "message_read_status",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messaging_opt_in": {
+      "name": "messaging_opt_in",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "meetup_id": {
+          "name": "meetup_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "nudge_sent_at": {
+          "name": "nudge_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "messaging_opt_in_meetupId_idx": {
+          "name": "messaging_opt_in_meetupId_idx",
+          "columns": [
+            {
+              "expression": "meetup_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messaging_opt_in_meetup_id_meetup_id_fk": {
+          "name": "messaging_opt_in_meetup_id_meetup_id_fk",
+          "tableFrom": "messaging_opt_in",
+          "tableTo": "meetup",
+          "columnsFrom": [
+            "meetup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messaging_opt_in_student_id_user_id_fk": {
+          "name": "messaging_opt_in_student_id_user_id_fk",
+          "tableFrom": "messaging_opt_in",
+          "tableTo": "user",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "messaging_opt_in_meetup_student_unique": {
+          "name": "messaging_opt_in_meetup_student_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "meetup_id",
+            "student_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_comment": {
+      "name": "student_comment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "student_comment_targetId_idx": {
+          "name": "student_comment_targetId_idx",
+          "columns": [
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "student_comment_author_id_user_id_fk": {
+          "name": "student_comment_author_id_user_id_fk",
+          "tableFrom": "student_comment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "student_comment_target_id_user_id_fk": {
+          "name": "student_comment_target_id_user_id_fk",
+          "tableFrom": "student_comment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_match": {
+      "name": "student_match",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "student_a_id": {
+          "name": "student_a_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_b_id": {
+          "name": "student_b_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_request_id": {
+          "name": "match_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'matched'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "student_match_studentA_idx": {
+          "name": "student_match_studentA_idx",
+          "columns": [
+            {
+              "expression": "student_a_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "student_match_studentB_idx": {
+          "name": "student_match_studentB_idx",
+          "columns": [
+            {
+              "expression": "student_b_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "student_match_student_a_id_user_id_fk": {
+          "name": "student_match_student_a_id_user_id_fk",
+          "tableFrom": "student_match",
+          "tableTo": "user",
+          "columnsFrom": [
+            "student_a_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "student_match_student_b_id_user_id_fk": {
+          "name": "student_match_student_b_id_user_id_fk",
+          "tableFrom": "student_match",
+          "tableTo": "user",
+          "columnsFrom": [
+            "student_b_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "student_match_match_request_id_match_request_id_fk": {
+          "name": "student_match_match_request_id_match_request_id_fk",
+          "tableFrom": "student_match",
+          "tableTo": "match_request",
+          "columnsFrom": [
+            "match_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_device_token": {
+      "name": "user_device_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_device_token_userId_token_idx": {
+          "name": "user_device_token_userId_token_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_device_token_user_id_user_id_fk": {
+          "name": "user_device_token_user_id_user_id_fk",
+          "tableFrom": "user_device_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_interest": {
+      "name": "user_interest",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interest": {
+          "name": "interest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_interest_userId_idx": {
+          "name": "user_interest_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_interest_user_id_user_id_fk": {
+          "name": "user_interest_user_id_user_id_fk",
+          "tableFrom": "user_interest",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_language": {
+      "name": "user_language",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proficiency": {
+          "name": "proficiency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_language_userId_idx": {
+          "name": "user_language_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_language_user_id_user_id_fk": {
+          "name": "user_language_user_id_user_id_fk",
+          "tableFrom": "user_language",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.venue": {
+      "name": "venue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "venue_name_idx": {
+          "name": "venue_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1776109302796,
       "tag": "0009_narrow_orphan",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1776109533625,
+      "tag": "0010_kind_reaper",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/sip-and-speak.ts
+++ b/packages/db/src/schema/sip-and-speak.ts
@@ -150,11 +150,14 @@ export const conversation = pgTable(
     user2Id: text("user2_id")
       .notNull()
       .references(() => user.id, { onDelete: "cascade" }),
+    // #141 — FK to meetup; unique per meetup (at most one conversation per meetup pair)
+    meetupId: text("meetup_id").references(() => meetup.id, { onDelete: "set null" }),
     createdAt: timestamp("created_at").defaultNow().notNull(),
   },
   (table) => [
     index("conversation_user1_idx").on(table.user1Id),
     index("conversation_user2_idx").on(table.user2Id),
+    uniqueIndex("conversation_meetupId_idx").on(table.meetupId),
   ],
 );
 


### PR DESCRIPTION
## Summary

This task fulfils the promise of the messaging opt-in flow: when both Students agree, a conversation channel is unlocked. It detects the both-accepted state inside `respondToOptIn`, creates a `conversation` row guarded by an `ON CONFLICT DO NOTHING` on the new `meetupId` FK, and fires `ConversationOpened` so both Students receive a push notification with a deep link to the channel. This event is the upstream dependency for Features #26–#29.

## Changes

- **DB schema**: `meetupId` nullable FK + unique index added to `conversation` table
- **Domain events**: `ConversationOpened` event type added
- **Pure utils**: `bothAccepted(responses[])` extracted for unit testing
- **tRPC router**: after second accept, checks all responses; if both accepted, inserts conversation and emits `ConversationOpened`
- **Notification handler**: `handleConversationOpened` sends push to both Students with partner name and `/conversations/:id` deep link
- **Migration**: additive `meetupId` column on `conversation`

## Test plan

- [x] `bothAccepted` returns true only when exactly 2 accept responses present
- [x] `bothAccepted` returns false for any decline or missing response
- [x] Both Students receive push notification with correct partner name
- [x] No push when neither Student has a device token

## Related

Closes #141
