### PR TITLE
feat(messaging): add server-side message content validation

### DIFF
--- a/packages/api/src/__tests__/messaging-send-validation.test.ts
+++ b/packages/api/src/__tests__/messaging-send-validation.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Tests for task #144 — Validate message content before send
+ *
+ * Covers:
+ *   - Empty message rejected
+ *   - Whitespace-only message rejected
+ *   - Valid message passes validation
+ *   - Max-length constraint (2000 chars)
+ */
+import { describe, it, expect } from "bun:test";
+
+import { validateMessageContent } from "../routers/messaging-utils";
+
+describe("#144 — validateMessageContent", () => {
+  it("rejects empty string", () => {
+    const result = validateMessageContent("");
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.error).toBe("EMPTY_CONTENT");
+  });
+
+  it("rejects whitespace-only string", () => {
+    const result = validateMessageContent("   ");
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.error).toBe("EMPTY_CONTENT");
+  });
+
+  it("accepts a valid message and returns trimmed content", () => {
+    const result = validateMessageContent("  Hello!  ");
+    expect(result.valid).toBe(true);
+    if (result.valid) expect(result.trimmed).toBe("Hello!");
+  });
+
+  it("accepts a message at the max-length boundary (2000 chars)", () => {
+    const result = validateMessageContent("a".repeat(2000));
+    expect(result.valid).toBe(true);
+  });
+
+  it("rejects a message exceeding max length (2001 chars)", () => {
+    const result = validateMessageContent("a".repeat(2001));
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.error).toBe("TOO_LONG");
+  });
+});

--- a/packages/api/src/routers/messaging-utils.ts
+++ b/packages/api/src/routers/messaging-utils.ts
@@ -46,6 +46,19 @@ export function isDeclineOutcome(
 }
 
 /**
+ * #144 — Validates message content before persistence.
+ * Returns `{ valid: true, trimmed }` on success or `{ valid: false, error }` on failure.
+ */
+export function validateMessageContent(
+  content: string,
+): { valid: true; trimmed: string } | { valid: false; error: "EMPTY_CONTENT" | "TOO_LONG" } {
+  const trimmed = content.trim();
+  if (!trimmed) return { valid: false, error: "EMPTY_CONTENT" };
+  if (trimmed.length > 2000) return { valid: false, error: "TOO_LONG" };
+  return { valid: true, trimmed };
+}
+
+/**
  * Derives the partner's ID from a meetup's proposer/receiver pair.
  */
 export function getPartnerId(

--- a/packages/api/src/routers/messaging.ts
+++ b/packages/api/src/routers/messaging.ts
@@ -6,7 +6,7 @@ import { protectedProcedure, router } from "../index";
 import { domainEvents } from "../domain-events";
 import { db } from "@sip-and-speak/db";
 import { meetup, messagingOptIn, conversation } from "@sip-and-speak/db/schema/sip-and-speak";
-import { hasAlreadyResponded, getPartnerId, shouldSendNudge, bothAccepted, isDeclineOutcome } from "./messaging-utils";
+import { hasAlreadyResponded, getPartnerId, shouldSendNudge, bothAccepted, isDeclineOutcome, validateMessageContent } from "./messaging-utils";
 
 export const messagingRouter = router({
   /**
@@ -201,8 +201,15 @@ export const messagingRouter = router({
         content: z.string(),
       }),
     )
-    .mutation(async () => {
-      // Stub — implementation added incrementally in #144, #146, #145
-      return { id: "" as string, conversationId: "" as string, senderId: "" as string, content: "" as string, createdAt: new Date() };
+    .mutation(async ({ input }) => {
+      // #144 — Content validation
+      const validation = validateMessageContent(input.content);
+      if (!validation.valid) {
+        throw new TRPCError({ code: "BAD_REQUEST", message: validation.error });
+      }
+
+      // #146 — Access gate (added in task #146)
+      // #145 — Persistence (added in task #145)
+      return { id: "" as string, conversationId: "" as string, senderId: "" as string, content: validation.trimmed, createdAt: new Date() };
     }),
 });


### PR DESCRIPTION
## Summary

The compose UI (task #143) calls `messaging.sendMessage` but the server was accepting any content. This adds server-side validation so empty or whitespace-only messages are rejected before they ever reach the database — regardless of what the client sends. Also enforces a 2000-character max-length cap.

## Changes

- `validateMessageContent` pure function added to `packages/api/src/routers/messaging-utils.ts`
- `sendMessage` procedure now calls `validateMessageContent` and throws `BAD_REQUEST` on invalid input
- Unit tests covering empty, whitespace-only, valid, boundary, and over-length cases

## Test plan

- [ ] Empty message returns validation error
- [ ] Whitespace-only message returns validation error
- [ ] Valid message passes through to next stage
- [ ] 2001-char message rejected; 2000-char accepted

## Related

Closes #144
