### PR TITLE
feat(messaging): add message compose UI

### DIFF
--- a/apps/native/__tests__/compose-ui.test.tsx
+++ b/apps/native/__tests__/compose-ui.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * Tests for task #143 — Build message compose UI
+ *
+ * Covers:
+ *   - Student types a message and taps Send → submitted + input cleared
+ *   - Student taps Send with empty input → blocked, inline hint shown
+ *   - Send button disabled while submission is in-flight
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react-native";
+import React from "react";
+
+// ── Router mock ───────────────────────────────────────────────────────────────
+
+jest.mock("expo-router", () => ({
+  useLocalSearchParams: () => ({ conversationId: "conv-1" }),
+  useRouter: () => ({ back: jest.fn() }),
+}));
+
+// ── tRPC / query mock ─────────────────────────────────────────────────────────
+
+const mockSendMessage = jest.fn();
+let sendMessageCallbacks: { onSuccess?: () => void; onError?: (e: Error) => void } = {};
+
+jest.mock("@/utils/trpc", () => ({
+  trpc: {
+    messaging: {
+      sendMessage: {
+        mutationOptions: (opts: { onSuccess?: () => void; onError?: (e: Error) => void }) => {
+          sendMessageCallbacks = opts;
+          return {
+            mutationFn: mockSendMessage,
+            onSuccess: opts?.onSuccess,
+            onError: opts?.onError,
+          };
+        },
+      },
+    },
+  },
+  queryClient: { invalidateQueries: jest.fn() },
+}));
+
+import ChatScreen from "../app/chat/[conversationId]";
+
+function renderWithQuery(ui: React.ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+}
+
+beforeEach(() => {
+  mockSendMessage.mockReset();
+  sendMessageCallbacks = {};
+});
+
+// ── #143: Compose UI scenarios ────────────────────────────────────────────────
+
+describe("#143 — Message compose UI", () => {
+  it("submits message and clears input on success", async () => {
+    mockSendMessage.mockResolvedValue({ id: "msg-1" });
+    renderWithQuery(<ChatScreen />);
+
+    const input = screen.getByTestId("message-input");
+    fireEvent.changeText(input, "Hello!");
+    fireEvent.press(screen.getByTestId("send-btn"));
+
+    await waitFor(() => {
+      expect(mockSendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ conversationId: "conv-1", content: "Hello!" }),
+        expect.anything(),
+      );
+    });
+
+    // Input cleared after success
+    await waitFor(() => {
+      expect(input.props.value).toBe("");
+    });
+  });
+
+  it("blocks submission and shows hint when input is empty", () => {
+    renderWithQuery(<ChatScreen />);
+
+    fireEvent.press(screen.getByTestId("send-btn"));
+
+    expect(mockSendMessage).not.toHaveBeenCalled();
+    expect(screen.getByTestId("empty-hint")).toBeTruthy();
+  });
+
+  it("disables Send button while submission is in-flight", async () => {
+    // Never resolves — keeps mutation pending
+    mockSendMessage.mockReturnValue(new Promise(() => {}));
+    renderWithQuery(<ChatScreen />);
+
+    const input = screen.getByTestId("message-input");
+    fireEvent.changeText(input, "Hi");
+    fireEvent.press(screen.getByTestId("send-btn"));
+
+    await waitFor(() => {
+      const btn = screen.getByTestId("send-btn");
+      expect(btn.props.accessibilityState?.disabled).toBe(true);
+    });
+  });
+});

