### PR TITLE
feat(#148): add read/unread status indicators on message bubbles

### DIFF
--- a/apps/native/__tests__/read-unread-indicators.test.tsx
+++ b/apps/native/__tests__/read-unread-indicators.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * Tests for task #148 — Render read/unread status indicators on messages
+ *
+ * Covers:
+ *   - Unread partner message shows unread indicator
+ *   - Own messages never show unread indicator
+ *   - Read partner message (isUnread: false) shows no indicator
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react-native";
+import React from "react";
+
+// ── FlatList mock ─────────────────────────────────────────────────────────────
+
+jest.mock("react-native", () => {
+  const RN = jest.requireActual("react-native");
+  RN.FlatList = ({ data, renderItem, testID }: {
+    data: unknown[];
+    renderItem: ({ item, index }: { item: unknown; index: number }) => React.ReactNode;
+    testID?: string;
+  }) => {
+    const React = require("react");
+    return React.createElement(
+      RN.View,
+      { testID },
+      data?.map((item, index) => renderItem({ item, index })),
+    );
+  };
+  return RN;
+});
+
+// ── Router mock ───────────────────────────────────────────────────────────────
+
+jest.mock("expo-router", () => ({
+  useLocalSearchParams: () => ({ conversationId: "conv-1" }),
+  useRouter: () => ({ back: jest.fn() }),
+}));
+
+// ── Auth mock ─────────────────────────────────────────────────────────────────
+
+jest.mock("@/lib/auth-client", () => ({
+  authClient: {
+    useSession: () => ({ data: { user: { id: "alice" } } }),
+  },
+}));
+
+// ── tRPC mock — mixed unread/read messages ────────────────────────────────────
+
+jest.mock("@/utils/trpc", () => ({
+  trpc: {
+    chat: {
+      getMessages: {
+        queryOptions: (_input: unknown, _opts: unknown) => ({
+          queryKey: ["chat.getMessages", "conv-1"],
+          queryFn: async () => ({
+            messages: [
+              { id: "m1", senderId: "alice", content: "Hi Bob",  createdAt: new Date("2024-01-01T10:00:00Z"), isUnread: false }, // own
+              { id: "m2", senderId: "bob",   content: "Hey!",    createdAt: new Date("2024-01-01T10:01:00Z"), isUnread: false }, // read partner
+              { id: "m3", senderId: "bob",   content: "New msg", createdAt: new Date("2024-01-01T10:02:00Z"), isUnread: true  }, // unread partner
+            ],
+          }),
+        }),
+      },
+    },
+    messaging: {
+      sendMessage: {
+        mutationOptions: (opts: { onSuccess?: () => void; onError?: (e: Error) => void }) => ({
+          mutationFn: jest.fn(),
+          onSuccess: opts.onSuccess,
+          onError: opts.onError,
+        }),
+      },
+    },
+  },
+}));
+
+// ── Component import ──────────────────────────────────────────────────────────
+
+import ChatScreen from "../app/chat/[conversationId]";
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+describe("#148 — Read/unread status indicators", () => {
+  it("shows unread indicator only on the unread partner message", async () => {
+    render(<ChatScreen />, { wrapper: Wrapper });
+    await waitFor(() => {
+      const indicators = screen.getAllByTestId("unread-indicator");
+      expect(indicators).toHaveLength(1); // only m3 (isUnread: true)
+    });
+  });
+
+  it("own messages do not show an unread indicator", async () => {
+    render(<ChatScreen />, { wrapper: Wrapper });
+    await waitFor(() => {
+      const bubbles = screen.getAllByTestId("message-bubble");
+      expect(bubbles).toHaveLength(3);
+    });
+    // Alice's own message (m1) has no unread indicator
+    const indicators = screen.queryAllByTestId("unread-indicator");
+    expect(indicators).toHaveLength(1); // only m3, not m1
+  });
+
+  it("read partner messages do not show an unread indicator", async () => {
+    render(<ChatScreen />, { wrapper: Wrapper });
+    await waitFor(() => {
+      const bubbles = screen.getAllByTestId("message-bubble");
+      expect(bubbles).toHaveLength(3);
+    });
+    // m2 is bob's but isUnread: false → no indicator for it
+    const indicators = screen.queryAllByTestId("unread-indicator");
+    expect(indicators).toHaveLength(1); // only m3
+  });
+});

--- a/apps/native/app/chat/[conversationId].tsx
+++ b/apps/native/app/chat/[conversationId].tsx
@@ -77,22 +77,32 @@ export default function ChatScreen() {
           return (
             <View
               testID="message-bubble"
-              className={`mx-4 my-1 max-w-[80%] rounded-2xl px-3 py-2 ${isMine ? "self-end bg-primary" : "self-start bg-muted"}`}
+              className={`mx-4 my-1 max-w-[80%] rounded-2xl px-3 py-2 ${isMine ? "self-end bg-primary" : item.isUnread ? "self-start bg-muted border-l-2 border-primary" : "self-start bg-muted"}`}
             >
               {!isMine && (
                 <Text testID="message-sender" className="text-xs text-muted-foreground mb-1">
                   Match
                 </Text>
               )}
-              <Text className={isMine ? "text-primary-foreground" : "text-foreground"}>
+              <Text
+                className={`${isMine ? "text-primary-foreground" : "text-foreground"} ${item.isUnread && !isMine ? "font-semibold" : ""}`}
+              >
                 {item.content}
               </Text>
-              <Text
-                testID="message-timestamp"
-                className={`text-xs mt-1 ${isMine ? "text-primary-foreground/70" : "text-muted-foreground"}`}
-              >
-                {formatTime(item.createdAt)}
-              </Text>
+              <View className="flex-row items-center justify-end gap-1 mt-1">
+                {item.isUnread && !isMine && (
+                  <View
+                    testID="unread-indicator"
+                    className="w-2 h-2 rounded-full bg-primary"
+                  />
+                )}
+                <Text
+                  testID="message-timestamp"
+                  className={`text-xs ${isMine ? "text-primary-foreground/70" : "text-muted-foreground"}`}
+                >
+                  {formatTime(item.createdAt)}
+                </Text>
+              </View>
             </View>
           );
         }}

