### PR TITLE
feat(messaging): block conversation and notify both Students on decline

### DIFF
--- a/apps/server/src/__tests__/notifications-messaging-decline.test.ts
+++ b/apps/server/src/__tests__/notifications-messaging-decline.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Tests for task #142 — Notify both Students when messaging channel won't open (decline outcome)
+ */
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+interface CapturedFetchCall {
+  url: string;
+  messages: Array<{ to: string; title?: string; body?: string; data?: Record<string, unknown> }>;
+}
+const fetchCalls: CapturedFetchCall[] = [];
+
+(global as unknown as { fetch: unknown }).fetch = mock(async (url: string, options: RequestInit) => {
+  fetchCalls.push({ url, messages: JSON.parse(options.body as string) as CapturedFetchCall["messages"] });
+  return { json: async () => ({ data: [{ status: "ok", id: "ticket-1" }] }) };
+});
+
+mock.module("@sip-and-speak/db/schema/sip-and-speak", () => ({ userDeviceToken: "userDeviceToken", userLanguage: "userLanguage" }));
+mock.module("@sip-and-speak/db/schema/auth", () => ({ user: "user" }));
+mock.module("drizzle-orm", () => ({ eq: (_col: unknown, val: unknown) => ({ _val: val }), or: (...args: unknown[]) => args }));
+
+const STUDENT_A_ID = "student-a-id";
+const STUDENT_B_ID = "student-b-id";
+
+let mockStudentATokens: Array<{ id: string; token: string }> = [];
+let mockStudentBTokens: Array<{ id: string; token: string }> = [];
+
+mock.module("@sip-and-speak/db", () => ({
+  db: {
+    select: (_fields: Record<string, unknown>) => ({
+      from: (_t: unknown) => ({
+        where: (clause: { _val: string }) => {
+          const rows = clause._val === STUDENT_A_ID ? mockStudentATokens : mockStudentBTokens;
+          return Promise.resolve(rows);
+        },
+      }),
+    }),
+  },
+}));
+
+mock.module("@sip-and-speak/api/domain-events", () => ({
+  domainEvents: { on: mock(() => undefined), emit: mock(() => undefined) },
+}));
+
+// eslint-disable-next-line import/first
+import { handleMessagingDeclineOutcome } from "../notifications";
+
+beforeEach(() => {
+  fetchCalls.length = 0;
+  mockStudentATokens = [];
+  mockStudentBTokens = [];
+});
+
+describe("#142 — Notify both Students on decline outcome", () => {
+  it("sends decline notification to both Students", async () => {
+    mockStudentATokens = [{ id: "tok-a", token: "ExponentPushToken[alice]" }];
+    mockStudentBTokens = [{ id: "tok-b", token: "ExponentPushToken[bob]" }];
+
+    await handleMessagingDeclineOutcome({ meetupId: "meetup-1", studentAId: STUDENT_A_ID, studentBId: STUDENT_B_ID });
+
+    expect(fetchCalls).toHaveLength(1);
+    const msgs = fetchCalls[0]!.messages;
+    expect(msgs).toHaveLength(2);
+    const tokens = msgs.map((m) => m.to);
+    expect(tokens).toContain("ExponentPushToken[alice]");
+    expect(tokens).toContain("ExponentPushToken[bob]");
+    msgs.forEach((m) => {
+      expect(m.title).toBe("Messaging not available");
+      expect(m.data?.type).toBe("messaging_decline_outcome");
+    });
+  });
+
+  it("sends no notification when neither Student has a device token", async () => {
+    await handleMessagingDeclineOutcome({ meetupId: "meetup-1", studentAId: STUDENT_A_ID, studentBId: STUDENT_B_ID });
+    expect(fetchCalls).toHaveLength(0);
+  });
+});

--- a/apps/server/src/notifications.ts
+++ b/apps/server/src/notifications.ts
@@ -8,7 +8,7 @@ import { eq } from "drizzle-orm";
 import { db } from "@sip-and-speak/db";
 import { userDeviceToken, userLanguage } from "@sip-and-speak/db/schema/sip-and-speak";
 import { user } from "@sip-and-speak/db/schema/auth";
