### PR TITLE
feat(messaging): connected student can accept or decline messaging after meetup

### DIFF
--- a/.wolf/anatomy.md
+++ b/.wolf/anatomy.md
@@ -1,12 +1,19 @@
 # anatomy.md
 
-> Auto-maintained by OpenWolf. Last scanned: 2026-04-13T18:00:36.014Z
-> Files: 244 tracked | Anatomy hits: 0 | Misses: 0
+> Auto-maintained by OpenWolf. Last scanned: 2026-04-13T19:33:10.539Z
+> Files: 249 tracked | Anatomy hits: 0 | Misses: 0
+
+## ../../../../tmp/
+
+- `pr-138-body.md` — Summary (~361 tok)
+- `task-138-body.md` — 🛠 Task: Send opt-in push notification to both Students after meetup is completed (~1150 tok)
+- `verify-138-body.md` — 🛠 Task: Send opt-in push notification to both Students after meetup is completed (~1104 tok)
 
 ## ../../.claude/projects/-Users-sander-personal-sip-and-speak/memory/
 
-- `MEMORY.md` — Memory Index (~73 tok)
+- `MEMORY.md` — Memory Index (~106 tok)
 - `project_epic3_loop_progress.md` — Completed (merged to main) (~838 tok)
+- `project_epic4_loop_progress.md` — Completed (~498 tok)
 
 ## ./
 
@@ -364,7 +371,7 @@
 ## apps/server/src/
 
 - `index.ts` — Wire domain event → push notification handlers on server start (~768 tok)
-- `notifications.ts` — Push notification service — Expo Push Notifications (~4231 tok)
+- `notifications.ts` — Push notification service — Expo Push Notifications (~6318 tok)
 
 ## apps/server/src/__tests__/
 
@@ -374,6 +381,7 @@
 - `notifications-meetup-confirmed.test.ts` — Tests for task #75 — Push notification on MeetupConfirmed (~1146 tok)
 - `notifications-meetup-counter-proposed.test.ts` — Tests for task #76 — Push notification on MeetupCounterProposed (~983 tok)
 - `notifications-meetup-declined.test.ts` — Tests for task #77 — Push notification on MeetupDeclined (~1012 tok)
+- `notifications-messaging-opt-in.test.ts` — Tests for task #138 — Send opt-in push notification to both Students after meetup is completed (~1504 tok)
 - `notifications-reschedule-proposed.test.ts` — Tests for task #89 — Push notification on MeetupRescheduleProposed (~777 tok)
 
 ## apps/web/
@@ -442,7 +450,7 @@
 ## packages/api/src/
 
 - `context.ts` — Exports CreateContextOptions, createContext, Context (~126 tok)
-- `domain-events.ts` — The student who just counter-proposed (new proposer after role swap) (~888 tok)
+- `domain-events.ts` — The student who just counter-proposed (new proposer after role swap) (~1357 tok)
 - `index.ts` — tRPC router (~156 tok)
 
 ## packages/api/src/__tests__/
@@ -456,7 +464,7 @@
 - `index.ts` — tRPC router: 2 procedures (~221 tok)
 - `matching-utils.ts` — Haversine distance in km between two lat/lng points (~1049 tok)
 - `matching.ts` — tRPC router: 5 procedures (~4728 tok)
-- `meetup.ts` — All bookable half-hour slots from 08:00 to 20:00 (~7091 tok)
+- `meetup.ts` — All bookable half-hour slots from 08:00 to 20:00 (~10102 tok)
 - `profile.ts` — tRPC router: 6 procedures (~4644 tok)
 - `venue-admin.ts` — Exports adminVenueRouter (~1166 tok)
 - `venue.ts` — Zod schemas: venueTagEnum (~1054 tok)
@@ -519,7 +527,7 @@
 
 - `auth.ts` — Exports user, session, account, verification + 3 more (~1028 tok)
 - `index.ts` (~17 tok)
-- `sip-and-speak.ts` — Exports languageProfile, userLanguage, userInterest, venue + 19 more (~3304 tok)
+- `sip-and-speak.ts` — Exports languageProfile, userLanguage, userInterest, venue + 19 more (~4002 tok)
 
 ## packages/db/src/seed/
 

--- a/.wolf/buglog.json
+++ b/.wolf/buglog.json
@@ -1474,6 +1474,70 @@
       "related_bugs": [],
       "occurrences": 1,
       "last_seen": "2026-04-13T17:59:00.983Z"
