### PR TITLE
feat(#149): mark messages as read when Student views conversation

### DIFF
--- a/apps/native/__tests__/mark-messages-as-read.test.tsx
+++ b/apps/native/__tests__/mark-messages-as-read.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * Tests for task #149 — Mark messages as read when Student views the conversation
+ *
+ * Covers:
+ *   - chat.markRead is called when the conversation screen mounts (focus)
+ *   - Re-visiting the conversation calls markRead again
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react-native";
+import React from "react";
+
+// ── FlatList mock ─────────────────────────────────────────────────────────────
+
+jest.mock("react-native", () => {
+  const RN = jest.requireActual("react-native");
+  RN.FlatList = ({ data, renderItem, testID, ListEmptyComponent }: {
+    data: unknown[];
+    renderItem: ({ item, index }: { item: unknown; index: number }) => React.ReactNode;
+    testID?: string;
+    ListEmptyComponent?: React.ReactNode;
+  }) => {
+    const React = require("react");
+    if (!data || data.length === 0) {
+      return React.createElement(RN.View, { testID }, ListEmptyComponent);
+    }
+    return React.createElement(
+      RN.View,
+      { testID },
+      data.map((item, index) => renderItem({ item, index })),
+    );
+  };
+  return RN;
+});
+
+// ── Router mock ───────────────────────────────────────────────────────────────
+
+let capturedFocusEffect: (() => void) | null = null;
+
+jest.mock("expo-router", () => {
+  const { useEffect } = require("react");
+  return {
+    useLocalSearchParams: () => ({ conversationId: "conv-1" }),
+    useRouter: () => ({ back: jest.fn() }),
+    useFocusEffect: (cb: () => void) => {
+      capturedFocusEffect = cb;
+      // Only fire once on mount (simulates initial screen focus)
+      useEffect(() => { cb(); }, []); // eslint-disable-line react-hooks/exhaustive-deps
+    },
+  };
+});
+
+// ── Auth mock ─────────────────────────────────────────────────────────────────
+
+jest.mock("@/lib/auth-client", () => ({
+  authClient: {
+    useSession: () => ({ data: { user: { id: "alice" } } }),
+  },
+}));
+
+// ── tRPC mock ─────────────────────────────────────────────────────────────────
+
+const mockMarkRead = jest.fn().mockResolvedValue({ lastReadAt: new Date() });
+
+jest.mock("@/utils/trpc", () => ({
+  trpc: {
+    chat: {
+      getMessages: {
+        queryOptions: (_input: unknown, _opts: unknown) => ({
+          queryKey: ["chat.getMessages", "conv-1"],
+          queryFn: async () => ({ messages: [] }),
+        }),
+      },
+      markRead: {
+        mutationOptions: () => ({
+          mutationFn: mockMarkRead,
+        }),
+      },
+    },
+    messaging: {
+      sendMessage: {
+        mutationOptions: (opts: { onSuccess?: () => void; onError?: (e: Error) => void }) => ({
+          mutationFn: jest.fn(),
+          onSuccess: opts.onSuccess,
+          onError: opts.onError,
+        }),
+      },
+    },
+  },
+}));
+
+// ── Component import ──────────────────────────────────────────────────────────
+
+import ChatScreen from "../app/chat/[conversationId]";
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+beforeEach(() => {
+  mockMarkRead.mockClear();
+  capturedFocusEffect = null;
+});
+
+describe("#149 — Mark messages as read on view", () => {
+  it("calls markRead when the conversation screen gets focus", async () => {
+    render(<ChatScreen />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(mockMarkRead).toHaveBeenCalledWith(
+        { conversationId: "conv-1" },
+        expect.anything(),
+      );
+    });
+  });
+
+  it("calls markRead again when the Student re-focuses the screen", async () => {
+    render(<ChatScreen />, { wrapper: Wrapper });
+
+    // Initial focus
+    await waitFor(() => expect(mockMarkRead).toHaveBeenCalledTimes(1));
+
+    // Simulate re-focus
+    if (capturedFocusEffect) capturedFocusEffect();
+
+    await waitFor(() => expect(mockMarkRead).toHaveBeenCalledTimes(2));
+  });
+});

--- a/apps/native/app/chat/[conversationId].tsx
+++ b/apps/native/app/chat/[conversationId].tsx
@@ -1,6 +1,7 @@
-import { useQuery, useMutation } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useLocalSearchParams } from "expo-router";
-import { useEffect, useRef, useState } from "react";
+import { useFocusEffect } from "expo-router";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { FlatList, Text, TextInput, TouchableOpacity, View } from "react-native";
 
 import { authClient } from "@/lib/auth-client";