-import { domainEvents, type MatchRequestSentEvent, type MatchRequestAcceptedEvent, type MatchRequestDeclinedEvent, type MeetupProposedEvent, type MeetupConfirmedEvent, type MeetupCounterProposedEvent, type MeetupDeclinedEvent, type MeetupCancelledEvent, type MeetupRescheduleProposedEvent, type MeetupRescheduledEvent, type MeetupRescheduleDeclinedEvent, type SipAndSpeakMomentCompletedEvent, type MeetupNotAttendedEvent, type MessagingOptInPromptedEvent, type MessagingNudgeNeededEvent, type ConversationOpenedEvent } from "@sip-and-speak/api/domain-events";
+import { domainEvents, type MatchRequestSentEvent, type MatchRequestAcceptedEvent, type MatchRequestDeclinedEvent, type MeetupProposedEvent, type MeetupConfirmedEvent, type MeetupCounterProposedEvent, type MeetupDeclinedEvent, type MeetupCancelledEvent, type MeetupRescheduleProposedEvent, type MeetupRescheduledEvent, type MeetupRescheduleDeclinedEvent, type SipAndSpeakMomentCompletedEvent, type MeetupNotAttendedEvent, type MessagingOptInPromptedEvent, type MessagingNudgeNeededEvent, type ConversationOpenedEvent, type MessagingDeclineOutcomeEvent } from "@sip-and-speak/api/domain-events";
 import { buildMatchRequestNotificationBody } from "@sip-and-speak/api/routers/matching-utils";
 
 const EXPO_PUSH_URL = "https://exp.host/--/api/v2/push/send";
@@ -385,6 +385,9 @@ export function registerNotificationHandlers(): void {
   domainEvents.on("ConversationOpened", (event) => {
     void handleConversationOpened(event);
   });
+  domainEvents.on("MessagingDeclineOutcome", (event) => {
+    void handleMessagingDeclineOutcome(event);
+  });
 }
 
 // #91 — Notify both Students when a reschedule is accepted and meetup details are updated
@@ -653,6 +656,33 @@ export async function handleConversationOpened(event: ConversationOpenedEvent): 
     await sendExpoPushNotification(messages);
   } catch (err) {
     console.error("[push] Failed to send ConversationOpened notification", { conversationId, meetupId, err });
+  }
+}
+
+// #142 — Notify both Students when messaging won't be available (decline outcome)
+export async function handleMessagingDeclineOutcome(event: MessagingDeclineOutcomeEvent): Promise<void> {
+  const { meetupId, studentAId, studentBId } = event;
+
+  const [tokensA, tokensB] = await Promise.all([
+    db.select({ id: userDeviceToken.id, token: userDeviceToken.token }).from(userDeviceToken).where(eq(userDeviceToken.userId, studentAId)),
+    db.select({ id: userDeviceToken.id, token: userDeviceToken.token }).from(userDeviceToken).where(eq(userDeviceToken.userId, studentBId)),
+  ]);
+
+  const messages: ExpoPushMessage[] = [
+    ...tokensA.map(({ token }) => ({ to: token, title: "Messaging not available", body: "One of you decided not to connect via messages — that's OK!", data: { meetupId, type: "messaging_decline_outcome" } })),
+    ...tokensB.map(({ token }) => ({ to: token, title: "Messaging not available", body: "One of you decided not to connect via messages — that's OK!", data: { meetupId, type: "messaging_decline_outcome" } })),
+  ];
+
+  if (messages.length === 0) {
+    console.info("[push] No tokens — skipping decline-outcome notification", { meetupId });
+    return;
+  }
+
+  console.info("[push] Sending MessagingDeclineOutcome notification", { meetupId, tokenCount: messages.length });
+  try {
+    await sendExpoPushNotification(messages);
+  } catch (err) {
+    console.error("[push] Failed to send MessagingDeclineOutcome notification", { meetupId, err });
   }
 }
 

--- a/packages/api/src/__tests__/messaging-decline.test.ts
+++ b/packages/api/src/__tests__/messaging-decline.test.ts
@@ -1,0 +1,23 @@
+/**
+ * Tests for task #142 — Block conversation when either Student declines
+ */
+import { describe, it, expect } from "bun:test";
+import { isDeclineOutcome } from "../routers/messaging-utils";
+
+describe("#142 — isDeclineOutcome", () => {
+  it("returns true when second Student declines after first accepted", () => {
+    expect(isDeclineOutcome([{ response: "accept" }, { response: "decline" }])).toBe(true);
+  });
+  it("returns true when first Student declines before second accepts", () => {
+    expect(isDeclineOutcome([{ response: "decline" }, { response: "accept" }])).toBe(true);
+  });
+  it("returns true when both Students decline", () => {
+    expect(isDeclineOutcome([{ response: "decline" }, { response: "decline" }])).toBe(true);
+  });
+  it("returns false when both accepted (conversation path)", () => {
+    expect(isDeclineOutcome([{ response: "accept" }, { response: "accept" }])).toBe(false);
+  });
+  it("returns false when only one has responded", () => {
+    expect(isDeclineOutcome([{ response: "decline" }])).toBe(false);
+  });
+});