+    },
+    {
+      "id": "bug-092",
+      "timestamp": "2026-04-13T19:05:48.319Z",
+      "error_message": "Missing error handling in function",
+      "file": "apps/server/src/notifications.ts",
+      "root_cause": "Code path had no error handling — exceptions would propagate uncaught",
+      "fix": "Added try/catch block",
+      "tags": [
+        "auto-detected",
+        "error-handling",
+        "ts"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-04-13T19:05:48.319Z"
+    },
+    {
+      "id": "bug-093",
+      "timestamp": "2026-04-13T19:20:54.170Z",
+      "error_message": "Significant refactor of ",
+      "file": "../../../../tmp/task-138-body.md",
+      "root_cause": "6 lines replaced/restructured",
+      "fix": "Rewrote 20→20 lines (6 removed) | Also: | Both Students receive opt-in prompt | | |; | No duplicate push on repeat completion | | |",
+      "tags": [
+        "auto-detected",
+        "refactor",
+        "md"
+      ],
+      "related_bugs": [],
+      "occurrences": 2,
+      "last_seen": "2026-04-13T19:20:58.995Z"
+    },
+    {
+      "id": "bug-094",
+      "timestamp": "2026-04-13T19:22:01.279Z",
+      "error_message": "Significant refactor of ",
+      "file": "../../../../tmp/verify-138-body.md",
+      "root_cause": "4 lines replaced/restructured",
+      "fix": "Rewrote 6→6 lines (4 removed)",
+      "tags": [
+        "auto-detected",
+        "refactor",
+        "md"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-04-13T19:22:01.279Z"
+    },
+    {
+      "id": "bug-095",
+      "timestamp": "2026-04-13T19:32:59.524Z",
+      "error_message": "Type error",
+      "file": "packages/db/src/schema/sip-and-speak.ts",
+      "root_cause": "Missing or incorrect type annotation",
+      "fix": "Added type assertion/annotation",
+      "tags": [
+        "auto-detected",
+        "type-fix",
+        "ts"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-04-13T19:32:59.524Z"
     }
   ]
 }

--- a/.wolf/cron-state.json
+++ b/.wolf/cron-state.json
@@ -1,5 +1,5 @@
 {
-  "last_heartbeat": "2026-04-13T17:59:08.084Z",
+  "last_heartbeat": "2026-04-13T19:29:08.121Z",
   "engine_status": "running",
   "execution_log": [
     {

--- a/.wolf/hooks/_session.json
+++ b/.wolf/hooks/_session.json
@@ -1,33 +1,80 @@
 {
-  "session_id": "session-2026-04-13-2001",
-  "started": "2026-04-13T18:01:27.274Z",
+  "session_id": "session-2026-04-13-2131",
+  "started": "2026-04-13T19:31:40.657Z",
   "files_read": {
-    "/Users/sander/personal/sip-and-speak/apps/server/src/notifications.ts": {
+    "/Users/sander/.claude/projects/-Users-sander-personal-sip-and-speak/memory/project_epic4_loop_progress.md": {
       "count": 1,
-      "tokens": 4231,
-      "first_read": "2026-04-13T19:00:30.388Z"
+      "tokens": 0,
+      "first_read": "2026-04-13T19:31:47.272Z"
     },
-    "/Users/sander/personal/sip-and-speak/packages/api/src/routers/meetup.ts": {
-      "count": 2,
-      "tokens": 7091,
-      "first_read": "2026-04-13T19:00:30.729Z"
+    "/Users/sander/personal/sip-and-speak/packages/db/src/schema/sip-and-speak.ts": {
+      "count": 1,
+      "tokens": 3304,
+      "first_read": "2026-04-13T19:32:09.768Z"
+    },
+    "/Users/sander/personal/sip-and-speak/packages/api/src/routers/index.ts": {
+      "count": 1,
+      "tokens": 221,
+      "first_read": "2026-04-13T19:32:09.977Z"
+    },
+    "/Users/sander/personal/sip-and-speak/packages/api/src/__tests__/meetup-rounds.test.ts": {
+      "count": 1,
+      "tokens": 256,
+      "first_read": "2026-04-13T19:32:15.859Z"
+    },
+    "/Users/sander/personal/sip-and-speak/packages/api/src/__tests__/matching.test.ts": {
+      "count": 1,
+      "tokens": 758,
+      "first_read": "2026-04-13T19:32:15.891Z"
     },
     "/Users/sander/personal/sip-and-speak/packages/api/src/domain-events.ts": {
       "count": 1,
-      "tokens": 888,
-      "first_read": "2026-04-13T19:00:49.939Z"
+      "tokens": 1257,
+      "first_read": "2026-04-13T19:32:26.989Z"
     },
-    "/Users/sander/personal/sip-and-speak/apps/server/src/__tests__/notifications-meetup-confirmed.test.ts": {
+    "/Users/sander/personal/sip-and-speak/packages/api/src/index.ts": {
       "count": 1,
-      "tokens": 1146,
-      "first_read": "2026-04-13T19:00:58.969Z"
+      "tokens": 156,
+      "first_read": "2026-04-13T19:32:27.403Z"
+    },
+    "/Users/sander/personal/sip-and-speak/packages/api/src/routers/meetup.ts": {
+      "count": 1,
+      "tokens": 10102,
+      "first_read": "2026-04-13T19:32:38.266Z"
+    },
+    "/Users/sander/personal/sip-and-speak/packages/db/src/schema/index.ts": {
+      "count": 1,
+      "tokens": 17,
+      "first_read": "2026-04-13T19:33:02.202Z"
     }
   },
-  "files_written": [],
-  "edit_counts": {},
-  "anatomy_hits": 4,
-  "anatomy_misses": 0,
-  "repeated_reads_warned": 1,
+  "files_written": [
+    {
+      "file": "/Users/sander/personal/sip-and-speak/packages/db/src/schema/sip-and-speak.ts",
+      "action": "edit",
+      "tokens": 327,
+      "at": "2026-04-13T19:32:59.522Z"
+    },
+    {
+      "file": "/Users/sander/personal/sip-and-speak/packages/api/src/domain-events.ts",
+      "action": "edit",
+      "tokens": 111,
+      "at": "2026-04-13T19:33:07.293Z"
+    },
+    {
+      "file": "/Users/sander/personal/sip-and-speak/packages/api/src/domain-events.ts",
+      "action": "edit",
+      "tokens": 44,
+      "at": "2026-04-13T19:33:10.546Z"
+    }
+  ],
+  "edit_counts": {
+    "packages/db/src/schema/sip-and-speak.ts": 1,
+    "packages/api/src/domain-events.ts": 2
+  },
+  "anatomy_hits": 8,
+  "anatomy_misses": 1,
+  "repeated_reads_warned": 0,
   "cerebrum_warnings": 0,
   "stop_count": 0
 }

--- a/.wolf/memory.md
+++ b/.wolf/memory.md
@@ -543,3 +543,32 @@
 
 | Time | Action | File(s) | Outcome | ~Tokens |
 |------|--------|---------|---------|--------|
+
+## Session: 2026-04-13 21:02
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+| 21:05 | Edited packages/api/src/domain-events.ts | expanded (+7 lines) | ~75 |
+| 21:05 | Edited packages/api/src/domain-events.ts | 2→3 lines | ~48 |
+| 21:05 | Edited packages/api/src/routers/meetup.ts | expanded (+8 lines) | ~168 |
+| 21:05 | Edited apps/server/src/notifications.ts | inline fix | ~142 |
+| 21:05 | Edited apps/server/src/notifications.ts | added error handling | ~610 |
+| 21:05 | Edited apps/server/src/notifications.ts | 4→7 lines | ~60 |
+| 21:06 | Created apps/server/src/__tests__/notifications-messaging-opt-in.test.ts | — | ~1504 |
+| 21:20 | Edited ../../../../tmp/task-138-body.md | 20→20 lines | ~337 |
+| 21:20 | Edited ../../../../tmp/task-138-body.md | 6→6 lines | ~115 |
+| 21:22 | Edited ../../../../tmp/verify-138-body.md | 6→6 lines | ~65 |
+| 21:22 | Edited ../../../../tmp/verify-138-body.md | inline fix | ~21 |
+| 21:27 | Edited ../../../../tmp/verify-138-body.md | 9→9 lines | ~63 |
+| 21:28 | Created ../../../../tmp/pr-138-body.md | — | ~385 |
+| 21:29 | Created ../../.claude/projects/-Users-sander-personal-sip-and-speak/memory/project_epic4_loop_progress.md | — | ~517 |
+| 21:29 | Edited ../../.claude/projects/-Users-sander-personal-sip-and-speak/memory/MEMORY.md | 4→5 lines | ~113 |
+| 21:29 | Session end: 2 writes across 2 files (project_epic4_loop_progress.md, MEMORY.md) | 5 reads | ~14070 tok |
+
+## Session: 2026-04-13 21:31
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+| 21:32 | Edited packages/db/src/schema/sip-and-speak.ts | expanded (+33 lines) | ~327 |
+| 21:33 | Edited packages/api/src/domain-events.ts | expanded (+14 lines) | ~111 |
+| 21:33 | Edited packages/api/src/domain-events.ts | 2→4 lines | ~44 |

--- a/.wolf/token-ledger.json
+++ b/.wolf/token-ledger.json
@@ -2,14 +2,14 @@
   "version": 1,
   "created_at": "2026-04-10T10:02:44.507Z",
   "lifetime": {
-    "total_tokens_estimated": 625810,
-    "total_reads": 376,
-    "total_writes": 557,
-    "total_sessions": 35,
-    "anatomy_hits": 304,
+    "total_tokens_estimated": 648523,
+    "total_reads": 383,
+    "total_writes": 559,
+    "total_sessions": 37,
+    "anatomy_hits": 311,
     "anatomy_misses": 72,
-    "repeated_reads_blocked": 93,
-    "estimated_savings_vs_bare_cli": 330097
+    "repeated_reads_blocked": 95,
+    "estimated_savings_vs_bare_cli": 345679
   },
   "sessions": [
     {
@@ -5882,6 +5882,91 @@
         "writes_count": 14,
         "repeated_reads_blocked": 1,
         "anatomy_lookups": 6
+      }
+    },
+    {
+      "id": "session-2026-04-13-2102",
+      "started": "2026-04-13T19:02:11.499Z",
+      "ended": "2026-04-13T19:04:01.543Z",
+      "reads": [
+        {
+          "file": "/Users/sander/personal/sip-and-speak/packages/api/src/routers/meetup.ts",
+          "tokens_estimated": 7091,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/apps/native/app/_layout.tsx",
+          "tokens_estimated": 1552,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        }
+      ],
+      "writes": [],
+      "totals": {
+        "input_tokens_estimated": 8643,
+        "output_tokens_estimated": 0,
+        "reads_count": 2,
+        "writes_count": 0,
+        "repeated_reads_blocked": 1,
+        "anatomy_lookups": 2
+      }
+    },
+    {
+      "id": "session-2026-04-13-2001",
+      "started": "2026-04-13T18:01:27.274Z",
+      "ended": "2026-04-13T19:29:45.007Z",
+      "reads": [
+        {
+          "file": "/Users/sander/personal/sip-and-speak/apps/server/src/notifications.ts",
+          "tokens_estimated": 4231,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/packages/api/src/routers/meetup.ts",
+          "tokens_estimated": 7091,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/packages/api/src/domain-events.ts",
+          "tokens_estimated": 888,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/apps/server/src/__tests__/notifications-meetup-confirmed.test.ts",
+          "tokens_estimated": 1146,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/sander/.claude/projects/-Users-sander-personal-sip-and-speak/memory/MEMORY.md",
+          "tokens_estimated": 39,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        }
+      ],
+      "writes": [
+        {
+          "file": "/Users/sander/.claude/projects/-Users-sander-personal-sip-and-speak/memory/project_epic4_loop_progress.md",
+          "tokens_estimated": 554,
+          "action": "create"
+        },
+        {
+          "file": "/Users/sander/.claude/projects/-Users-sander-personal-sip-and-speak/memory/MEMORY.md",
+          "tokens_estimated": 121,
+          "action": "edit"
+        }
+      ],
+      "totals": {
+        "input_tokens_estimated": 13395,
+        "output_tokens_estimated": 675,
+        "reads_count": 5,
+        "writes_count": 2,
+        "repeated_reads_blocked": 1,
+        "anatomy_lookups": 5
       }
     }
   ],

--- a/apps/server/src/__tests__/notifications-conversation-opened.test.ts
+++ b/apps/server/src/__tests__/notifications-conversation-opened.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Tests for task #141 — Open conversation channel and notify both Students when both accept
+ *
+ * Covers:
+ *   - Both Students receive a "messaging is now open" push notification
+ *   - No notification sent when neither Student has a device token
+ */
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+// ── Fetch mock ────────────────────────────────────────────────────────────────
+
+interface CapturedFetchCall {
+  url: string;
+  messages: Array<{ to: string; title?: string; body?: string; data?: Record<string, unknown> }>;
+}
+
+const fetchCalls: CapturedFetchCall[] = [];
+
+(global as unknown as { fetch: unknown }).fetch = mock(async (url: string, options: RequestInit) => {
+  fetchCalls.push({
+    url,
+    messages: JSON.parse(options.body as string) as CapturedFetchCall["messages"],
+  });
+  return {
+    json: async () => ({ data: [{ status: "ok", id: "ticket-1" }] }),
+  };
+});
+
+// ── Schema mocks ──────────────────────────────────────────────────────────────
+
+const USER_TABLE = "user";
+const DEVICE_TOKEN_TABLE = "userDeviceToken";
+
+mock.module("@sip-and-speak/db/schema/sip-and-speak", () => ({
+  userDeviceToken: DEVICE_TOKEN_TABLE,
+  userLanguage: "userLanguage",
+}));
+
+mock.module("@sip-and-speak/db/schema/auth", () => ({
+  user: USER_TABLE,
+}));
+
+// ── drizzle-orm mock ──────────────────────────────────────────────────────────
+
+mock.module("drizzle-orm", () => ({
+  eq: (_col: unknown, val: unknown) => ({ _val: val }),
+  or: (...args: unknown[]) => args,
+}));
+
+// ── DB mock ───────────────────────────────────────────────────────────────────
+
+const STUDENT_A_ID = "student-a-id";
+const STUDENT_B_ID = "student-b-id";
+
+let mockStudentATokens: Array<{ id: string; token: string }> = [];
+let mockStudentBTokens: Array<{ id: string; token: string }> = [];
+
+const STUDENT_A_NAME = [{ name: "Alice" }];
+const STUDENT_B_NAME = [{ name: "Bob" }];
+
+mock.module("@sip-and-speak/db", () => ({
+  db: {
+    select: (fields: Record<string, unknown>) => {
+      const isNameQuery = "name" in fields;
+      return {
+        from: (_table: unknown) => ({
+          where: (clause: { _val: string }) => {
+            if (isNameQuery) {
+              const rows = clause._val === STUDENT_A_ID ? STUDENT_A_NAME : STUDENT_B_NAME;
+              return { limit: (_n: number) => Promise.resolve(rows) };
+            }
+            const rows =
+              clause._val === STUDENT_A_ID ? mockStudentATokens : mockStudentBTokens;
+            return Promise.resolve(rows);
+          },
+        }),
+      };
+    },
+  },
+}));
+
+// ── Domain events mock ────────────────────────────────────────────────────────
+
+mock.module("@sip-and-speak/api/domain-events", () => ({
+  domainEvents: { on: mock((_evt: string, _fn: unknown) => undefined), emit: mock(() => undefined) },
+}));
+
+// ── Import under test (after mocks) ──────────────────────────────────────────
+
+// eslint-disable-next-line import/first
+import { handleConversationOpened } from "../notifications";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeConversationOpenedEvent(
+  overrides: Partial<{
+    conversationId: string;
+    meetupId: string;
+    studentAId: string;
+    studentBId: string;
+  }> = {},
+) {
+  return {
+    conversationId: overrides.conversationId ?? "conv-1",
+    meetupId: overrides.meetupId ?? "meetup-1",
+    studentAId: overrides.studentAId ?? STUDENT_A_ID,
+    studentBId: overrides.studentBId ?? STUDENT_B_ID,
+    openedAt: new Date(),
+  };
+}
+
+beforeEach(() => {
+  fetchCalls.length = 0;
+  mockStudentATokens = [];
+  mockStudentBTokens = [];
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("#141 — Notify both Students when conversation channel opens", () => {
+  it("sends a push to both Students with partner name and conversation deep link", async () => {
+    mockStudentATokens = [{ id: "tok-a", token: "ExponentPushToken[alice]" }];
+    mockStudentBTokens = [{ id: "tok-b", token: "ExponentPushToken[bob]" }];
+
+    await handleConversationOpened(makeConversationOpenedEvent());
+
+    expect(fetchCalls).toHaveLength(1);
+
+    const call = fetchCalls[0];
+    if (!call) throw new Error("Expected a fetch call");
+
+    expect(call.messages).toHaveLength(2);
+
+    const aliceMsg = call.messages.find((m) => m.to === "ExponentPushToken[alice]");
+    const bobMsg = call.messages.find((m) => m.to === "ExponentPushToken[bob]");
+
+    expect(aliceMsg?.title).toBe("Your messaging channel is open!");
+    expect(aliceMsg?.body).toContain("Bob");
+    expect(aliceMsg?.data?.type).toBe("conversation_opened");
+    expect(aliceMsg?.data?.conversationId).toBe("conv-1");
+    expect(aliceMsg?.data?.deepLink).toBe("/conversations/conv-1");
+
+    expect(bobMsg?.title).toBe("Your messaging channel is open!");
+    expect(bobMsg?.body).toContain("Alice");
+    expect(bobMsg?.data?.conversationId).toBe("conv-1");
+  });
+
+  it("sends no notification when neither Student has a registered device token", async () => {
+    mockStudentATokens = [];
+    mockStudentBTokens = [];
+
+    await handleConversationOpened(makeConversationOpenedEvent());
+
+    expect(fetchCalls).toHaveLength(0);
+  });
+});

--- a/apps/server/src/__tests__/notifications-messaging-decline.test.ts
+++ b/apps/server/src/__tests__/notifications-messaging-decline.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Tests for task #142 — Notify both Students when messaging channel won't open (decline outcome)
+ */
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+interface CapturedFetchCall {
+  url: string;
+  messages: Array<{ to: string; title?: string; body?: string; data?: Record<string, unknown> }>;
+}
+const fetchCalls: CapturedFetchCall[] = [];
+
+(global as unknown as { fetch: unknown }).fetch = mock(async (url: string, options: RequestInit) => {
+  fetchCalls.push({ url, messages: JSON.parse(options.body as string) as CapturedFetchCall["messages"] });
+  return { json: async () => ({ data: [{ status: "ok", id: "ticket-1" }] }) };
+});
+
+mock.module("@sip-and-speak/db/schema/sip-and-speak", () => ({ userDeviceToken: "userDeviceToken", userLanguage: "userLanguage" }));
+mock.module("@sip-and-speak/db/schema/auth", () => ({ user: "user" }));
+mock.module("drizzle-orm", () => ({ eq: (_col: unknown, val: unknown) => ({ _val: val }), or: (...args: unknown[]) => args }));
+
+const STUDENT_A_ID = "student-a-id";
+const STUDENT_B_ID = "student-b-id";
+
+let mockStudentATokens: Array<{ id: string; token: string }> = [];
+let mockStudentBTokens: Array<{ id: string; token: string }> = [];
+
+mock.module("@sip-and-speak/db", () => ({
+  db: {
+    select: (_fields: Record<string, unknown>) => ({
+      from: (_t: unknown) => ({
+        where: (clause: { _val: string }) => {
+          const rows = clause._val === STUDENT_A_ID ? mockStudentATokens : mockStudentBTokens;
+          return Promise.resolve(rows);
+        },
+      }),
+    }),
+  },
+}));
+
+mock.module("@sip-and-speak/api/domain-events", () => ({
+  domainEvents: { on: mock(() => undefined), emit: mock(() => undefined) },
+}));
+
+// eslint-disable-next-line import/first
+import { handleMessagingDeclineOutcome } from "../notifications";
+
+beforeEach(() => {
+  fetchCalls.length = 0;
+  mockStudentATokens = [];
+  mockStudentBTokens = [];
+});
+
+describe("#142 — Notify both Students on decline outcome", () => {
+  it("sends decline notification to both Students", async () => {
+    mockStudentATokens = [{ id: "tok-a", token: "ExponentPushToken[alice]" }];
+    mockStudentBTokens = [{ id: "tok-b", token: "ExponentPushToken[bob]" }];
+
+    await handleMessagingDeclineOutcome({ meetupId: "meetup-1", studentAId: STUDENT_A_ID, studentBId: STUDENT_B_ID });
+
+    expect(fetchCalls).toHaveLength(1);
+    const msgs = fetchCalls[0]!.messages;
+    expect(msgs).toHaveLength(2);
+    const tokens = msgs.map((m) => m.to);
+    expect(tokens).toContain("ExponentPushToken[alice]");
+    expect(tokens).toContain("ExponentPushToken[bob]");
+    msgs.forEach((m) => {
+      expect(m.title).toBe("Messaging not available");
+      expect(m.data?.type).toBe("messaging_decline_outcome");
+    });
+  });
+
+  it("sends no notification when neither Student has a device token", async () => {
+    await handleMessagingDeclineOutcome({ meetupId: "meetup-1", studentAId: STUDENT_A_ID, studentBId: STUDENT_B_ID });
+    expect(fetchCalls).toHaveLength(0);
+  });
+});

--- a/apps/server/src/__tests__/notifications-messaging-nudge.test.ts
+++ b/apps/server/src/__tests__/notifications-messaging-nudge.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Tests for task #140 — Send second push to pending Student when their match accepts
+ *
+ * Covers:
+ *   - Pending Student receives a nudge push when their match accepts
+ *   - No nudge sent when pending Student has no device token
+ */
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+// ── Fetch mock ────────────────────────────────────────────────────────────────
+
+interface CapturedFetchCall {
+  url: string;
+  messages: Array<{ to: string; title?: string; body?: string; data?: Record<string, unknown> }>;
+}
+
+const fetchCalls: CapturedFetchCall[] = [];
+
+(global as unknown as { fetch: unknown }).fetch = mock(async (url: string, options: RequestInit) => {
+  fetchCalls.push({
+    url,
+    messages: JSON.parse(options.body as string) as CapturedFetchCall["messages"],
+  });
+  return {
+    json: async () => ({ data: [{ status: "ok", id: "ticket-1" }] }),
+  };
+});
+
+// ── Schema mocks ──────────────────────────────────────────────────────────────
+
+const USER_TABLE = "user";
+const DEVICE_TOKEN_TABLE = "userDeviceToken";
+
+mock.module("@sip-and-speak/db/schema/sip-and-speak", () => ({
+  userDeviceToken: DEVICE_TOKEN_TABLE,
+  userLanguage: "userLanguage",
+}));
+
+mock.module("@sip-and-speak/db/schema/auth", () => ({
+  user: USER_TABLE,
+}));
+
+// ── drizzle-orm mock ──────────────────────────────────────────────────────────
+
+mock.module("drizzle-orm", () => ({
+  eq: (_col: unknown, val: unknown) => ({ _val: val }),
+  or: (...args: unknown[]) => args,
+}));
+
+// ── DB mock ───────────────────────────────────────────────────────────────────
+
+const ACCEPTING_STUDENT_ID = "student-a-id";
+const PENDING_STUDENT_ID = "student-b-id";
+
+let mockAcceptingStudentTokens: Array<{ id: string; token: string }> = [];
+let mockPendingStudentTokens: Array<{ id: string; token: string }> = [];
+
+const ACCEPTING_STUDENT_NAME = [{ name: "Alice" }];
+
+mock.module("@sip-and-speak/db", () => ({
+  db: {
+    select: (fields: Record<string, unknown>) => {
+      const isNameQuery = "name" in fields;
+      return {
+        from: (_table: unknown) => ({
+          where: (clause: { _val: string }) => {
+            if (isNameQuery) {
+              const rows = clause._val === ACCEPTING_STUDENT_ID ? ACCEPTING_STUDENT_NAME : [];
+              return { limit: (_n: number) => Promise.resolve(rows) };
+            }
+            const rows =
+              clause._val === ACCEPTING_STUDENT_ID
+                ? mockAcceptingStudentTokens
+                : mockPendingStudentTokens;
+            return Promise.resolve(rows);
+          },
+        }),
+      };
+    },
+  },
+}));
+
+// ── Domain events mock ────────────────────────────────────────────────────────
+
+mock.module("@sip-and-speak/api/domain-events", () => ({
+  domainEvents: { on: mock((_evt: string, _fn: unknown) => undefined), emit: mock(() => undefined) },
+}));
+
+// ── Import under test (after mocks) ──────────────────────────────────────────
+
+// eslint-disable-next-line import/first
+import { handleMessagingNudge } from "../notifications";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeNudgeEvent(
+  overrides: Partial<{
+    meetupId: string;
+    acceptingStudentId: string;
+    pendingStudentId: string;
+  }> = {},
+) {
+  return {
+    meetupId: overrides.meetupId ?? "meetup-1",
+    acceptingStudentId: overrides.acceptingStudentId ?? ACCEPTING_STUDENT_ID,
+    pendingStudentId: overrides.pendingStudentId ?? PENDING_STUDENT_ID,
+  };
+}
+
+beforeEach(() => {
+  fetchCalls.length = 0;
+  mockAcceptingStudentTokens = [];
+  mockPendingStudentTokens = [];
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("#140 — Send second push to pending Student when their match accepts", () => {
+  it("sends a nudge push to the pending Student with the accepting Student's name", async () => {
+    mockPendingStudentTokens = [{ id: "tok-b", token: "ExponentPushToken[bob]" }];
+
+    await handleMessagingNudge(makeNudgeEvent());
+
+    expect(fetchCalls).toHaveLength(1);
+
+    const call = fetchCalls[0];
+    if (!call) throw new Error("Expected a fetch call");
+
+    expect(call.messages).toHaveLength(1);
+    const msg = call.messages[0];
+    if (!msg) throw new Error("Expected a message");
+
+    expect(msg.to).toBe("ExponentPushToken[bob]");
+    expect(msg.title).toBe("Your match wants to message you!");
+    expect(msg.body).toContain("Alice");
+    expect(msg.data?.type).toBe("messaging_nudge");
+    expect(msg.data?.meetupId).toBe("meetup-1");
+  });
+
+  it("sends no notification when pending Student has no registered device token", async () => {
+    mockPendingStudentTokens = [];
+
+    await handleMessagingNudge(makeNudgeEvent());
+
+    expect(fetchCalls).toHaveLength(0);
+  });
+});

--- a/apps/server/src/__tests__/notifications-messaging-opt-in.test.ts
+++ b/apps/server/src/__tests__/notifications-messaging-opt-in.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Tests for task #138 — Send opt-in push notification to both Students after meetup is completed
+ *
+ * Covers:
+ *   - Both Students receive an opt-in prompt when their meetup is completed
+ *   - No notification sent when neither Student has a device token
+ */
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+// ── Fetch mock ────────────────────────────────────────────────────────────────
+
+interface CapturedFetchCall {
+  url: string;
+  messages: Array<{ to: string; title?: string; body?: string; data?: Record<string, unknown> }>;
+}
+
+const fetchCalls: CapturedFetchCall[] = [];
+
+(global as unknown as { fetch: unknown }).fetch = mock(async (url: string, options: RequestInit) => {
+  fetchCalls.push({
+    url,
+    messages: JSON.parse(options.body as string) as CapturedFetchCall["messages"],
+  });
+  return {
+    json: async () => ({ data: [{ status: "ok", id: "ticket-1" }] }),
+  };
+});
+
+// ── Schema mocks ──────────────────────────────────────────────────────────────
+
+const USER_TABLE = "user";
+const DEVICE_TOKEN_TABLE = "userDeviceToken";
+
+mock.module("@sip-and-speak/db/schema/sip-and-speak", () => ({
+  userDeviceToken: DEVICE_TOKEN_TABLE,
+  userLanguage: "userLanguage",
+}));
+
+mock.module("@sip-and-speak/db/schema/auth", () => ({
+  user: USER_TABLE,
+}));
+
+// ── drizzle-orm mock ──────────────────────────────────────────────────────────
+
+mock.module("drizzle-orm", () => ({
+  eq: (_col: unknown, val: unknown) => ({ _val: val }),
+  or: (...args: unknown[]) => args,
+}));
+
+// ── DB mock ───────────────────────────────────────────────────────────────────
+
+const STUDENT_A_ID = "student-a-id";
+const STUDENT_B_ID = "student-b-id";
+
+let mockStudentATokens: Array<{ id: string; token: string }> = [];
+let mockStudentBTokens: Array<{ id: string; token: string }> = [];
+
+const STUDENT_A_NAME = [{ name: "Alice" }];
+const STUDENT_B_NAME = [{ name: "Bob" }];
+
+mock.module("@sip-and-speak/db", () => ({
+  db: {
+    select: (fields: Record<string, unknown>) => {
+      const isNameQuery = "name" in fields;
+      return {
+        from: (_table: unknown) => ({
+          where: (clause: { _val: string }) => {
+            if (isNameQuery) {
+              const rows = clause._val === STUDENT_A_ID ? STUDENT_A_NAME : STUDENT_B_NAME;
+              return { limit: (_n: number) => Promise.resolve(rows) };
+            }
+            const rows = clause._val === STUDENT_A_ID ? mockStudentATokens : mockStudentBTokens;
+            return Promise.resolve(rows);
+          },
+        }),
+      };
+    },
+  },
+}));
+
+// ── Domain events mock ────────────────────────────────────────────────────────
+
+mock.module("@sip-and-speak/api/domain-events", () => ({
+  domainEvents: { on: mock((_evt: string, _fn: unknown) => undefined), emit: mock(() => undefined) },
+}));
+
+// ── Import under test (after mocks) ──────────────────────────────────────────
+
+// eslint-disable-next-line import/first
+import { handleMessagingOptInPrompted } from "../notifications";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeOptInEvent(
+  overrides: Partial<{ meetupId: string; studentAId: string; studentBId: string }> = {},
+) {
+  return {
+    meetupId: overrides.meetupId ?? "meetup-1",
+    studentAId: overrides.studentAId ?? STUDENT_A_ID,
+    studentBId: overrides.studentBId ?? STUDENT_B_ID,
+    promptedAt: new Date(),
+  };
+}
+
+beforeEach(() => {
+  fetchCalls.length = 0;
+  mockStudentATokens = [];
+  mockStudentBTokens = [];
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("#138 — Send opt-in push notification to both Students after meetup is completed", () => {
+  it("sends an opt-in push to both Students when their meetup is completed", async () => {
+    mockStudentATokens = [{ id: "tok-a", token: "ExponentPushToken[alice]" }];
+    mockStudentBTokens = [{ id: "tok-b", token: "ExponentPushToken[bob]" }];
+
+    await handleMessagingOptInPrompted(makeOptInEvent());
+
+    expect(fetchCalls).toHaveLength(1);
+
+    const call = fetchCalls[0];
+    if (!call) throw new Error("Expected a fetch call");
+
+    expect(call.messages).toHaveLength(2);
+
+    const tokens = call.messages.map((m) => m.to);
+    expect(tokens).toContain("ExponentPushToken[alice]");
+    expect(tokens).toContain("ExponentPushToken[bob]");
+
+    // Student A (Alice) sees Bob's name
+    const aliceMsg = call.messages.find((m) => m.to === "ExponentPushToken[alice]");
+    expect(aliceMsg?.title).toBe("Want to keep in touch?");
+    expect(aliceMsg?.body).toContain("Bob");
+    expect(aliceMsg?.data?.type).toBe("messaging_opt_in");
+    expect(aliceMsg?.data?.meetupId).toBe("meetup-1");
+
+    // Student B (Bob) sees Alice's name
+    const bobMsg = call.messages.find((m) => m.to === "ExponentPushToken[bob]");
+    expect(bobMsg?.title).toBe("Want to keep in touch?");
+    expect(bobMsg?.body).toContain("Alice");
+    expect(bobMsg?.data?.type).toBe("messaging_opt_in");
+    expect(bobMsg?.data?.meetupId).toBe("meetup-1");
+  });
+
+  it("sends no notification when neither Student has a registered device token", async () => {
+    mockStudentATokens = [];
+    mockStudentBTokens = [];
+
+    await handleMessagingOptInPrompted(makeOptInEvent());
+
+    expect(fetchCalls).toHaveLength(0);
+  });
+});

--- a/apps/server/src/notifications.ts
+++ b/apps/server/src/notifications.ts
@@ -8,7 +8,7 @@ import { eq } from "drizzle-orm";
 import { db } from "@sip-and-speak/db";
 import { userDeviceToken, userLanguage } from "@sip-and-speak/db/schema/sip-and-speak";
 import { user } from "@sip-and-speak/db/schema/auth";
-import { domainEvents, type MatchRequestSentEvent, type MatchRequestAcceptedEvent, type MatchRequestDeclinedEvent, type MeetupProposedEvent, type MeetupConfirmedEvent, type MeetupCounterProposedEvent, type MeetupDeclinedEvent, type MeetupCancelledEvent, type MeetupRescheduleProposedEvent, type MeetupRescheduledEvent, type MeetupRescheduleDeclinedEvent, type SipAndSpeakMomentCompletedEvent, type MeetupNotAttendedEvent, type MessagingOptInPromptedEvent, type MessagingNudgeNeededEvent, type ConversationOpenedEvent } from "@sip-and-speak/api/domain-events";
+import { domainEvents, type MatchRequestSentEvent, type MatchRequestAcceptedEvent, type MatchRequestDeclinedEvent, type MeetupProposedEvent, type MeetupConfirmedEvent, type MeetupCounterProposedEvent, type MeetupDeclinedEvent, type MeetupCancelledEvent, type MeetupRescheduleProposedEvent, type MeetupRescheduledEvent, type MeetupRescheduleDeclinedEvent, type SipAndSpeakMomentCompletedEvent, type MeetupNotAttendedEvent, type MessagingOptInPromptedEvent, type MessagingNudgeNeededEvent, type ConversationOpenedEvent, type MessagingDeclineOutcomeEvent } from "@sip-and-speak/api/domain-events";
 import { buildMatchRequestNotificationBody } from "@sip-and-speak/api/routers/matching-utils";
 
 const EXPO_PUSH_URL = "https://exp.host/--/api/v2/push/send";
@@ -385,6 +385,9 @@ export function registerNotificationHandlers(): void {
   domainEvents.on("ConversationOpened", (event) => {
     void handleConversationOpened(event);
   });
+  domainEvents.on("MessagingDeclineOutcome", (event) => {
+    void handleMessagingDeclineOutcome(event);
+  });
 }
 
 // #91 — Notify both Students when a reschedule is accepted and meetup details are updated
@@ -653,6 +656,33 @@ export async function handleConversationOpened(event: ConversationOpenedEvent): 
     await sendExpoPushNotification(messages);
   } catch (err) {
     console.error("[push] Failed to send ConversationOpened notification", { conversationId, meetupId, err });
+  }
+}
+
+// #142 — Notify both Students when messaging won't be available (decline outcome)
+export async function handleMessagingDeclineOutcome(event: MessagingDeclineOutcomeEvent): Promise<void> {
+  const { meetupId, studentAId, studentBId } = event;
+
+  const [tokensA, tokensB] = await Promise.all([
+    db.select({ id: userDeviceToken.id, token: userDeviceToken.token }).from(userDeviceToken).where(eq(userDeviceToken.userId, studentAId)),
+    db.select({ id: userDeviceToken.id, token: userDeviceToken.token }).from(userDeviceToken).where(eq(userDeviceToken.userId, studentBId)),
+  ]);
+
+  const messages: ExpoPushMessage[] = [
+    ...tokensA.map(({ token }) => ({ to: token, title: "Messaging not available", body: "One of you decided not to connect via messages — that's OK!", data: { meetupId, type: "messaging_decline_outcome" } })),
+    ...tokensB.map(({ token }) => ({ to: token, title: "Messaging not available", body: "One of you decided not to connect via messages — that's OK!", data: { meetupId, type: "messaging_decline_outcome" } })),
+  ];
+
+  if (messages.length === 0) {
+    console.info("[push] No tokens — skipping decline-outcome notification", { meetupId });
+    return;
+  }
+
+  console.info("[push] Sending MessagingDeclineOutcome notification", { meetupId, tokenCount: messages.length });
+  try {
+    await sendExpoPushNotification(messages);
+  } catch (err) {
+    console.error("[push] Failed to send MessagingDeclineOutcome notification", { meetupId, err });
   }
 }
 

--- a/apps/server/src/notifications.ts
+++ b/apps/server/src/notifications.ts
@@ -8,7 +8,7 @@ import { eq } from "drizzle-orm";
 import { db } from "@sip-and-speak/db";
 import { userDeviceToken, userLanguage } from "@sip-and-speak/db/schema/sip-and-speak";
 import { user } from "@sip-and-speak/db/schema/auth";
-import { domainEvents, type MatchRequestSentEvent, type MatchRequestAcceptedEvent, type MatchRequestDeclinedEvent, type MeetupProposedEvent, type MeetupConfirmedEvent, type MeetupCounterProposedEvent, type MeetupDeclinedEvent, type MeetupCancelledEvent, type MeetupRescheduleProposedEvent, type MeetupRescheduledEvent, type MeetupRescheduleDeclinedEvent, type SipAndSpeakMomentCompletedEvent, type MeetupNotAttendedEvent, type MessagingOptInPromptedEvent } from "@sip-and-speak/api/domain-events";
+import { domainEvents, type MatchRequestSentEvent, type MatchRequestAcceptedEvent, type MatchRequestDeclinedEvent, type MeetupProposedEvent, type MeetupConfirmedEvent, type MeetupCounterProposedEvent, type MeetupDeclinedEvent, type MeetupCancelledEvent, type MeetupRescheduleProposedEvent, type MeetupRescheduledEvent, type MeetupRescheduleDeclinedEvent, type SipAndSpeakMomentCompletedEvent, type MeetupNotAttendedEvent, type MessagingOptInPromptedEvent, type MessagingNudgeNeededEvent } from "@sip-and-speak/api/domain-events";
 import { buildMatchRequestNotificationBody } from "@sip-and-speak/api/routers/matching-utils";
 
 const EXPO_PUSH_URL = "https://exp.host/--/api/v2/push/send";
@@ -379,6 +379,9 @@ export function registerNotificationHandlers(): void {
   domainEvents.on("MessagingOptInPrompted", (event) => {
     void handleMessagingOptInPrompted(event);
   });
+  domainEvents.on("MessagingNudgeNeeded", (event) => {
+    void handleMessagingNudge(event);
+  });
 }
 
 // #91 — Notify both Students when a reschedule is accepted and meetup details are updated
@@ -552,6 +555,44 @@ export async function handleMessagingOptInPrompted(event: MessagingOptInPrompted
     await sendExpoPushNotification(messages);
   } catch (err) {
     console.error("[push] Failed to send MessagingOptInPrompted notification", { meetupId, err });
+  }
+}
+
+// #140 — Nudge the pending Student when their match accepts the messaging opt-in
+export async function handleMessagingNudge(event: MessagingNudgeNeededEvent): Promise<void> {
+  const { meetupId, acceptingStudentId, pendingStudentId } = event;
+
+  const [acceptingStudentResult, tokens] = await Promise.all([
+    db.select({ name: user.name }).from(user).where(eq(user.id, acceptingStudentId)).limit(1),
+    db
+      .select({ id: userDeviceToken.id, token: userDeviceToken.token })
+      .from(userDeviceToken)
+      .where(eq(userDeviceToken.userId, pendingStudentId)),
+  ]);
+
+  if (tokens.length === 0) {
+    console.info("[push] No device token for pending student — skipping messaging nudge", {
+      meetupId,
+      pendingStudentId,
+    });
+    return;
+  }
+
+  const acceptingStudentName = acceptingStudentResult[0]?.name ?? "Your match";
+
+  const messages: ExpoPushMessage[] = tokens.map(({ token }) => ({
+    to: token,
+    title: "Your match wants to message you!",
+    body: `${acceptingStudentName} accepted messaging — let them know if you're in!`,
+    data: { meetupId, type: "messaging_nudge", deepLink: `/messaging/opt-in/${meetupId}` },
+  }));
+
+  console.info("[push] Sending MessagingNudge notification", { meetupId, pendingStudentId, tokenCount: messages.length });
+
+  try {
+    await sendExpoPushNotification(messages);
+  } catch (err) {
+    console.error("[push] Failed to send MessagingNudge notification", { meetupId, pendingStudentId, err });
   }
 }
 

--- a/apps/server/src/notifications.ts
+++ b/apps/server/src/notifications.ts
@@ -8,7 +8,7 @@ import { eq } from "drizzle-orm";
 import { db } from "@sip-and-speak/db";
 import { userDeviceToken, userLanguage } from "@sip-and-speak/db/schema/sip-and-speak";
 import { user } from "@sip-and-speak/db/schema/auth";
-import { domainEvents, type MatchRequestSentEvent, type MatchRequestAcceptedEvent, type MatchRequestDeclinedEvent, type MeetupProposedEvent, type MeetupConfirmedEvent, type MeetupCounterProposedEvent, type MeetupDeclinedEvent, type MeetupCancelledEvent, type MeetupRescheduleProposedEvent, type MeetupRescheduledEvent, type MeetupRescheduleDeclinedEvent, type SipAndSpeakMomentCompletedEvent, type MeetupNotAttendedEvent } from "@sip-and-speak/api/domain-events";
+import { domainEvents, type MatchRequestSentEvent, type MatchRequestAcceptedEvent, type MatchRequestDeclinedEvent, type MeetupProposedEvent, type MeetupConfirmedEvent, type MeetupCounterProposedEvent, type MeetupDeclinedEvent, type MeetupCancelledEvent, type MeetupRescheduleProposedEvent, type MeetupRescheduledEvent, type MeetupRescheduleDeclinedEvent, type SipAndSpeakMomentCompletedEvent, type MeetupNotAttendedEvent, type MessagingOptInPromptedEvent } from "@sip-and-speak/api/domain-events";
 import { buildMatchRequestNotificationBody } from "@sip-and-speak/api/routers/matching-utils";
 
 const EXPO_PUSH_URL = "https://exp.host/--/api/v2/push/send";
@@ -376,6 +376,9 @@ export function registerNotificationHandlers(): void {
   domainEvents.on("MeetupNotAttended", (event) => {
     void handleMeetupNotAttended(event);
   });
+  domainEvents.on("MessagingOptInPrompted", (event) => {
+    void handleMessagingOptInPrompted(event);
+  });
 }
 
 // #91 — Notify both Students when a reschedule is accepted and meetup details are updated
@@ -495,6 +498,60 @@ async function handleSipAndSpeakMomentCompleted(event: SipAndSpeakMomentComplete
     await sendExpoPushNotification(messages);
   } catch (err) {
     console.error("[push] Failed to send SipAndSpeakMomentCompleted notification", { meetupId, err });
+  }
+}
+
+// #138 — Prompt both Students to opt in to messaging after a completed meetup
+export async function handleMessagingOptInPrompted(event: MessagingOptInPromptedEvent): Promise<void> {
+  const { meetupId, studentAId, studentBId } = event;
+
+  const [studentAResult, studentBResult, tokensA, tokensB] = await Promise.all([
+    db.select({ name: user.name }).from(user).where(eq(user.id, studentAId)).limit(1),
+    db.select({ name: user.name }).from(user).where(eq(user.id, studentBId)).limit(1),
+    db
+      .select({ id: userDeviceToken.id, token: userDeviceToken.token })
+      .from(userDeviceToken)
+      .where(eq(userDeviceToken.userId, studentAId)),
+    db
+      .select({ id: userDeviceToken.id, token: userDeviceToken.token })
+      .from(userDeviceToken)
+      .where(eq(userDeviceToken.userId, studentBId)),
+  ]);
+
+  const studentAName = studentAResult[0]?.name ?? "Your match";
+  const studentBName = studentBResult[0]?.name ?? "Your match";
+
+  const messages: ExpoPushMessage[] = [];
+
+  for (const { token } of tokensA) {
+    messages.push({
+      to: token,
+      title: "Want to keep in touch?",
+      body: `${studentBName} completed a S&S moment with you — would you like to message them?`,
+      data: { meetupId, type: "messaging_opt_in", deepLink: `/messaging/opt-in/${meetupId}` },
+    });
+  }
+
+  for (const { token } of tokensB) {
+    messages.push({
+      to: token,
+      title: "Want to keep in touch?",
+      body: `${studentAName} completed a S&S moment with you — would you like to message them?`,
+      data: { meetupId, type: "messaging_opt_in", deepLink: `/messaging/opt-in/${meetupId}` },
+    });
+  }
+
+  if (messages.length === 0) {
+    console.info("[push] No device tokens for either student — skipping opt-in notification", { meetupId });
+    return;
+  }
+
+  console.info("[push] Sending MessagingOptInPrompted notification", { meetupId, tokenCount: messages.length });
+
+  try {
+    await sendExpoPushNotification(messages);
+  } catch (err) {
+    console.error("[push] Failed to send MessagingOptInPrompted notification", { meetupId, err });
   }
 }
 

--- a/apps/server/src/notifications.ts
+++ b/apps/server/src/notifications.ts
@@ -8,7 +8,7 @@ import { eq } from "drizzle-orm";
 import { db } from "@sip-and-speak/db";
 import { userDeviceToken, userLanguage } from "@sip-and-speak/db/schema/sip-and-speak";
 import { user } from "@sip-and-speak/db/schema/auth";
-import { domainEvents, type MatchRequestSentEvent, type MatchRequestAcceptedEvent, type MatchRequestDeclinedEvent, type MeetupProposedEvent, type MeetupConfirmedEvent, type MeetupCounterProposedEvent, type MeetupDeclinedEvent, type MeetupCancelledEvent, type MeetupRescheduleProposedEvent, type MeetupRescheduledEvent, type MeetupRescheduleDeclinedEvent, type SipAndSpeakMomentCompletedEvent, type MeetupNotAttendedEvent, type MessagingOptInPromptedEvent, type MessagingNudgeNeededEvent } from "@sip-and-speak/api/domain-events";
+import { domainEvents, type MatchRequestSentEvent, type MatchRequestAcceptedEvent, type MatchRequestDeclinedEvent, type MeetupProposedEvent, type MeetupConfirmedEvent, type MeetupCounterProposedEvent, type MeetupDeclinedEvent, type MeetupCancelledEvent, type MeetupRescheduleProposedEvent, type MeetupRescheduledEvent, type MeetupRescheduleDeclinedEvent, type SipAndSpeakMomentCompletedEvent, type MeetupNotAttendedEvent, type MessagingOptInPromptedEvent, type MessagingNudgeNeededEvent, type ConversationOpenedEvent } from "@sip-and-speak/api/domain-events";
 import { buildMatchRequestNotificationBody } from "@sip-and-speak/api/routers/matching-utils";
 
 const EXPO_PUSH_URL = "https://exp.host/--/api/v2/push/send";
@@ -382,6 +382,9 @@ export function registerNotificationHandlers(): void {
   domainEvents.on("MessagingNudgeNeeded", (event) => {
     void handleMessagingNudge(event);
   });
+  domainEvents.on("ConversationOpened", (event) => {
+    void handleConversationOpened(event);
+  });
 }
 
 // #91 — Notify both Students when a reschedule is accepted and meetup details are updated
@@ -593,6 +596,63 @@ export async function handleMessagingNudge(event: MessagingNudgeNeededEvent): Pr
     await sendExpoPushNotification(messages);
   } catch (err) {
     console.error("[push] Failed to send MessagingNudge notification", { meetupId, pendingStudentId, err });
+  }
+}
+
+// #141 — Notify both Students when their conversation channel is opened
+export async function handleConversationOpened(event: ConversationOpenedEvent): Promise<void> {
+  const { conversationId, meetupId, studentAId, studentBId } = event;
+
+  const [studentAResult, studentBResult, tokensA, tokensB] = await Promise.all([
+    db.select({ name: user.name }).from(user).where(eq(user.id, studentAId)).limit(1),
+    db.select({ name: user.name }).from(user).where(eq(user.id, studentBId)).limit(1),
+    db
+      .select({ id: userDeviceToken.id, token: userDeviceToken.token })
+      .from(userDeviceToken)
+      .where(eq(userDeviceToken.userId, studentAId)),
+    db
+      .select({ id: userDeviceToken.id, token: userDeviceToken.token })
+      .from(userDeviceToken)
+      .where(eq(userDeviceToken.userId, studentBId)),
+  ]);
+
+  const studentAName = studentAResult[0]?.name ?? "Your match";
+  const studentBName = studentBResult[0]?.name ?? "Your match";
+
+  const messages: ExpoPushMessage[] = [];
+
+  for (const { token } of tokensA) {
+    messages.push({
+      to: token,
+      title: "Your messaging channel is open!",
+      body: `${studentBName} also accepted — you can now message each other.`,
+      data: { conversationId, meetupId, type: "conversation_opened", deepLink: `/conversations/${conversationId}` },
+    });
+  }
+
+  for (const { token } of tokensB) {
+    messages.push({
+      to: token,
+      title: "Your messaging channel is open!",
+      body: `${studentAName} also accepted — you can now message each other.`,
+      data: { conversationId, meetupId, type: "conversation_opened", deepLink: `/conversations/${conversationId}` },
+    });
+  }
+
+  if (messages.length === 0) {
+    console.info("[push] No device tokens for either student — skipping conversation-opened notification", {
+      conversationId,
+      meetupId,
+    });
+    return;
+  }
+
+  console.info("[push] Sending ConversationOpened notification", { conversationId, meetupId, tokenCount: messages.length });
+
+  try {
+    await sendExpoPushNotification(messages);
+  } catch (err) {
+    console.error("[push] Failed to send ConversationOpened notification", { conversationId, meetupId, err });
   }
 }
 

--- a/packages/api/src/__tests__/messaging-conversation.test.ts
+++ b/packages/api/src/__tests__/messaging-conversation.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Tests for task #141 — Open conversation channel when both Students accept
+ *
+ * Covers:
+ *   - bothAccepted returns true only when both responses are "accept"
+ *   - Decline by either student prevents conversation opening
+ */
+import { describe, it, expect } from "bun:test";
+
+import { bothAccepted } from "../routers/messaging-utils";
+
+describe("#141 — bothAccepted", () => {
+  it("returns true when both Students have accepted", () => {
+    expect(
+      bothAccepted([{ response: "accept" }, { response: "accept" }]),
+    ).toBe(true);
+  });
+
+  it("returns false when only one Student has accepted", () => {
+    expect(bothAccepted([{ response: "accept" }])).toBe(false);
+  });
+
+  it("returns false when first Student declined", () => {
+    expect(
+      bothAccepted([{ response: "decline" }, { response: "accept" }]),
+    ).toBe(false);
+  });
+
+  it("returns false when second Student declined", () => {
+    expect(
+      bothAccepted([{ response: "accept" }, { response: "decline" }]),
+    ).toBe(false);
+  });
+
+  it("returns false when both Students declined", () => {
+    expect(
+      bothAccepted([{ response: "decline" }, { response: "decline" }]),
+    ).toBe(false);
+  });
+
+  it("returns false when no responses yet", () => {
+    expect(bothAccepted([])).toBe(false);
+  });
+});

--- a/packages/api/src/__tests__/messaging-decline.test.ts
+++ b/packages/api/src/__tests__/messaging-decline.test.ts
@@ -1,0 +1,23 @@
+/**
+ * Tests for task #142 — Block conversation when either Student declines
+ */
+import { describe, it, expect } from "bun:test";
+import { isDeclineOutcome } from "../routers/messaging-utils";
+
+describe("#142 — isDeclineOutcome", () => {
+  it("returns true when second Student declines after first accepted", () => {
+    expect(isDeclineOutcome([{ response: "accept" }, { response: "decline" }])).toBe(true);
+  });
+  it("returns true when first Student declines before second accepts", () => {
+    expect(isDeclineOutcome([{ response: "decline" }, { response: "accept" }])).toBe(true);
+  });
+  it("returns true when both Students decline", () => {
+    expect(isDeclineOutcome([{ response: "decline" }, { response: "decline" }])).toBe(true);
+  });
+  it("returns false when both accepted (conversation path)", () => {
+    expect(isDeclineOutcome([{ response: "accept" }, { response: "accept" }])).toBe(false);
+  });
+  it("returns false when only one has responded", () => {
+    expect(isDeclineOutcome([{ response: "decline" }])).toBe(false);
+  });
+});

--- a/packages/api/src/__tests__/messaging-nudge.test.ts
+++ b/packages/api/src/__tests__/messaging-nudge.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Tests for task #140 — Send second push to pending Student when their match accepts
+ *
+ * Covers:
+ *   - shouldSendNudge returns true when student accepts and partner hasn't responded
+ *   - shouldSendNudge returns false when partner has already responded
+ *   - shouldSendNudge returns false when student declines (no nudge on decline)
+ */
+import { describe, it, expect } from "bun:test";
+
+import { shouldSendNudge } from "../routers/messaging-utils";
+
+describe("#140 — shouldSendNudge", () => {
+  it("returns true when accepting student's partner has not yet responded", () => {
+    expect(shouldSendNudge("accept", undefined)).toBe(true);
+  });
+
+  it("returns false when partner has already accepted (both responded)", () => {
+    expect(shouldSendNudge("accept", { response: "accept" })).toBe(false);
+  });
+
+  it("returns false when partner has already declined (both responded)", () => {
+    expect(shouldSendNudge("accept", { response: "decline" })).toBe(false);
+  });
+
+  it("returns false when student declines (no nudge on decline path)", () => {
+    expect(shouldSendNudge("decline", undefined)).toBe(false);
+  });
+});

--- a/packages/api/src/__tests__/messaging-opt-in.test.ts
+++ b/packages/api/src/__tests__/messaging-opt-in.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Tests for task #139 — Record each Student's messaging opt-in response independently
+ *
+ * Covers:
+ *   - Student accepts messaging opt-in
+ *   - Student declines messaging opt-in
+ *   - Student attempts to respond twice (duplicate prevention)
+ */
+import { describe, it, expect } from "bun:test";
+
+import { hasAlreadyResponded, getPartnerId } from "../routers/messaging-utils";
+
+describe("#139 — hasAlreadyResponded", () => {
+  it("returns false when no existing response (student has not yet responded)", () => {
+    expect(hasAlreadyResponded(undefined)).toBe(false);
+  });
+
+  it("returns true when student has already accepted", () => {
+    expect(hasAlreadyResponded({ response: "accept" })).toBe(true);
+  });
+
+  it("returns true when student has already declined", () => {
+    expect(hasAlreadyResponded({ response: "decline" })).toBe(true);
+  });
+});
+
+describe("#139 — getPartnerId", () => {
+  it("returns receiverId when student is the proposer", () => {
+    expect(getPartnerId("proposer-A", "receiver-B", "proposer-A")).toBe("receiver-B");
+  });
+
+  it("returns proposerId when student is the receiver", () => {
+    expect(getPartnerId("proposer-A", "receiver-B", "receiver-B")).toBe("proposer-A");
+  });
+});

--- a/packages/api/src/domain-events.ts
+++ b/packages/api/src/domain-events.ts
@@ -137,6 +137,13 @@ export interface MeetupNotAttendedEvent {
   recordedAt: Date;
 }
 
+export interface MessagingOptInPromptedEvent {
+  meetupId: string;
+  studentAId: string;
+  studentBId: string;
+  promptedAt: Date;
+}
+
 type DomainEventMap = {
   LanguageProfileUpdated: [LanguageProfileUpdatedEvent];
   InterestProfileUpdated: [InterestProfileUpdatedEvent];
@@ -155,6 +162,7 @@ type DomainEventMap = {
   AttendanceReported: [AttendanceReportedEvent];
   SipAndSpeakMomentCompleted: [SipAndSpeakMomentCompletedEvent];
   MeetupNotAttended: [MeetupNotAttendedEvent];
+  MessagingOptInPrompted: [MessagingOptInPromptedEvent];
 };
 
 class TypedEventEmitter extends EventEmitter {

--- a/packages/api/src/domain-events.ts
+++ b/packages/api/src/domain-events.ts
@@ -158,6 +158,14 @@ export interface MessagingDeclinedEvent {
   respondedAt: Date;
 }
 
+export interface MessagingNudgeNeededEvent {
+  meetupId: string;
+  /** The student who accepted and triggered the nudge */
+  acceptingStudentId: string;
+  /** The student who has not yet responded and should receive the nudge */
+  pendingStudentId: string;
+}
+
 type DomainEventMap = {
   LanguageProfileUpdated: [LanguageProfileUpdatedEvent];
   InterestProfileUpdated: [InterestProfileUpdatedEvent];
@@ -179,6 +187,7 @@ type DomainEventMap = {
   MessagingOptInPrompted: [MessagingOptInPromptedEvent];
   MessagingAccepted: [MessagingAcceptedEvent];
   MessagingDeclined: [MessagingDeclinedEvent];
+  MessagingNudgeNeeded: [MessagingNudgeNeededEvent];
 };
 
 class TypedEventEmitter extends EventEmitter {

--- a/packages/api/src/domain-events.ts
+++ b/packages/api/src/domain-events.ts
@@ -144,6 +144,20 @@ export interface MessagingOptInPromptedEvent {
   promptedAt: Date;
 }
 
+export interface MessagingAcceptedEvent {
+  meetupId: string;
+  studentId: string;
+  partnerId: string;
+  respondedAt: Date;
+}
+
+export interface MessagingDeclinedEvent {
+  meetupId: string;
+  studentId: string;
+  partnerId: string;
+  respondedAt: Date;
+}
+
 type DomainEventMap = {
   LanguageProfileUpdated: [LanguageProfileUpdatedEvent];
   InterestProfileUpdated: [InterestProfileUpdatedEvent];
@@ -163,6 +177,8 @@ type DomainEventMap = {
   SipAndSpeakMomentCompleted: [SipAndSpeakMomentCompletedEvent];
   MeetupNotAttended: [MeetupNotAttendedEvent];
   MessagingOptInPrompted: [MessagingOptInPromptedEvent];
+  MessagingAccepted: [MessagingAcceptedEvent];
+  MessagingDeclined: [MessagingDeclinedEvent];
 };
 
 class TypedEventEmitter extends EventEmitter {

--- a/packages/api/src/domain-events.ts
+++ b/packages/api/src/domain-events.ts
@@ -166,6 +166,12 @@ export interface ConversationOpenedEvent {
   openedAt: Date;
 }
 
+export interface MessagingDeclineOutcomeEvent {
+  meetupId: string;
+  studentAId: string;
+  studentBId: string;
+}
+
 export interface MessagingNudgeNeededEvent {
   meetupId: string;
   /** The student who accepted and triggered the nudge */
@@ -197,6 +203,7 @@ type DomainEventMap = {
   MessagingDeclined: [MessagingDeclinedEvent];
   MessagingNudgeNeeded: [MessagingNudgeNeededEvent];
   ConversationOpened: [ConversationOpenedEvent];
+  MessagingDeclineOutcome: [MessagingDeclineOutcomeEvent];
 };
 
 class TypedEventEmitter extends EventEmitter {

--- a/packages/api/src/domain-events.ts
+++ b/packages/api/src/domain-events.ts
@@ -158,6 +158,14 @@ export interface MessagingDeclinedEvent {
   respondedAt: Date;
 }
 
+export interface ConversationOpenedEvent {
+  conversationId: string;
+  meetupId: string;
+  studentAId: string;
+  studentBId: string;
+  openedAt: Date;
+}
+
 export interface MessagingNudgeNeededEvent {
   meetupId: string;
   /** The student who accepted and triggered the nudge */
@@ -188,6 +196,7 @@ type DomainEventMap = {
   MessagingAccepted: [MessagingAcceptedEvent];
   MessagingDeclined: [MessagingDeclinedEvent];
   MessagingNudgeNeeded: [MessagingNudgeNeededEvent];
+  ConversationOpened: [ConversationOpenedEvent];
 };
 
 class TypedEventEmitter extends EventEmitter {

--- a/packages/api/src/routers/index.ts
+++ b/packages/api/src/routers/index.ts
@@ -5,6 +5,7 @@ import { venueRouter } from "./venue";
 import { adminVenueRouter } from "./venue-admin";
 import { meetupRouter } from "./meetup";
 import { chatRouter } from "./chat";
+import { messagingRouter } from "./messaging";
 
 export const appRouter = router({
   healthCheck: publicProcedure.query(() => {
@@ -22,5 +23,6 @@ export const appRouter = router({
   adminVenue: adminVenueRouter,
   meetup: meetupRouter,
   chat: chatRouter,
+  messaging: messagingRouter,
 });
 export type AppRouter = typeof appRouter;

--- a/packages/api/src/routers/meetup.ts
+++ b/packages/api/src/routers/meetup.ts
@@ -1032,6 +1032,14 @@ export const meetupRouter = router({
               studentBId: existing.receiverId,
               completedAt: new Date(),
             });
+
+            // #138 — Prompt both Students to opt in to messaging after a completed meetup
+            domainEvents.emit("MessagingOptInPrompted", {
+              meetupId: input.meetupId,
+              studentAId: existing.proposerId,
+              studentBId: existing.receiverId,
+              promptedAt: new Date(),
+            });
           }
         } else {
           // #101 — At least one non-attendance → return pair to Matched (meetup closed)

--- a/packages/api/src/routers/messaging-utils.ts
+++ b/packages/api/src/routers/messaging-utils.ts
@@ -14,6 +14,17 @@ export function hasAlreadyResponded(
 }
 
 /**
+ * Returns true if a nudge push should be sent to the pending partner.
+ * Conditions: the current student just accepted, AND the partner has not yet responded.
+ */
+export function shouldSendNudge(
+  myResponse: "accept" | "decline",
+  partnerResponse: { response: "accept" | "decline" } | undefined,
+): boolean {
+  return myResponse === "accept" && partnerResponse === undefined;
+}
+
+/**
  * Derives the partner's ID from a meetup's proposer/receiver pair.
  */
 export function getPartnerId(

--- a/packages/api/src/routers/messaging-utils.ts
+++ b/packages/api/src/routers/messaging-utils.ts
@@ -25,6 +25,16 @@ export function shouldSendNudge(
 }
 
 /**
+ * Returns true when both Students have responded with "accept".
+ * Used to determine whether a conversation channel should be opened.
+ */
+export function bothAccepted(
+  responses: Array<{ response: "accept" | "decline" }>,
+): boolean {
+  return responses.length === 2 && responses.every((r) => r.response === "accept");
+}
+
+/**
  * Derives the partner's ID from a meetup's proposer/receiver pair.
  */
 export function getPartnerId(

--- a/packages/api/src/routers/messaging-utils.ts
+++ b/packages/api/src/routers/messaging-utils.ts
@@ -35,6 +35,17 @@ export function bothAccepted(
 }
 
 /**
+ * Returns true when both Students have responded and at least one declined.
+ * Used to determine whether to send the decline-outcome notifications.
+ * Note: does NOT reveal which Student declined — callers must not expose that.
+ */
+export function isDeclineOutcome(
+  responses: Array<{ response: "accept" | "decline" }>,
+): boolean {
+  return responses.length === 2 && !responses.every((r) => r.response === "accept");
+}
+
+/**
  * Derives the partner's ID from a meetup's proposer/receiver pair.
  */
 export function getPartnerId(

--- a/packages/api/src/routers/messaging-utils.ts
+++ b/packages/api/src/routers/messaging-utils.ts
@@ -1,0 +1,25 @@
+/**
+ * Pure helpers for the messaging opt-in router.
+ * Extracted for unit testing without a DB connection.
+ */
+
+/**
+ * Returns true if the student has already responded to the opt-in for this meetup.
+ * Used to enforce the "one response per (meetupId, studentId)" invariant.
+ */
+export function hasAlreadyResponded(
+  existingResponse: { response: "accept" | "decline" } | undefined,
+): boolean {
+  return existingResponse !== undefined;
+}
+
+/**
+ * Derives the partner's ID from a meetup's proposer/receiver pair.
+ */
+export function getPartnerId(
+  proposerId: string,
+  receiverId: string,
+  studentId: string,
+): string {
+  return proposerId === studentId ? receiverId : proposerId;
+}

--- a/packages/api/src/routers/messaging.ts
+++ b/packages/api/src/routers/messaging.ts
@@ -1,0 +1,111 @@
+import { z } from "zod";
+import { TRPCError } from "@trpc/server";
+import { and, eq } from "drizzle-orm";
+
+import { protectedProcedure, router } from "../index";
+import { domainEvents } from "../domain-events";
+import { db } from "@sip-and-speak/db";
+import { meetup, messagingOptIn } from "@sip-and-speak/db/schema/sip-and-speak";
+import { hasAlreadyResponded, getPartnerId } from "./messaging-utils";
+
+export const messagingRouter = router({
+  /**
+   * #139 — Record a Student's accept/decline response to the messaging opt-in prompt.
+   * Each (meetupId, studentId) pair can only respond once.
+   */
+  respondToOptIn: protectedProcedure
+    .input(
+      z.object({
+        meetupId: z.string(),
+        response: z.enum(["accept", "decline"]),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const studentId = ctx.session.user.id;
+
+      // Verify meetup exists and student is a participant
+      const [existing] = await db
+        .select({
+          id: meetup.id,
+          status: meetup.status,
+          proposerId: meetup.proposerId,
+          receiverId: meetup.receiverId,
+        })
+        .from(meetup)
+        .where(eq(meetup.id, input.meetupId))
+        .limit(1);
+
+      if (!existing) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Meetup not found" });
+      }
+
+      const isParticipant =
+        existing.proposerId === studentId || existing.receiverId === studentId;
+
+      if (!isParticipant) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "You are not a participant in this meetup",
+        });
+      }
+
+      if (existing.status !== "completed") {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Messaging opt-in is only available for completed meetups",
+        });
+      }
+
+      // Enforce one response per (meetupId, studentId)
+      const [existingResponse] = await db
+        .select({ response: messagingOptIn.response })
+        .from(messagingOptIn)
+        .where(
+          and(
+            eq(messagingOptIn.meetupId, input.meetupId),
+            eq(messagingOptIn.studentId, studentId),
+          ),
+        )
+        .limit(1);
+
+      if (hasAlreadyResponded(existingResponse)) {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message: "You have already responded to the messaging opt-in for this meetup",
+        });
+      }
+
+      const [created] = await db
+        .insert(messagingOptIn)
+        .values({
+          meetupId: input.meetupId,
+          studentId,
+          response: input.response,
+        })
+        .returning();
+
+      const partnerId = getPartnerId(existing.proposerId, existing.receiverId, studentId);
+
+      if (input.response === "accept") {
+        domainEvents.emit("MessagingAccepted", {
+          meetupId: input.meetupId,
+          studentId,
+          partnerId,
+          respondedAt: created!.respondedAt,
+        });
+      } else {
+        domainEvents.emit("MessagingDeclined", {
+          meetupId: input.meetupId,
+          studentId,
+          partnerId,
+          respondedAt: created!.respondedAt,
+        });
+      }
+
+      console.log(
+        `[messaging] opt-in response recorded meetupId=${input.meetupId} studentId=${studentId} response=${input.response}`,
+      );
+
+      return { recorded: true as const };
+    }),
+});

--- a/packages/api/src/routers/messaging.ts
+++ b/packages/api/src/routers/messaging.ts
@@ -5,8 +5,8 @@ import { and, eq, isNull } from "drizzle-orm";
 import { protectedProcedure, router } from "../index";
 import { domainEvents } from "../domain-events";
 import { db } from "@sip-and-speak/db";
-import { meetup, messagingOptIn } from "@sip-and-speak/db/schema/sip-and-speak";
-import { hasAlreadyResponded, getPartnerId, shouldSendNudge } from "./messaging-utils";
+import { meetup, messagingOptIn, conversation } from "@sip-and-speak/db/schema/sip-and-speak";
+import { hasAlreadyResponded, getPartnerId, shouldSendNudge, bothAccepted } from "./messaging-utils";
 
 export const messagingRouter = router({
   /**
@@ -125,6 +125,38 @@ export const messagingRouter = router({
               meetupId: input.meetupId,
               acceptingStudentId: studentId,
               pendingStudentId: partnerId,
+            });
+          }
+        }
+
+        // #141 — Check if both Students have now accepted; if so, open the conversation
+        const allResponses = await db
+          .select({ response: messagingOptIn.response })
+          .from(messagingOptIn)
+          .where(eq(messagingOptIn.meetupId, input.meetupId));
+
+        if (bothAccepted(allResponses)) {
+          // Use INSERT ... ON CONFLICT DO NOTHING to guard against race conditions
+          const [newConversation] = await db
+            .insert(conversation)
+            .values({
+              user1Id: studentId,
+              user2Id: partnerId,
+              meetupId: input.meetupId,
+            })
+            .onConflictDoNothing({ target: conversation.meetupId })
+            .returning();
+
+          if (newConversation) {
+            console.log(
+              `[messaging] conversation opened conversationId=${newConversation.id} meetupId=${input.meetupId}`,
+            );
+            domainEvents.emit("ConversationOpened", {
+              conversationId: newConversation.id,
+              meetupId: input.meetupId,
+              studentAId: studentId,
+              studentBId: partnerId,
+              openedAt: newConversation.createdAt,
             });
           }
         }

--- a/packages/api/src/routers/messaging.ts
+++ b/packages/api/src/routers/messaging.ts
@@ -6,7 +6,7 @@ import { protectedProcedure, router } from "../index";
 import { domainEvents } from "../domain-events";
 import { db } from "@sip-and-speak/db";
 import { meetup, messagingOptIn, conversation } from "@sip-and-speak/db/schema/sip-and-speak";
-import { hasAlreadyResponded, getPartnerId, shouldSendNudge, bothAccepted } from "./messaging-utils";
+import { hasAlreadyResponded, getPartnerId, shouldSendNudge, bothAccepted, isDeclineOutcome } from "./messaging-utils";
 
 export const messagingRouter = router({
   /**
@@ -167,6 +167,20 @@ export const messagingRouter = router({
           partnerId,
           respondedAt: created!.respondedAt,
         });
+
+        // #142 — Check if both have now responded; if any declined, emit outcome
+        const declineResponses = await db
+          .select({ response: messagingOptIn.response })
+          .from(messagingOptIn)
+          .where(eq(messagingOptIn.meetupId, input.meetupId));
+
+        if (isDeclineOutcome(declineResponses)) {
+          domainEvents.emit("MessagingDeclineOutcome", {
+            meetupId: input.meetupId,
+            studentAId: studentId,
+            studentBId: partnerId,
+          });
+        }
       }
 
       console.log(

--- a/packages/api/src/routers/messaging.ts
+++ b/packages/api/src/routers/messaging.ts
@@ -1,12 +1,12 @@
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
-import { and, eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 
 import { protectedProcedure, router } from "../index";
 import { domainEvents } from "../domain-events";
 import { db } from "@sip-and-speak/db";
 import { meetup, messagingOptIn } from "@sip-and-speak/db/schema/sip-and-speak";
-import { hasAlreadyResponded, getPartnerId } from "./messaging-utils";
+import { hasAlreadyResponded, getPartnerId, shouldSendNudge } from "./messaging-utils";
 
 export const messagingRouter = router({
   /**
@@ -93,6 +93,41 @@ export const messagingRouter = router({
           partnerId,
           respondedAt: created!.respondedAt,
         });
+
+        // #140 — Check if partner has responded; if not, nudge them
+        const [partnerResponse] = await db
+          .select({ response: messagingOptIn.response })
+          .from(messagingOptIn)
+          .where(
+            and(
+              eq(messagingOptIn.meetupId, input.meetupId),
+              eq(messagingOptIn.studentId, partnerId),
+            ),
+          )
+          .limit(1);
+
+        if (shouldSendNudge("accept", partnerResponse)) {
+          // Atomically mark nudge as sent to prevent duplicates on concurrent accepts
+          const updated = await db
+            .update(messagingOptIn)
+            .set({ nudgeSentAt: new Date() })
+            .where(
+              and(
+                eq(messagingOptIn.meetupId, input.meetupId),
+                eq(messagingOptIn.studentId, studentId),
+                isNull(messagingOptIn.nudgeSentAt),
+              ),
+            )
+            .returning({ id: messagingOptIn.id });
+
+          if (updated.length > 0) {
+            domainEvents.emit("MessagingNudgeNeeded", {
+              meetupId: input.meetupId,
+              acceptingStudentId: studentId,
+              pendingStudentId: partnerId,
+            });
+          }
+        }
       } else {
         domainEvents.emit("MessagingDeclined", {
           meetupId: input.meetupId,

--- a/packages/db/src/migrations/0008_pink_the_order.sql
+++ b/packages/db/src/migrations/0008_pink_the_order.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "messaging_opt_in" (
+	"id" text PRIMARY KEY NOT NULL,
+	"meetup_id" text NOT NULL,
+	"student_id" text NOT NULL,
+	"response" text NOT NULL,
+	"responded_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "messaging_opt_in_meetup_student_unique" UNIQUE("meetup_id","student_id")
+);
+--> statement-breakpoint
+ALTER TABLE "messaging_opt_in" ADD CONSTRAINT "messaging_opt_in_meetup_id_meetup_id_fk" FOREIGN KEY ("meetup_id") REFERENCES "public"."meetup"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "messaging_opt_in" ADD CONSTRAINT "messaging_opt_in_student_id_user_id_fk" FOREIGN KEY ("student_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "messaging_opt_in_meetupId_idx" ON "messaging_opt_in" USING btree ("meetup_id");

--- a/packages/db/src/migrations/0009_narrow_orphan.sql
+++ b/packages/db/src/migrations/0009_narrow_orphan.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "messaging_opt_in" ADD COLUMN "nudge_sent_at" timestamp;

--- a/packages/db/src/migrations/0010_kind_reaper.sql
+++ b/packages/db/src/migrations/0010_kind_reaper.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "conversation" ADD COLUMN "meetup_id" text;--> statement-breakpoint
+ALTER TABLE "conversation" ADD CONSTRAINT "conversation_meetup_id_meetup_id_fk" FOREIGN KEY ("meetup_id") REFERENCES "public"."meetup"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "conversation_meetupId_idx" ON "conversation" USING btree ("meetup_id");

--- a/packages/db/src/migrations/meta/0008_snapshot.json
+++ b/packages/db/src/migrations/meta/0008_snapshot.json
@@ -1,0 +1,1795 @@
+{
+  "id": "f2a90941-4d22-4647-a68d-e3c737eb7268",
+  "prevId": "68a8379e-5987-4459-b443-f3aaf7271410",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attendance_report": {
+      "name": "attendance_report",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "meetup_id": {
+          "name": "meetup_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attended": {
+          "name": "attended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reported_at": {
+          "name": "reported_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "attendance_report_meetupId_idx": {
+          "name": "attendance_report_meetupId_idx",
+          "columns": [
+            {
+              "expression": "meetup_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attendance_report_meetup_id_meetup_id_fk": {
+          "name": "attendance_report_meetup_id_meetup_id_fk",
+          "tableFrom": "attendance_report",
+          "tableTo": "meetup",
+          "columnsFrom": [
+            "meetup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attendance_report_student_id_user_id_fk": {
+          "name": "attendance_report_student_id_user_id_fk",
+          "tableFrom": "attendance_report",
+          "tableTo": "user",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "attendance_report_meetup_student_unique": {
+          "name": "attendance_report_meetup_student_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "meetup_id",
+            "student_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation": {
+      "name": "conversation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user1_id": {
+          "name": "user1_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user2_id": {
+          "name": "user2_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_user1_idx": {
+          "name": "conversation_user1_idx",
+          "columns": [
+            {
+              "expression": "user1_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_user2_idx": {
+          "name": "conversation_user2_idx",
+          "columns": [
+            {
+              "expression": "user2_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_user1_id_user_id_fk": {
+          "name": "conversation_user1_id_user_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user1_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_user2_id_user_id_fk": {
+          "name": "conversation_user2_id_user_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user2_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.language_profile": {
+      "name": "language_profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "university": {
+          "name": "university",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "age": {
+          "name": "age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_complete": {
+          "name": "onboarding_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "language_profile_user_id_user_id_fk": {
+          "name": "language_profile_user_id_user_id_fk",
+          "tableFrom": "language_profile",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "language_profile_user_id_unique": {
+          "name": "language_profile_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_request": {
+      "name": "match_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "requester_id": {
+          "name": "requester_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receiver_id": {
+          "name": "receiver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "match_request_requesterId_idx": {
+          "name": "match_request_requesterId_idx",
+          "columns": [
+            {
+              "expression": "requester_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "match_request_receiverId_idx": {
+          "name": "match_request_receiverId_idx",
+          "columns": [
+            {
+              "expression": "receiver_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "match_request_requester_id_user_id_fk": {
+          "name": "match_request_requester_id_user_id_fk",
+          "tableFrom": "match_request",
+          "tableTo": "user",
+          "columnsFrom": [
+            "requester_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "match_request_receiver_id_user_id_fk": {
+          "name": "match_request_receiver_id_user_id_fk",
+          "tableFrom": "match_request",
+          "tableTo": "user",
+          "columnsFrom": [
+            "receiver_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meetup": {
+      "name": "meetup",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "proposer_id": {
+          "name": "proposer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receiver_id": {
+          "name": "receiver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "venue_id": {
+          "name": "venue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "reschedule_proposer_id": {
+          "name": "reschedule_proposer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reschedule_venue_id": {
+          "name": "reschedule_venue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reschedule_date": {
+          "name": "reschedule_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reschedule_time": {
+          "name": "reschedule_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "meetup_proposerId_idx": {
+          "name": "meetup_proposerId_idx",
+          "columns": [
+            {
+              "expression": "proposer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meetup_receiverId_idx": {
+          "name": "meetup_receiverId_idx",
+          "columns": [
+            {
+              "expression": "receiver_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meetup_date_idx": {
+          "name": "meetup_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "meetup_proposer_id_user_id_fk": {
+          "name": "meetup_proposer_id_user_id_fk",
+          "tableFrom": "meetup",
+          "tableTo": "user",
+          "columnsFrom": [
+            "proposer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meetup_receiver_id_user_id_fk": {
+          "name": "meetup_receiver_id_user_id_fk",
+          "tableFrom": "meetup",
+          "tableTo": "user",
+          "columnsFrom": [
+            "receiver_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meetup_venue_id_venue_id_fk": {
+          "name": "meetup_venue_id_venue_id_fk",
+          "tableFrom": "meetup",
+          "tableTo": "venue",
+          "columnsFrom": [
+            "venue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meetup_reschedule_proposer_id_user_id_fk": {
+          "name": "meetup_reschedule_proposer_id_user_id_fk",
+          "tableFrom": "meetup",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reschedule_proposer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "meetup_reschedule_venue_id_venue_id_fk": {
+          "name": "meetup_reschedule_venue_id_venue_id_fk",
+          "tableFrom": "meetup",
+          "tableTo": "venue",
+          "columnsFrom": [
+            "reschedule_venue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message": {
+      "name": "message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_conversationId_idx": {
+          "name": "message_conversationId_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_createdAt_idx": {
+          "name": "message_createdAt_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_conversation_id_conversation_id_fk": {
+          "name": "message_conversation_id_conversation_id_fk",
+          "tableFrom": "message",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_sender_id_user_id_fk": {
+          "name": "message_sender_id_user_id_fk",
+          "tableFrom": "message",
+          "tableTo": "user",
+          "columnsFrom": [
+            "sender_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message_read_status": {
+      "name": "message_read_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_read_conversationId_userId_idx": {
+          "name": "message_read_conversationId_userId_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_read_status_conversation_id_conversation_id_fk": {
+          "name": "message_read_status_conversation_id_conversation_id_fk",
+          "tableFrom": "message_read_status",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_read_status_user_id_user_id_fk": {
+          "name": "message_read_status_user_id_user_id_fk",
+          "tableFrom": "message_read_status",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messaging_opt_in": {
+      "name": "messaging_opt_in",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "meetup_id": {
+          "name": "meetup_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "messaging_opt_in_meetupId_idx": {
+          "name": "messaging_opt_in_meetupId_idx",
+          "columns": [
+            {
+              "expression": "meetup_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messaging_opt_in_meetup_id_meetup_id_fk": {
+          "name": "messaging_opt_in_meetup_id_meetup_id_fk",
+          "tableFrom": "messaging_opt_in",
+          "tableTo": "meetup",
+          "columnsFrom": [
+            "meetup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messaging_opt_in_student_id_user_id_fk": {
+          "name": "messaging_opt_in_student_id_user_id_fk",
+          "tableFrom": "messaging_opt_in",
+          "tableTo": "user",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "messaging_opt_in_meetup_student_unique": {
+          "name": "messaging_opt_in_meetup_student_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "meetup_id",
+            "student_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_comment": {
+      "name": "student_comment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "student_comment_targetId_idx": {
+          "name": "student_comment_targetId_idx",
+          "columns": [
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "student_comment_author_id_user_id_fk": {
+          "name": "student_comment_author_id_user_id_fk",
+          "tableFrom": "student_comment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "student_comment_target_id_user_id_fk": {
+          "name": "student_comment_target_id_user_id_fk",
+          "tableFrom": "student_comment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_match": {
+      "name": "student_match",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "student_a_id": {
+          "name": "student_a_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_b_id": {
+          "name": "student_b_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_request_id": {
+          "name": "match_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'matched'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "student_match_studentA_idx": {
+          "name": "student_match_studentA_idx",
+          "columns": [
+            {
+              "expression": "student_a_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "student_match_studentB_idx": {
+          "name": "student_match_studentB_idx",
+          "columns": [
+            {
+              "expression": "student_b_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "student_match_student_a_id_user_id_fk": {
+          "name": "student_match_student_a_id_user_id_fk",
+          "tableFrom": "student_match",
+          "tableTo": "user",
+          "columnsFrom": [
+            "student_a_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "student_match_student_b_id_user_id_fk": {
+          "name": "student_match_student_b_id_user_id_fk",
+          "tableFrom": "student_match",
+          "tableTo": "user",
+          "columnsFrom": [
+            "student_b_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "student_match_match_request_id_match_request_id_fk": {
+          "name": "student_match_match_request_id_match_request_id_fk",
+          "tableFrom": "student_match",
+          "tableTo": "match_request",
+          "columnsFrom": [
+            "match_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_device_token": {
+      "name": "user_device_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_device_token_userId_token_idx": {
+          "name": "user_device_token_userId_token_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_device_token_user_id_user_id_fk": {
+          "name": "user_device_token_user_id_user_id_fk",
+          "tableFrom": "user_device_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_interest": {
+      "name": "user_interest",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interest": {
+          "name": "interest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_interest_userId_idx": {
+          "name": "user_interest_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_interest_user_id_user_id_fk": {
+          "name": "user_interest_user_id_user_id_fk",
+          "tableFrom": "user_interest",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_language": {
+      "name": "user_language",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proficiency": {
+          "name": "proficiency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_language_userId_idx": {
+          "name": "user_language_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_language_user_id_user_id_fk": {
+          "name": "user_language_user_id_user_id_fk",
+          "tableFrom": "user_language",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.venue": {
+      "name": "venue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "venue_name_idx": {
+          "name": "venue_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/src/migrations/meta/0009_snapshot.json
+++ b/packages/db/src/migrations/meta/0009_snapshot.json
@@ -1,0 +1,1801 @@
+{
+  "id": "17ae2773-82ec-411c-bac9-2025d66bdf1c",
+  "prevId": "f2a90941-4d22-4647-a68d-e3c737eb7268",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attendance_report": {
+      "name": "attendance_report",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "meetup_id": {
+          "name": "meetup_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attended": {
+          "name": "attended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reported_at": {
+          "name": "reported_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "attendance_report_meetupId_idx": {
+          "name": "attendance_report_meetupId_idx",
+          "columns": [
+            {
+              "expression": "meetup_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attendance_report_meetup_id_meetup_id_fk": {
+          "name": "attendance_report_meetup_id_meetup_id_fk",
+          "tableFrom": "attendance_report",
+          "tableTo": "meetup",
+          "columnsFrom": [
+            "meetup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attendance_report_student_id_user_id_fk": {
+          "name": "attendance_report_student_id_user_id_fk",
+          "tableFrom": "attendance_report",
+          "tableTo": "user",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "attendance_report_meetup_student_unique": {
+          "name": "attendance_report_meetup_student_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "meetup_id",
+            "student_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation": {
+      "name": "conversation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user1_id": {
+          "name": "user1_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user2_id": {
+          "name": "user2_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_user1_idx": {
+          "name": "conversation_user1_idx",
+          "columns": [
+            {
+              "expression": "user1_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_user2_idx": {
+          "name": "conversation_user2_idx",
+          "columns": [
+            {
+              "expression": "user2_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_user1_id_user_id_fk": {
+          "name": "conversation_user1_id_user_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user1_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_user2_id_user_id_fk": {
+          "name": "conversation_user2_id_user_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user2_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.language_profile": {
+      "name": "language_profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "university": {
+          "name": "university",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "age": {
+          "name": "age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_complete": {
+          "name": "onboarding_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "language_profile_user_id_user_id_fk": {
+          "name": "language_profile_user_id_user_id_fk",
+          "tableFrom": "language_profile",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "language_profile_user_id_unique": {
+          "name": "language_profile_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_request": {
+      "name": "match_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "requester_id": {
+          "name": "requester_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receiver_id": {
+          "name": "receiver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "match_request_requesterId_idx": {
+          "name": "match_request_requesterId_idx",
+          "columns": [
+            {
+              "expression": "requester_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "match_request_receiverId_idx": {
+          "name": "match_request_receiverId_idx",
+          "columns": [
+            {
+              "expression": "receiver_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "match_request_requester_id_user_id_fk": {
+          "name": "match_request_requester_id_user_id_fk",
+          "tableFrom": "match_request",
+          "tableTo": "user",
+          "columnsFrom": [
+            "requester_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "match_request_receiver_id_user_id_fk": {
+          "name": "match_request_receiver_id_user_id_fk",
+          "tableFrom": "match_request",
+          "tableTo": "user",
+          "columnsFrom": [
+            "receiver_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meetup": {
+      "name": "meetup",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "proposer_id": {
+          "name": "proposer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receiver_id": {
+          "name": "receiver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "venue_id": {
+          "name": "venue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "reschedule_proposer_id": {
+          "name": "reschedule_proposer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reschedule_venue_id": {
+          "name": "reschedule_venue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reschedule_date": {
+          "name": "reschedule_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reschedule_time": {
+          "name": "reschedule_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "meetup_proposerId_idx": {
+          "name": "meetup_proposerId_idx",
+          "columns": [
+            {
+              "expression": "proposer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meetup_receiverId_idx": {
+          "name": "meetup_receiverId_idx",
+          "columns": [
+            {
+              "expression": "receiver_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meetup_date_idx": {
+          "name": "meetup_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "meetup_proposer_id_user_id_fk": {
+          "name": "meetup_proposer_id_user_id_fk",
+          "tableFrom": "meetup",
+          "tableTo": "user",
+          "columnsFrom": [
+            "proposer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meetup_receiver_id_user_id_fk": {
+          "name": "meetup_receiver_id_user_id_fk",
+          "tableFrom": "meetup",
+          "tableTo": "user",
+          "columnsFrom": [
+            "receiver_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meetup_venue_id_venue_id_fk": {
+          "name": "meetup_venue_id_venue_id_fk",
+          "tableFrom": "meetup",
+          "tableTo": "venue",
+          "columnsFrom": [
+            "venue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meetup_reschedule_proposer_id_user_id_fk": {
+          "name": "meetup_reschedule_proposer_id_user_id_fk",
+          "tableFrom": "meetup",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reschedule_proposer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "meetup_reschedule_venue_id_venue_id_fk": {
+          "name": "meetup_reschedule_venue_id_venue_id_fk",
+          "tableFrom": "meetup",
+          "tableTo": "venue",
+          "columnsFrom": [
+            "reschedule_venue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message": {
+      "name": "message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_conversationId_idx": {
+          "name": "message_conversationId_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_createdAt_idx": {
+          "name": "message_createdAt_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_conversation_id_conversation_id_fk": {
+          "name": "message_conversation_id_conversation_id_fk",
+          "tableFrom": "message",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_sender_id_user_id_fk": {
+          "name": "message_sender_id_user_id_fk",
+          "tableFrom": "message",
+          "tableTo": "user",
+          "columnsFrom": [
+            "sender_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message_read_status": {
+      "name": "message_read_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_read_conversationId_userId_idx": {
+          "name": "message_read_conversationId_userId_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_read_status_conversation_id_conversation_id_fk": {
+          "name": "message_read_status_conversation_id_conversation_id_fk",
+          "tableFrom": "message_read_status",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_read_status_user_id_user_id_fk": {
+          "name": "message_read_status_user_id_user_id_fk",
+          "tableFrom": "message_read_status",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messaging_opt_in": {
+      "name": "messaging_opt_in",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "meetup_id": {
+          "name": "meetup_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "nudge_sent_at": {
+          "name": "nudge_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "messaging_opt_in_meetupId_idx": {
+          "name": "messaging_opt_in_meetupId_idx",
+          "columns": [
+            {
+              "expression": "meetup_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messaging_opt_in_meetup_id_meetup_id_fk": {
+          "name": "messaging_opt_in_meetup_id_meetup_id_fk",
+          "tableFrom": "messaging_opt_in",
+          "tableTo": "meetup",
+          "columnsFrom": [
+            "meetup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messaging_opt_in_student_id_user_id_fk": {
+          "name": "messaging_opt_in_student_id_user_id_fk",
+          "tableFrom": "messaging_opt_in",
+          "tableTo": "user",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "messaging_opt_in_meetup_student_unique": {
+          "name": "messaging_opt_in_meetup_student_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "meetup_id",
+            "student_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_comment": {
+      "name": "student_comment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "student_comment_targetId_idx": {
+          "name": "student_comment_targetId_idx",
+          "columns": [
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "student_comment_author_id_user_id_fk": {
+          "name": "student_comment_author_id_user_id_fk",
+          "tableFrom": "student_comment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "student_comment_target_id_user_id_fk": {
+          "name": "student_comment_target_id_user_id_fk",
+          "tableFrom": "student_comment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_match": {
+      "name": "student_match",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "student_a_id": {
+          "name": "student_a_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_b_id": {
+          "name": "student_b_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_request_id": {
+          "name": "match_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'matched'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "student_match_studentA_idx": {
+          "name": "student_match_studentA_idx",
+          "columns": [
+            {
+              "expression": "student_a_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "student_match_studentB_idx": {
+          "name": "student_match_studentB_idx",
+          "columns": [
+            {
+              "expression": "student_b_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "student_match_student_a_id_user_id_fk": {
+          "name": "student_match_student_a_id_user_id_fk",
+          "tableFrom": "student_match",
+          "tableTo": "user",
+          "columnsFrom": [
+            "student_a_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "student_match_student_b_id_user_id_fk": {
+          "name": "student_match_student_b_id_user_id_fk",
+          "tableFrom": "student_match",
+          "tableTo": "user",
+          "columnsFrom": [
+            "student_b_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "student_match_match_request_id_match_request_id_fk": {
+          "name": "student_match_match_request_id_match_request_id_fk",
+          "tableFrom": "student_match",
+          "tableTo": "match_request",
+          "columnsFrom": [
+            "match_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_device_token": {
+      "name": "user_device_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_device_token_userId_token_idx": {
+          "name": "user_device_token_userId_token_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_device_token_user_id_user_id_fk": {
+          "name": "user_device_token_user_id_user_id_fk",
+          "tableFrom": "user_device_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_interest": {
+      "name": "user_interest",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interest": {
+          "name": "interest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_interest_userId_idx": {
+          "name": "user_interest_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_interest_user_id_user_id_fk": {
+          "name": "user_interest_user_id_user_id_fk",
+          "tableFrom": "user_interest",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_language": {
+      "name": "user_language",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proficiency": {
+          "name": "proficiency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_language_userId_idx": {
+          "name": "user_language_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_language_user_id_user_id_fk": {
+          "name": "user_language_user_id_user_id_fk",
+          "tableFrom": "user_language",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.venue": {
+      "name": "venue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "venue_name_idx": {
+          "name": "venue_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/src/migrations/meta/0010_snapshot.json
+++ b/packages/db/src/migrations/meta/0010_snapshot.json
@@ -1,0 +1,1835 @@
+{
+  "id": "53b2ab22-e030-4692-88dd-ece690cacf98",
+  "prevId": "17ae2773-82ec-411c-bac9-2025d66bdf1c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attendance_report": {
+      "name": "attendance_report",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "meetup_id": {
+          "name": "meetup_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attended": {
+          "name": "attended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reported_at": {
+          "name": "reported_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "attendance_report_meetupId_idx": {
+          "name": "attendance_report_meetupId_idx",
+          "columns": [
+            {
+              "expression": "meetup_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attendance_report_meetup_id_meetup_id_fk": {
+          "name": "attendance_report_meetup_id_meetup_id_fk",
+          "tableFrom": "attendance_report",
+          "tableTo": "meetup",
+          "columnsFrom": [
+            "meetup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attendance_report_student_id_user_id_fk": {
+          "name": "attendance_report_student_id_user_id_fk",
+          "tableFrom": "attendance_report",
+          "tableTo": "user",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "attendance_report_meetup_student_unique": {
+          "name": "attendance_report_meetup_student_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "meetup_id",
+            "student_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation": {
+      "name": "conversation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user1_id": {
+          "name": "user1_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user2_id": {
+          "name": "user2_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meetup_id": {
+          "name": "meetup_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_user1_idx": {
+          "name": "conversation_user1_idx",
+          "columns": [
+            {
+              "expression": "user1_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_user2_idx": {
+          "name": "conversation_user2_idx",
+          "columns": [
+            {
+              "expression": "user2_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_meetupId_idx": {
+          "name": "conversation_meetupId_idx",
+          "columns": [
+            {
+              "expression": "meetup_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_user1_id_user_id_fk": {
+          "name": "conversation_user1_id_user_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user1_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_user2_id_user_id_fk": {
+          "name": "conversation_user2_id_user_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user2_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_meetup_id_meetup_id_fk": {
+          "name": "conversation_meetup_id_meetup_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "meetup",
+          "columnsFrom": [
+            "meetup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.language_profile": {
+      "name": "language_profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "university": {
+          "name": "university",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "age": {
+          "name": "age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_complete": {
+          "name": "onboarding_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "language_profile_user_id_user_id_fk": {
+          "name": "language_profile_user_id_user_id_fk",
+          "tableFrom": "language_profile",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "language_profile_user_id_unique": {
+          "name": "language_profile_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_request": {
+      "name": "match_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "requester_id": {
+          "name": "requester_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receiver_id": {
+          "name": "receiver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "match_request_requesterId_idx": {
+          "name": "match_request_requesterId_idx",
+          "columns": [
+            {
+              "expression": "requester_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "match_request_receiverId_idx": {
+          "name": "match_request_receiverId_idx",
+          "columns": [
+            {
+              "expression": "receiver_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "match_request_requester_id_user_id_fk": {
+          "name": "match_request_requester_id_user_id_fk",
+          "tableFrom": "match_request",
+          "tableTo": "user",
+          "columnsFrom": [
+            "requester_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "match_request_receiver_id_user_id_fk": {
+          "name": "match_request_receiver_id_user_id_fk",
+          "tableFrom": "match_request",
+          "tableTo": "user",
+          "columnsFrom": [
+            "receiver_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meetup": {
+      "name": "meetup",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "proposer_id": {
+          "name": "proposer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receiver_id": {
+          "name": "receiver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "venue_id": {
+          "name": "venue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "reschedule_proposer_id": {
+          "name": "reschedule_proposer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reschedule_venue_id": {
+          "name": "reschedule_venue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reschedule_date": {
+          "name": "reschedule_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reschedule_time": {
+          "name": "reschedule_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "meetup_proposerId_idx": {
+          "name": "meetup_proposerId_idx",
+          "columns": [
+            {
+              "expression": "proposer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meetup_receiverId_idx": {
+          "name": "meetup_receiverId_idx",
+          "columns": [
+            {
+              "expression": "receiver_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meetup_date_idx": {
+          "name": "meetup_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "meetup_proposer_id_user_id_fk": {
+          "name": "meetup_proposer_id_user_id_fk",
+          "tableFrom": "meetup",
+          "tableTo": "user",
+          "columnsFrom": [
+            "proposer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meetup_receiver_id_user_id_fk": {
+          "name": "meetup_receiver_id_user_id_fk",
+          "tableFrom": "meetup",
+          "tableTo": "user",
+          "columnsFrom": [
+            "receiver_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meetup_venue_id_venue_id_fk": {
+          "name": "meetup_venue_id_venue_id_fk",
+          "tableFrom": "meetup",
+          "tableTo": "venue",
+          "columnsFrom": [
+            "venue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meetup_reschedule_proposer_id_user_id_fk": {
+          "name": "meetup_reschedule_proposer_id_user_id_fk",
+          "tableFrom": "meetup",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reschedule_proposer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "meetup_reschedule_venue_id_venue_id_fk": {
+          "name": "meetup_reschedule_venue_id_venue_id_fk",
+          "tableFrom": "meetup",
+          "tableTo": "venue",
+          "columnsFrom": [
+            "reschedule_venue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message": {
+      "name": "message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_conversationId_idx": {
+          "name": "message_conversationId_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_createdAt_idx": {
+          "name": "message_createdAt_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_conversation_id_conversation_id_fk": {
+          "name": "message_conversation_id_conversation_id_fk",
+          "tableFrom": "message",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_sender_id_user_id_fk": {
+          "name": "message_sender_id_user_id_fk",
+          "tableFrom": "message",
+          "tableTo": "user",
+          "columnsFrom": [
+            "sender_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message_read_status": {
+      "name": "message_read_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_read_conversationId_userId_idx": {
+          "name": "message_read_conversationId_userId_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_read_status_conversation_id_conversation_id_fk": {
+          "name": "message_read_status_conversation_id_conversation_id_fk",
+          "tableFrom": "message_read_status",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_read_status_user_id_user_id_fk": {
+          "name": "message_read_status_user_id_user_id_fk",
+          "tableFrom": "message_read_status",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messaging_opt_in": {
+      "name": "messaging_opt_in",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "meetup_id": {
+          "name": "meetup_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "nudge_sent_at": {
+          "name": "nudge_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "messaging_opt_in_meetupId_idx": {
+          "name": "messaging_opt_in_meetupId_idx",
+          "columns": [
+            {
+              "expression": "meetup_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messaging_opt_in_meetup_id_meetup_id_fk": {
+          "name": "messaging_opt_in_meetup_id_meetup_id_fk",
+          "tableFrom": "messaging_opt_in",
+          "tableTo": "meetup",
+          "columnsFrom": [
+            "meetup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messaging_opt_in_student_id_user_id_fk": {
+          "name": "messaging_opt_in_student_id_user_id_fk",
+          "tableFrom": "messaging_opt_in",
+          "tableTo": "user",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "messaging_opt_in_meetup_student_unique": {
+          "name": "messaging_opt_in_meetup_student_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "meetup_id",
+            "student_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_comment": {
+      "name": "student_comment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "student_comment_targetId_idx": {
+          "name": "student_comment_targetId_idx",
+          "columns": [
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "student_comment_author_id_user_id_fk": {
+          "name": "student_comment_author_id_user_id_fk",
+          "tableFrom": "student_comment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "student_comment_target_id_user_id_fk": {
+          "name": "student_comment_target_id_user_id_fk",
+          "tableFrom": "student_comment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_match": {
+      "name": "student_match",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "student_a_id": {
+          "name": "student_a_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_b_id": {
+          "name": "student_b_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_request_id": {
+          "name": "match_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'matched'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "student_match_studentA_idx": {
+          "name": "student_match_studentA_idx",
+          "columns": [
+            {
+              "expression": "student_a_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "student_match_studentB_idx": {
+          "name": "student_match_studentB_idx",
+          "columns": [
+            {
+              "expression": "student_b_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "student_match_student_a_id_user_id_fk": {
+          "name": "student_match_student_a_id_user_id_fk",
+          "tableFrom": "student_match",
+          "tableTo": "user",
+          "columnsFrom": [
+            "student_a_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "student_match_student_b_id_user_id_fk": {
+          "name": "student_match_student_b_id_user_id_fk",
+          "tableFrom": "student_match",
+          "tableTo": "user",
+          "columnsFrom": [
+            "student_b_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "student_match_match_request_id_match_request_id_fk": {
+          "name": "student_match_match_request_id_match_request_id_fk",
+          "tableFrom": "student_match",
+          "tableTo": "match_request",
+          "columnsFrom": [
+            "match_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_device_token": {
+      "name": "user_device_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_device_token_userId_token_idx": {
+          "name": "user_device_token_userId_token_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_device_token_user_id_user_id_fk": {
+          "name": "user_device_token_user_id_user_id_fk",
+          "tableFrom": "user_device_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_interest": {
+      "name": "user_interest",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interest": {
+          "name": "interest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_interest_userId_idx": {
+          "name": "user_interest_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_interest_user_id_user_id_fk": {
+          "name": "user_interest_user_id_user_id_fk",
+          "tableFrom": "user_interest",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_language": {
+      "name": "user_language",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proficiency": {
+          "name": "proficiency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_language_userId_idx": {
+          "name": "user_language_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_language_user_id_user_id_fk": {
+          "name": "user_language_user_id_user_id_fk",
+          "tableFrom": "user_language",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.venue": {
+      "name": "venue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "venue_name_idx": {
+          "name": "venue_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1776108828439,
       "tag": "0008_pink_the_order",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1776109302796,
+      "tag": "0009_narrow_orphan",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1776109302796,
       "tag": "0009_narrow_orphan",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1776109533625,
+      "tag": "0010_kind_reaper",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1776105551308,
       "tag": "0007_wooden_texas_twister",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1776108828439,
+      "tag": "0008_pink_the_order",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/sip-and-speak.ts
+++ b/packages/db/src/schema/sip-and-speak.ts
@@ -428,6 +428,39 @@ export const attendanceReport = pgTable(
   ],
 );
 
+// #139 — Messaging opt-in: each Student independently records their accept/decline response
+export const messagingOptIn = pgTable(
+  "messaging_opt_in",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    meetupId: text("meetup_id")
+      .notNull()
+      .references(() => meetup.id, { onDelete: "cascade" }),
+    studentId: text("student_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    response: text("response", { enum: ["accept", "decline"] }).notNull(),
+    respondedAt: timestamp("responded_at").defaultNow().notNull(),
+  },
+  (table) => [
+    unique("messaging_opt_in_meetup_student_unique").on(table.meetupId, table.studentId),
+    index("messaging_opt_in_meetupId_idx").on(table.meetupId),
+  ],
+);
+
+export const messagingOptInRelations = relations(messagingOptIn, ({ one }) => ({
+  meetup: one(meetup, {
+    fields: [messagingOptIn.meetupId],
+    references: [meetup.id],
+  }),
+  student: one(user, {
+    fields: [messagingOptIn.studentId],
+    references: [user.id],
+  }),
+}));
+
 export const studentMatchRelations = relations(studentMatch, ({ one }) => ({
   studentA: one(user, {
     fields: [studentMatch.studentAId],

--- a/packages/db/src/schema/sip-and-speak.ts
+++ b/packages/db/src/schema/sip-and-speak.ts
@@ -150,11 +150,14 @@ export const conversation = pgTable(
     user2Id: text("user2_id")
       .notNull()
       .references(() => user.id, { onDelete: "cascade" }),
+    // #141 — FK to meetup; unique per meetup (at most one conversation per meetup pair)
+    meetupId: text("meetup_id").references(() => meetup.id, { onDelete: "set null" }),
     createdAt: timestamp("created_at").defaultNow().notNull(),
   },
   (table) => [
     index("conversation_user1_idx").on(table.user1Id),
     index("conversation_user2_idx").on(table.user2Id),
+    uniqueIndex("conversation_meetupId_idx").on(table.meetupId),
   ],
 );
 

--- a/packages/db/src/schema/sip-and-speak.ts
+++ b/packages/db/src/schema/sip-and-speak.ts
@@ -443,6 +443,8 @@ export const messagingOptIn = pgTable(
       .references(() => user.id, { onDelete: "cascade" }),
     response: text("response", { enum: ["accept", "decline"] }).notNull(),
     respondedAt: timestamp("responded_at").defaultNow().notNull(),
+    // #140 — Set when this acceptance triggered a nudge push to the pending partner; prevents duplicate nudges
+    nudgeSentAt: timestamp("nudge_sent_at"),
   },
   (table) => [
     unique("messaging_opt_in_meetup_student_unique").on(table.meetupId, table.studentId),


### PR DESCRIPTION
## Summary

Implements Feature #25 end-to-end: after a S&S moment completes, both Students are prompted to opt in to messaging. This feature adds the full opt-in response lifecycle — recording responses, nudging the pending partner when their match accepts, opening the conversation channel when both agree, and notifying both when either declines.

## Changes

- **#138** — Opt-in push sent to both Students after `MeetupCompleted`
- **#139** — `messagingOptIn` table + `messaging.respondToOptIn` tRPC procedure
- **#140** — Second nudge push to pending Student when match accepts (`nudgeSentAt` guard)
- **#141** — Conversation created + both notified when both accept (`ConversationOpened`)
- **#142** — Both notified sensitively when either declines (`MessagingDeclineOutcome`)

## Test plan

- [x] Opt-in push sent to both Students on meetup completion
- [x] Accept/decline recorded; duplicate response rejected (CONFLICT)
- [x] Nudge sent to pending Student; not sent when partner already responded
- [x] Conversation opened only when both accept; no duplicate on race condition
- [x] Decline outcome notified to both; no conversation created

## Related

Closes #25
Closes #138
Closes #139
Closes #140
Closes #141
Closes #142