--- a/apps/native/app/chat/[conversationId].tsx
+++ b/apps/native/app/chat/[conversationId].tsx
@@ -1,0 +1,80 @@
+import { useMutation } from "@tanstack/react-query";
+import { useLocalSearchParams } from "expo-router";
+import { useState } from "react";
+import { Text, TextInput, TouchableOpacity, View } from "react-native";
+
+import { Container } from "@/components/container";
+import { trpc } from "@/utils/trpc";
+
+export default function ChatScreen() {
+  const { conversationId } = useLocalSearchParams<{ conversationId: string }>();
+  const [content, setContent] = useState("");
+  const [showEmptyHint, setShowEmptyHint] = useState(false);
+  const [sendError, setSendError] = useState<string | null>(null);
+
+  const sendMessage = useMutation(
+    trpc.messaging.sendMessage.mutationOptions({
+      onSuccess: () => {
+        setContent("");
+        setSendError(null);
+      },
+      onError: (err) => setSendError(err.message),
+    }),
+  );
+
+  function handleSend() {
+    if (!content.trim()) {
+      setShowEmptyHint(true);
+      return;
+    }
+    setShowEmptyHint(false);
+    setSendError(null);
+    sendMessage.mutate({ conversationId, content: content.trim() });
+  }
+
+  function handleChangeText(text: string) {
+    setContent(text);
+    if (text.trim()) setShowEmptyHint(false);
+  }
+
+  const isPending = sendMessage.isPending;
+
+  return (
+    <Container isScrollable={false}>
+      <View className="flex-1" />
+
+      <View className="border-t border-border px-4 py-3 gap-2">
+        {showEmptyHint && (
+          <Text testID="empty-hint" className="text-danger text-sm">
+            Message cannot be empty.
+          </Text>
+        )}
+        {sendError && (
+          <Text className="text-danger text-sm">{sendError}</Text>
+        )}
+        <View className="flex-row items-end gap-2">
+          <TextInput
+            testID="message-input"
+            className="flex-1 border border-border rounded-xl px-3 py-2 text-foreground bg-background"
+            placeholder="Type a message…"
+            placeholderTextColor="gray"
+            multiline
+            value={content}
+            onChangeText={handleChangeText}
+            editable={!isPending}
+            accessibilityLabel="Message input"
+          />
+          <TouchableOpacity
+            testID="send-btn"
+            onPress={handleSend}
+            disabled={isPending}
+            accessibilityState={{ disabled: isPending }}
+            className="bg-primary rounded-xl px-4 py-2 justify-center"
+          >
+            <Text className="text-primary-foreground font-semibold">Send</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </Container>
+  );
+}

--- a/packages/api/src/routers/messaging.ts
+++ b/packages/api/src/routers/messaging.ts
@@ -189,4 +189,20 @@ export const messagingRouter = router({
 
       return { recorded: true as const };
     }),
+
+  /**
+   * #143 — Stub: entry point called by the compose UI.
+   * Access-gate added in #146, validation in #144, persistence in #145.
+   */
+  sendMessage: protectedProcedure
+    .input(
+      z.object({
+        conversationId: z.string(),
+        content: z.string(),
+      }),
+    )
+    .mutation(async () => {
+      // Stub — implementation added incrementally in #144, #146, #145
+      return { id: "" as string, conversationId: "" as string, senderId: "" as string, content: "" as string, createdAt: new Date() };
+    }),
 });


### PR DESCRIPTION
## Summary

Connected Students need a way to compose and send messages within their open conversation. This adds the conversation screen with a text input and Send button — the UI entry point for the messaging flow. It also adds a `sendMessage` tRPC procedure stub that the UI calls; the access-gate (#146), content validation (#144), and persistence (#145) are layered on top in subsequent tasks.

## Changes

- New conversation screen at `apps/native/app/chat/[conversationId].tsx` with controlled text input, Send button, inline empty-message validation hint, and loading/disabled state during send
- `sendMessage` procedure stub added to `packages/api/src/routers/messaging.ts` (returns empty shell; implemented in #144/#146/#145)
- Jest tests covering all 3 Gherkin scenarios

## Test plan

- [ ] Student types a message and taps Send — mutation called, input cleared on success
- [ ] Student taps Send with empty input — mutation not called, inline hint shown
- [ ] Send button is disabled while submission is in-flight

## Related

Closes #143