--- a/packages/api/src/domain-events.ts
+++ b/packages/api/src/domain-events.ts
@@ -166,6 +166,12 @@ export interface ConversationOpenedEvent {
   openedAt: Date;
 }
 
+export interface MessagingDeclineOutcomeEvent {
+  meetupId: string;
+  studentAId: string;
+  studentBId: string;
+}
+
 export interface MessagingNudgeNeededEvent {
   meetupId: string;
   /** The student who accepted and triggered the nudge */
@@ -197,6 +203,7 @@ type DomainEventMap = {
   MessagingDeclined: [MessagingDeclinedEvent];
   MessagingNudgeNeeded: [MessagingNudgeNeededEvent];
   ConversationOpened: [ConversationOpenedEvent];
+  MessagingDeclineOutcome: [MessagingDeclineOutcomeEvent];
 };
 
 class TypedEventEmitter extends EventEmitter {

--- a/packages/api/src/routers/messaging-utils.ts
+++ b/packages/api/src/routers/messaging-utils.ts
@@ -35,6 +35,17 @@ export function bothAccepted(
 }
 
 /**
+ * Returns true when both Students have responded and at least one declined.
+ * Used to determine whether to send the decline-outcome notifications.
+ * Note: does NOT reveal which Student declined — callers must not expose that.
+ */
+export function isDeclineOutcome(
+  responses: Array<{ response: "accept" | "decline" }>,
+): boolean {
+  return responses.length === 2 && !responses.every((r) => r.response === "accept");
+}
+
+/**
  * Derives the partner's ID from a meetup's proposer/receiver pair.
  */
 export function getPartnerId(

--- a/packages/api/src/routers/messaging.ts
+++ b/packages/api/src/routers/messaging.ts
@@ -6,7 +6,7 @@ import { protectedProcedure, router } from "../index";
 import { domainEvents } from "../domain-events";
 import { db } from "@sip-and-speak/db";
 import { meetup, messagingOptIn, conversation } from "@sip-and-speak/db/schema/sip-and-speak";
-import { hasAlreadyResponded, getPartnerId, shouldSendNudge, bothAccepted } from "./messaging-utils";
+import { hasAlreadyResponded, getPartnerId, shouldSendNudge, bothAccepted, isDeclineOutcome } from "./messaging-utils";
 
 export const messagingRouter = router({
   /**
@@ -167,6 +167,20 @@ export const messagingRouter = router({
           partnerId,
           respondedAt: created!.respondedAt,
         });
+
+        // #142 — Check if both have now responded; if any declined, emit outcome
+        const declineResponses = await db
+          .select({ response: messagingOptIn.response })
+          .from(messagingOptIn)
+          .where(eq(messagingOptIn.meetupId, input.meetupId));
+
+        if (isDeclineOutcome(declineResponses)) {
+          domainEvents.emit("MessagingDeclineOutcome", {
+            meetupId: input.meetupId,
+            studentAId: studentId,
+            studentBId: partnerId,
+          });
+        }
       }
 
       console.log(


### PR DESCRIPTION
## Summary
When either Student declines, the conversation is never created (already guarded by `bothAccepted` in #141). This task detects the decline outcome after both have responded and notifies both Students sensitively — without revealing who declined.

## Changes
- `isDeclineOutcome` pure helper in `messaging-utils.ts`
- `MessagingDeclineOutcome` domain event
- `respondToOptIn` emits event after a decline when both have responded
- `handleMessagingDeclineOutcome` sends push to both Students

## Test plan
- [x] Decline after accept → `isDeclineOutcome` true
- [x] Accept after decline → `isDeclineOutcome` true  
- [x] Both decline → `isDeclineOutcome` true
- [x] Both push notifications sent correctly
- [x] No push when no tokens

## Related
Closes #142