@@ -21,6 +22,25 @@ export default function ChatScreen() {
   const [showEmptyHint, setShowEmptyHint] = useState(false);
   const [sendError, setSendError] = useState<string | null>(null);
   const listRef = useRef<FlatList>(null);
+  const queryClient = useQueryClient();
+
+  const markRead = useMutation(
+    trpc.chat.markRead.mutationOptions(),
+  );
+
+  useFocusEffect(
+    useCallback(() => {
+      markRead.mutate(
+        { conversationId },
+        {
+          onSuccess: () => {
+            // Invalidate getMessages so isUnread indicators refresh
+            void queryClient.invalidateQueries({ queryKey: ["chat.getMessages"] });
+          },
+        },
+      );
+    }, [conversationId]),
+  );
 
   const { data } = useQuery(
     trpc.chat.getMessages.queryOptions(

--- a/packages/api/src/__tests__/messaging-mark-read.test.ts
+++ b/packages/api/src/__tests__/messaging-mark-read.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Tests for task #149 — Mark messages as read when Student views the conversation
+ *
+ * Covers:
+ *   - lastReadAt advances when now > existing
+ *   - lastReadAt never moves backwards (monotone invariant)
+ *   - First read (no existing record) uses now
+ */
+import { describe, it, expect } from "bun:test";
+
+import { computeMarkReadAt } from "../routers/messaging-utils";
+
+const T0 = new Date("2024-01-01T10:00:00Z");
+const T1 = new Date("2024-01-01T10:01:00Z");
+const T2 = new Date("2024-01-01T10:02:00Z");
+
+describe("#149 — computeMarkReadAt", () => {
+  it("advances lastReadAt when now is later", () => {
+    const result = computeMarkReadAt(T0, T1);
+    expect(result).toEqual(T1);
+  });
+
+  it("keeps existing lastReadAt when now is earlier (monotone invariant)", () => {
+    const result = computeMarkReadAt(T2, T0);
+    expect(result).toEqual(T2);
+  });
+
+  it("keeps existing lastReadAt when now equals existing", () => {
+    const result = computeMarkReadAt(T1, T1);
+    expect(result).toEqual(T1);
+  });
+
+  it("uses now when there is no existing lastReadAt", () => {
+    const result = computeMarkReadAt(null, T1);
+    expect(result).toEqual(T1);
+  });
+});

--- a/packages/api/src/routers/chat.ts
+++ b/packages/api/src/routers/chat.ts
@@ -8,7 +8,7 @@ import {
   messageReadStatus,
 } from "@sip-and-speak/db/schema/sip-and-speak";
 import { user } from "@sip-and-speak/db/schema/auth";
-import { checkReadAccess, computeIsUnread } from "./messaging-utils";
+import { checkReadAccess, computeIsUnread, computeMarkReadAt } from "./messaging-utils";
 import { protectedProcedure, router } from "../index";
 
 export const chatRouter = router({
@@ -343,19 +343,22 @@ export const chatRouter = router({
         )
         .limit(1);
 
+      const now = new Date();
+      const newLastReadAt = computeMarkReadAt(existing[0]?.lastReadAt ?? null, now);
+
       if (existing.length > 0) {
         await db
           .update(messageReadStatus)
-          .set({ lastReadAt: new Date() })
+          .set({ lastReadAt: newLastReadAt })
           .where(eq(messageReadStatus.id, existing[0].id));
       } else {
         await db.insert(messageReadStatus).values({
           conversationId: input.conversationId,
           userId,
-          lastReadAt: new Date(),
+          lastReadAt: newLastReadAt,
         });
       }
 
-      return { success: true };
+      return { lastReadAt: newLastReadAt };
     }),
 });

--- a/packages/api/src/routers/messaging-utils.ts
+++ b/packages/api/src/routers/messaging-utils.ts
@@ -46,6 +46,15 @@ export function isDeclineOutcome(
 }
 
 /**
+ * #149 — Computes the new lastReadAt timestamp for a mark-as-read operation.
+ * lastReadAt can only move forward — returns the later of existing and now.
+ */
+export function computeMarkReadAt(existingLastReadAt: Date | null, now: Date): Date {
+  if (existingLastReadAt === null) return now;
+  return now > existingLastReadAt ? now : existingLastReadAt;
+}
+
+/**
  * #146 — Checks whether a sender is allowed to post in a conversation.
  * Returns `{ allowed: true }` or `{ allowed: false, error }`.
  */


### PR DESCRIPTION
## Summary

- Adds `computeMarkReadAt` pure helper enforcing the monotone invariant: `lastReadAt` can only move forward
- Wires helper into `chat.markRead` procedure so it never sets an earlier timestamp
- Calls `chat.markRead` via `useFocusEffect` in ChatScreen — fires on mount and on every re-visit
- Invalidates `getMessages` cache on success so unread indicators refresh immediately
- 4 API unit tests (monotone invariant) + 2 native tests (markRead called on focus/re-focus)

## Test plan

- [x] `lastReadAt` advances when now > existing
- [x] `lastReadAt` stays when now < existing (monotone)
- [x] `lastReadAt` stays on equal timestamps
- [x] First read (no existing) uses now
- [x] `chat.markRead` called on screen mount
- [x] `chat.markRead` called again on re-focus

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)