--- a/packages/api/src/__tests__/messaging-read-status.test.ts
+++ b/packages/api/src/__tests__/messaging-read-status.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Tests for task #148 — Read/unread status indicators on messages
+ *
+ * Covers:
+ *   - Unread messages (partner, no read record) → isUnread: true
+ *   - Read messages (partner, createdAt ≤ lastReadAt) → isUnread: false
+ *   - Own messages always read → isUnread: false
+ *   - Indicators update after lastReadAt advances
+ */
+import { describe, it, expect } from "bun:test";
+
+import { computeIsUnread } from "../routers/messaging-utils";
+
+const T0 = new Date("2024-01-01T10:00:00Z");
+const T1 = new Date("2024-01-01T10:01:00Z");
+const T2 = new Date("2024-01-01T10:02:00Z");
+
+describe("#148 — computeIsUnread", () => {
+  it("partner message with no read record is unread", () => {
+    expect(computeIsUnread({ senderId: "bob", createdAt: T1 }, "alice", null)).toBe(true);
+  });
+
+  it("partner message sent after lastReadAt is unread", () => {
+    expect(computeIsUnread({ senderId: "bob", createdAt: T2 }, "alice", T1)).toBe(true);
+  });
+
+  it("partner message sent before lastReadAt is read", () => {
+    expect(computeIsUnread({ senderId: "bob", createdAt: T0 }, "alice", T1)).toBe(false);
+  });
+
+  it("partner message sent exactly at lastReadAt is read", () => {
+    expect(computeIsUnread({ senderId: "bob", createdAt: T1 }, "alice", T1)).toBe(false);
+  });
+
+  it("own message is always read regardless of lastReadAt", () => {
+    expect(computeIsUnread({ senderId: "alice", createdAt: T2 }, "alice", null)).toBe(false);
+    expect(computeIsUnread({ senderId: "alice", createdAt: T2 }, "alice", T0)).toBe(false);
+  });
+});

--- a/packages/api/src/routers/chat.ts
+++ b/packages/api/src/routers/chat.ts
@@ -8,7 +8,7 @@ import {
   messageReadStatus,
 } from "@sip-and-speak/db/schema/sip-and-speak";
 import { user } from "@sip-and-speak/db/schema/auth";
-import { checkReadAccess } from "./messaging-utils";
+import { checkReadAccess, computeIsUnread } from "./messaging-utils";
 import { protectedProcedure, router } from "../index";
 
 export const chatRouter = router({
@@ -126,9 +126,26 @@ export const chatRouter = router({
       const hasMore = messages.length > input.limit;
       const items = hasMore ? messages.slice(0, input.limit) : messages;
 
+      // Fetch viewer's read status for isUnread computation (#148)
+      const readStatusRows = await db
+        .select({ lastReadAt: messageReadStatus.lastReadAt })
+        .from(messageReadStatus)
+        .where(
+          and(
+            eq(messageReadStatus.conversationId, input.conversationId),
+            eq(messageReadStatus.userId, userId),
+          ),
+        )
+        .limit(1);
+      const lastReadAt = readStatusRows[0]?.lastReadAt ?? null;
+
+      const chronological = items.reverse();
       return {
-        messages: items.reverse(), // chronological order
-        nextCursor: hasMore ? items[items.length - 1]?.id : undefined,
+        messages: chronological.map((msg) => ({
+          ...msg,
+          isUnread: computeIsUnread(msg, userId, lastReadAt),
+        })),
+        nextCursor: hasMore ? chronological[chronological.length - 1]?.id : undefined,
       };
     }),
 

--- a/packages/api/src/routers/messaging-utils.ts
+++ b/packages/api/src/routers/messaging-utils.ts
@@ -74,6 +74,21 @@ export function validateMessageContent(
 }
 
 /**
+ * #148 — Determines whether a message is unread by the viewing student.
+ * Own messages are always treated as read.
+ * Partner messages are unread if their createdAt is after the viewer's lastReadAt.
+ */
+export function computeIsUnread(
+  message: { senderId: string; createdAt: Date },
+  viewerId: string,
+  lastReadAt: Date | null,
+): boolean {
+  if (message.senderId === viewerId) return false; // own messages always read
+  if (lastReadAt === null) return true; // no read record → all partner messages unread
+  return message.createdAt > lastReadAt;
+}
+
+/**
  * #151 — Checks whether a reader is allowed to fetch messages from a conversation.
  * Non-participants and suspended conversations both return NOT_A_PARTICIPANT to
  * avoid leaking whether the conversation exists.


### PR DESCRIPTION
## Summary

- Extends `chat.getMessages` to compute `isUnread` server-side per message (join `messageReadStatus.lastReadAt`)
- Own messages always treated as read; partner messages compared against `lastReadAt`
- UI: unread partner messages show a dot indicator + bold text + left border highlight
- Added `computeIsUnread` pure helper to `messaging-utils.ts` (5 unit tests)
- 3 native tests covering indicator presence/absence

## Test plan

- [x] Partner message with no read record → `isUnread: true`
- [x] Partner message after `lastReadAt` → `isUnread: true`
- [x] Partner message before `lastReadAt` → `isUnread: false`
- [x] Own message always `isUnread: false`
- [x] UI: unread indicator rendered only on unread partner messages

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)