### PR TITLE
feat(#151): enforce read access control on getMessages

### DIFF
--- a/packages/api/src/__tests__/messaging-read-access.test.ts
+++ b/packages/api/src/__tests__/messaging-read-access.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Tests for task #151 — Block read access to conversations that are not mutually accepted
+ *
+ * Covers:
+ *   - Non-participant cannot fetch conversation messages
+ *   - Participant can read their own conversation
+ *   - Suspended conversation returns NOT_A_PARTICIPANT (no info leak)
+ *   - Non-existent conversation returns NOT_A_PARTICIPANT (no info leak)
+ */
+import { describe, it, expect } from "bun:test";
+
+import { checkReadAccess } from "../routers/messaging-utils";
+
+const openConv = { user1Id: "alice", user2Id: "bob", status: "open" as const };
+const suspendedConv = { user1Id: "alice", user2Id: "bob", status: "suspended" as const };
+
+describe("#151 — checkReadAccess", () => {
+  it("rejects a non-participant with NOT_A_PARTICIPANT", () => {
+    const result = checkReadAccess(openConv, "charlie");
+    expect(result.allowed).toBe(false);
+    if (!result.allowed) expect(result.error).toBe("NOT_A_PARTICIPANT");
+  });
+
+  it("rejects access to a suspended conversation with NOT_A_PARTICIPANT", () => {
+    const result = checkReadAccess(suspendedConv, "alice");
+    expect(result.allowed).toBe(false);
+    if (!result.allowed) expect(result.error).toBe("NOT_A_PARTICIPANT");
+  });
+
+  it("rejects a non-existent conversation with NOT_A_PARTICIPANT", () => {
+    const result = checkReadAccess(undefined, "alice");
+    expect(result.allowed).toBe(false);
+    if (!result.allowed) expect(result.error).toBe("NOT_A_PARTICIPANT");
+  });
+
+  it("allows user1 to read an open conversation", () => {
+    const result = checkReadAccess(openConv, "alice");
+    expect(result.allowed).toBe(true);
+  });
+
+  it("allows user2 to read an open conversation", () => {
+    const result = checkReadAccess(openConv, "bob");
+    expect(result.allowed).toBe(true);
+  });
+});

--- a/packages/api/src/routers/chat.ts
+++ b/packages/api/src/routers/chat.ts
@@ -1,5 +1,6 @@
 import { and, desc, eq, lt, or } from "drizzle-orm";
 import { z } from "zod";
+import { TRPCError } from "@trpc/server";
 import { db } from "@sip-and-speak/db";
 import {
   conversation,
@@ -7,6 +8,7 @@ import {
   messageReadStatus,
 } from "@sip-and-speak/db/schema/sip-and-speak";
 import { user } from "@sip-and-speak/db/schema/auth";
+import { checkReadAccess } from "./messaging-utils";
 import { protectedProcedure, router } from "../index";
 
 export const chatRouter = router({
@@ -103,8 +105,9 @@ export const chatRouter = router({
         )
         .limit(1);
 
-      if (conv.length === 0) {
-        throw new Error("Conversation not found");
+      const access = checkReadAccess(conv[0], userId);
+      if (!access.allowed) {
+        throw new TRPCError({ code: "FORBIDDEN", message: access.error });
       }
 
       const conditions = [eq(message.conversationId, input.conversationId)];

--- a/packages/api/src/routers/messaging-utils.ts
+++ b/packages/api/src/routers/messaging-utils.ts
@@ -74,6 +74,22 @@ export function validateMessageContent(
 }
 
 /**
+ * #151 — Checks whether a reader is allowed to fetch messages from a conversation.
+ * Non-participants and suspended conversations both return NOT_A_PARTICIPANT to
+ * avoid leaking whether the conversation exists.
+ */
+export function checkReadAccess(
+  conv: { user1Id: string; user2Id: string; status: "open" | "suspended" } | undefined,
+  readerId: string,
+): { allowed: true } | { allowed: false; error: "NOT_A_PARTICIPANT" } {
+  if (!conv) return { allowed: false, error: "NOT_A_PARTICIPANT" };
+  const isParticipant = conv.user1Id === readerId || conv.user2Id === readerId;
+  if (!isParticipant) return { allowed: false, error: "NOT_A_PARTICIPANT" };
+  if (conv.status !== "open") return { allowed: false, error: "NOT_A_PARTICIPANT" };
+  return { allowed: true };
+}
+
+/**
  * Derives the partner's ID from a meetup's proposer/receiver pair.
  */
 export function getPartnerId(


### PR DESCRIPTION
## Summary

- Adds `checkReadAccess` pure helper to `messaging-utils.ts` — returns `NOT_A_PARTICIPANT` for non-participants and suspended conversations (no information leak)
- Wires helper into `chat.getMessages`, replacing bare `throw new Error` with `TRPCError FORBIDDEN`
- Adds participant check for suspended conversation status (previously unchecked)
- 5 unit tests covering all access scenarios

## Test plan

- [x] Non-participant → `NOT_A_PARTICIPANT`
- [x] Suspended conversation participant → `NOT_A_PARTICIPANT`
- [x] Non-existent conversation → `NOT_A_PARTICIPANT`
- [x] user1 allowed in open conversation
- [x] user2 allowed in open conversation

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)