### PR TITLE
feat(messaging): persist message to DB and return created row

### DIFF
--- a/packages/api/src/__tests__/messaging-send-persistence.test.ts
+++ b/packages/api/src/__tests__/messaging-send-persistence.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Tests for task #145 — Persist and deliver message to recipient
+ *
+ * Covers:
+ *   - Message insert is called with correct conversationId, senderId, content
+ *   - Created message row is returned to sender
+ *   - DB error propagates (no partial record created)
+ */
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+// ── drizzle-orm mock (must be before any imports that use it) ─────────────────
+
+mock.module("drizzle-orm", () => ({
+  eq: (_col: unknown, val: unknown) => ({ _eq: val }),
+  and: (...args: unknown[]) => args,
+  isNull: () => ({ _isNull: true }),
+}));
+
+// ── DB mock ───────────────────────────────────────────────────────────────────
+
+const insertedRows: Array<{ conversationId: string; senderId: string; content: string }> = [];
+let dbError: Error | null = null;
+
+mock.module("@sip-and-speak/db", () => ({
+  db: {
+    insert: (_table: unknown) => ({
+      values: (row: { conversationId: string; senderId: string; content: string }) => ({
+        returning: () => {
+          if (dbError) return Promise.reject(dbError);
+          const created = { id: "msg-1", createdAt: new Date(), ...row };
+          insertedRows.push(row);
+          return Promise.resolve([created]);
+        },
+      }),
+    }),
+  },
+}));
+
+mock.module("@sip-and-speak/db/schema/sip-and-speak", () => ({
+  message: "message",
+  conversation: "conversation",
+  meetup: "meetup",
+  messagingOptIn: "messagingOptIn",
+}));
+
+// ── Import under test (after mocks) ──────────────────────────────────────────
+
+import { persistMessage } from "../routers/messaging-persist";
+
+beforeEach(() => {
+  insertedRows.length = 0;
+  dbError = null;
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("#145 — persistMessage", () => {
+  it("inserts message with correct fields and returns the created row", async () => {
+    const result = await persistMessage({
+      conversationId: "conv-1",
+      senderId: "alice",
+      content: "Hello Bob!",
+    });
+
+    expect(insertedRows).toHaveLength(1);
+    expect(insertedRows[0]).toMatchObject({
+      conversationId: "conv-1",
+      senderId: "alice",
+      content: "Hello Bob!",
+    });
+    expect(result.id).toBe("msg-1");
+    expect(result.content).toBe("Hello Bob!");
+  });
+
+  it("propagates DB error without creating a partial record", async () => {
+    dbError = new Error("DB connection lost");
+
+    await expect(
+      persistMessage({ conversationId: "conv-1", senderId: "alice", content: "Hi" }),
+    ).rejects.toThrow("DB connection lost");
+
+    expect(insertedRows).toHaveLength(0);
+  });
+});

--- a/packages/api/src/routers/messaging-persist.ts
+++ b/packages/api/src/routers/messaging-persist.ts
@@ -1,0 +1,29 @@
+/**
+ * #145 — Persistence helpers for the messaging send flow.
+ * Extracted for unit testing without requiring a live tRPC context.
+ */
+import { db } from "@sip-and-speak/db";
+import { message } from "@sip-and-speak/db/schema/sip-and-speak";
+
+export interface PersistMessageInput {
+  conversationId: string;
+  senderId: string;
+  content: string;
+}
+
+/**
+ * Inserts a message row and returns the created record.
+ * Throws on DB failure — no partial record is created.
+ */
+export async function persistMessage(input: PersistMessageInput) {
+  const [created] = await db
+    .insert(message)
+    .values({
+      conversationId: input.conversationId,
+      senderId: input.senderId,
+      content: input.content,
+    })
+    .returning();
+
+  return created!;
+}

--- a/packages/api/src/routers/messaging.ts
+++ b/packages/api/src/routers/messaging.ts
@@ -7,6 +7,7 @@ import { domainEvents } from "../domain-events";
 import { db } from "@sip-and-speak/db";
 import { meetup, messagingOptIn, conversation } from "@sip-and-speak/db/schema/sip-and-speak";
 import { hasAlreadyResponded, getPartnerId, shouldSendNudge, bothAccepted, isDeclineOutcome, validateMessageContent, checkConversationAccess } from "./messaging-utils";
+import { persistMessage } from "./messaging-persist";
 
 export const messagingRouter = router({
   /**
@@ -231,7 +232,17 @@ export const messagingRouter = router({
         throw new TRPCError({ code: "BAD_REQUEST", message: validation.error });
       }
 
-      // #145 — Persistence (added in task #145)
-      return { id: "" as string, conversationId: input.conversationId, senderId, content: validation.trimmed, createdAt: new Date() };
+      // #145 — Persist and return the created message
+      const created = await persistMessage({
+        conversationId: input.conversationId,
+        senderId,
+        content: validation.trimmed,
+      });
+
+      console.log(
+        `[messaging] message sent conversationId=${input.conversationId} senderId=${senderId}`,
+      );
+
+      return created;
     }),
 });


### PR DESCRIPTION
## Summary

The `sendMessage` procedure had a stub return after access-gate and validation. This task completes the implementation by actually inserting the message into the `message` table and returning the created row — making messages durable and immediately queryable by the recipient on their next fetch.

## Changes

- `persistMessage` function extracted to `packages/api/src/routers/messaging-persist.ts` (DB insert + return created row)
- `sendMessage` procedure now calls `persistMessage` after access and validation pass; logs `[messaging] message sent` on success
- Unit tests verifying correct insert fields and graceful DB error propagation

## Test plan

- [ ] Message inserted with correct conversationId, senderId, content
- [ ] Created row (with generated id and createdAt) returned to sender
- [ ] DB error propagates to caller; no partial record created

## Related

Closes #145
