### PR TITLE
feat(#152): send push notification to recipient when a new message arrives

### DIFF
--- a/apps/server/src/__tests__/notifications-message-sent.test.ts
+++ b/apps/server/src/__tests__/notifications-message-sent.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for task #152 — Send push notification to recipient when a new message arrives
+ *
+ * Covers:
+ *   - Recipient receives a push identifying the sender (no message content)
+ *   - No push sent when recipient has no registered device token
+ */
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+// ── Fetch mock ────────────────────────────────────────────────────────────────
+
+interface CapturedFetchCall {
+  url: string;
+  messages: Array<{ to: string; title?: string; body?: string; data?: Record<string, unknown> }>;
+}
+
+const fetchCalls: CapturedFetchCall[] = [];
+
+(global as unknown as { fetch: unknown }).fetch = mock(async (url: string, options: RequestInit) => {
+  fetchCalls.push({
+    url,
+    messages: JSON.parse(options.body as string) as CapturedFetchCall["messages"],
+  });
+  return {
+    json: async () => ({ data: [{ status: "ok", id: "ticket-1" }] }),
+  };
+});
+
+// ── Schema mocks ──────────────────────────────────────────────────────────────
+
+const DEVICE_TOKEN_TABLE = "userDeviceToken";
+
+mock.module("@sip-and-speak/db/schema/sip-and-speak", () => ({
+  userDeviceToken: DEVICE_TOKEN_TABLE,
+  userLanguage: "userLanguage",
+}));
+
+mock.module("@sip-and-speak/db/schema/auth", () => ({
+  user: "user",
+}));
+
+// ── drizzle-orm mock ──────────────────────────────────────────────────────────
+
+mock.module("drizzle-orm", () => ({
+  eq: (_col: unknown, val: unknown) => ({ _val: val }),
+}));
+
+// ── DB mock ───────────────────────────────────────────────────────────────────
+
+const SENDER_ID = "sender-id";
+const RECIPIENT_ID = "recipient-id";
+
+let mockRecipientTokens: Array<{ id: string; token: string }> = [];
+
+mock.module("@sip-and-speak/db", () => ({
+  db: {
+    select: (_fields: Record<string, unknown>) => ({
+      from: (_table: unknown) => ({
+        where: (clause: { _val: string }) => {
+          const rows = clause._val === RECIPIENT_ID ? mockRecipientTokens : [];
+          return Promise.resolve(rows);
+        },
+      }),
+    }),
+    delete: (_table: unknown) => ({
+      where: (_clause: unknown) => Promise.resolve([]),
+    }),
+  },
+}));
+
+// ── Domain events mock ────────────────────────────────────────────────────────
+
+mock.module("@sip-and-speak/api/domain-events", () => ({
+  domainEvents: { on: mock((_evt: string, _fn: unknown) => undefined), emit: mock(() => undefined) },
+}));
+
+// ── Import under test (after mocks) ──────────────────────────────────────────
+
+// eslint-disable-next-line import/first
+import { handleMessageSent } from "../notifications";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeMessageSentEvent(
+  overrides: Partial<{
+    conversationId: string;
+    senderId: string;
+    recipientId: string;
+    senderName: string;
+  }> = {},
+) {
+  return {
+    conversationId: overrides.conversationId ?? "conv-1",
+    senderId: overrides.senderId ?? SENDER_ID,
+    recipientId: overrides.recipientId ?? RECIPIENT_ID,
+    senderName: overrides.senderName ?? "Alice",
+  };
+}
+
+beforeEach(() => {
+  fetchCalls.length = 0;
+  mockRecipientTokens = [];
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("#152 — Send push notification to recipient when a new message arrives", () => {
+  it("sends a push to the recipient identifying the sender without message content", async () => {
+    mockRecipientTokens = [{ id: "tok-1", token: "ExponentPushToken[recipient]" }];
+
+    await handleMessageSent(makeMessageSentEvent());
+
+    expect(fetchCalls).toHaveLength(1);
+
+    const call = fetchCalls[0];
+    if (!call) throw new Error("Expected a fetch call");
+
+    expect(call.messages).toHaveLength(1);
+    const msg = call.messages[0];
+    if (!msg) throw new Error("Expected a message");
+
+    expect(msg.to).toBe("ExponentPushToken[recipient]");
+    expect(msg.title).toContain("Alice");
+    expect(msg.body).toBeUndefined();
+    expect(msg.data?.type).toBe("message_received");
+    expect(msg.data?.conversationId).toBe("conv-1");
+    expect(msg.data?.senderId).toBe(SENDER_ID);
+  });
+
+  it("sends no notification when recipient has no registered device token", async () => {
+    mockRecipientTokens = [];
+
+    await handleMessageSent(makeMessageSentEvent());
+
+    expect(fetchCalls).toHaveLength(0);
+  });
+});

--- a/apps/server/src/notifications.ts
+++ b/apps/server/src/notifications.ts
@@ -8,7 +8,7 @@ import { eq } from "drizzle-orm";
 import { db } from "@sip-and-speak/db";
 import { userDeviceToken, userLanguage } from "@sip-and-speak/db/schema/sip-and-speak";
 import { user } from "@sip-and-speak/db/schema/auth";
-import { domainEvents, type MatchRequestSentEvent, type MatchRequestAcceptedEvent, type MatchRequestDeclinedEvent, type MeetupProposedEvent, type MeetupConfirmedEvent, type MeetupCounterProposedEvent, type MeetupDeclinedEvent, type MeetupCancelledEvent, type MeetupRescheduleProposedEvent, type MeetupRescheduledEvent, type MeetupRescheduleDeclinedEvent, type SipAndSpeakMomentCompletedEvent, type MeetupNotAttendedEvent, type MessagingOptInPromptedEvent, type MessagingNudgeNeededEvent, type ConversationOpenedEvent, type MessagingDeclineOutcomeEvent } from "@sip-and-speak/api/domain-events";
+import { domainEvents, type MatchRequestSentEvent, type MatchRequestAcceptedEvent, type MatchRequestDeclinedEvent, type MeetupProposedEvent, type MeetupConfirmedEvent, type MeetupCounterProposedEvent, type MeetupDeclinedEvent, type MeetupCancelledEvent, type MeetupRescheduleProposedEvent, type MeetupRescheduledEvent, type MeetupRescheduleDeclinedEvent, type SipAndSpeakMomentCompletedEvent, type MeetupNotAttendedEvent, type MessagingOptInPromptedEvent, type MessagingNudgeNeededEvent, type ConversationOpenedEvent, type MessagingDeclineOutcomeEvent, type MessageSentEvent } from "@sip-and-speak/api/domain-events";
 import { buildMatchRequestNotificationBody } from "@sip-and-speak/api/routers/matching-utils";
 
 const EXPO_PUSH_URL = "https://exp.host/--/api/v2/push/send";
@@ -388,6 +388,9 @@ export function registerNotificationHandlers(): void {
   domainEvents.on("MessagingDeclineOutcome", (event) => {
     void handleMessagingDeclineOutcome(event);
   });
+  domainEvents.on("MessageSent", (event) => {
+    void handleMessageSent(event);
+  });
 }
 
 // #91 — Notify both Students when a reschedule is accepted and meetup details are updated
@@ -683,6 +686,64 @@ export async function handleMessagingDeclineOutcome(event: MessagingDeclineOutco
     await sendExpoPushNotification(messages);
   } catch (err) {
     console.error("[push] Failed to send MessagingDeclineOutcome notification", { meetupId, err });
+  }
+}
+
+// #152 — Notify recipient when a new message arrives
+export async function handleMessageSent(event: MessageSentEvent): Promise<void> {
+  const { conversationId, senderId, recipientId, senderName } = event;
+
+  const tokens = await db
+    .select({ id: userDeviceToken.id, token: userDeviceToken.token })
+    .from(userDeviceToken)
+    .where(eq(userDeviceToken.userId, recipientId));
+
+  if (tokens.length === 0) {
+    console.info("[push] No device token for recipient — skipping new message notification", {
+      conversationId,
+      recipientId,
+    });
+    return;
+  }
+
+  const messages: ExpoPushMessage[] = tokens.map(({ token }) => ({
+    to: token,
+    title: `${senderName} sent you a message`,
+    body: undefined,
+    data: { conversationId, senderId, type: "message_received" },
+  }));
+
+  console.info("[push] Sending MessageSent notification", {
+    conversationId,
+    recipientId,
+    tokenCount: messages.length,
+  });
+
+  try {
+    const tickets = await sendExpoPushNotification(messages);
+
+    const staleTokenIds: string[] = [];
+    for (let i = 0; i < tickets.length; i++) {
+      const ticket = tickets[i];
+      if (ticket?.status === "error" && ticket.details?.error === "DeviceNotRegistered") {
+        const staleId = tokens[i]?.id;
+        if (staleId) staleTokenIds.push(staleId);
+      }
+    }
+
+    if (staleTokenIds.length > 0) {
+      await Promise.all(
+        staleTokenIds.map((id) => db.delete(userDeviceToken).where(eq(userDeviceToken.id, id))),
+      );
+      console.info("[push] Removed stale device tokens", { staleTokenIds });
+    }
+
+    console.info("[push] MessageSent notification delivery complete", {
+      conversationId,
+      tickets: tickets.map((t) => ({ status: t.status, id: t.id })),
+    });
+  } catch (err) {
+    console.error("[push] Failed to send MessageSent notification", { conversationId, err });
   }
 }
 

--- a/packages/api/src/domain-events.ts
+++ b/packages/api/src/domain-events.ts
@@ -180,6 +180,13 @@ export interface MessagingNudgeNeededEvent {
   pendingStudentId: string;
 }
 
+export interface MessageSentEvent {
+  conversationId: string;
+  senderId: string;
+  recipientId: string;
+  senderName: string;
+}
+
 type DomainEventMap = {
   LanguageProfileUpdated: [LanguageProfileUpdatedEvent];
   InterestProfileUpdated: [InterestProfileUpdatedEvent];
@@ -204,6 +211,7 @@ type DomainEventMap = {
   MessagingNudgeNeeded: [MessagingNudgeNeededEvent];
   ConversationOpened: [ConversationOpenedEvent];
   MessagingDeclineOutcome: [MessagingDeclineOutcomeEvent];
+  MessageSent: [MessageSentEvent];
 };
 
 class TypedEventEmitter extends EventEmitter {

--- a/packages/api/src/routers/messaging.ts
+++ b/packages/api/src/routers/messaging.ts
@@ -6,6 +6,7 @@ import { protectedProcedure, router } from "../index";
 import { domainEvents } from "../domain-events";
 import { db } from "@sip-and-speak/db";
 import { meetup, messagingOptIn, conversation } from "@sip-and-speak/db/schema/sip-and-speak";
+import { user } from "@sip-and-speak/db/schema/auth";
 import { hasAlreadyResponded, getPartnerId, shouldSendNudge, bothAccepted, isDeclineOutcome, validateMessageContent, checkConversationAccess } from "./messaging-utils";
 import { persistMessage } from "./messaging-persist";
 
@@ -233,10 +234,23 @@ export const messagingRouter = router({
       }
 
       // #145 — Persist and return the created message
-      const created = await persistMessage({
+      const [created, senderResult] = await Promise.all([
+        persistMessage({
+          conversationId: input.conversationId,
+          senderId,
+          content: validation.trimmed,
+        }),
+        db.select({ name: user.name }).from(user).where(eq(user.id, senderId)).limit(1),
+      ]);
+
+      // #152 — Notify recipient about new message
+      const recipientId = conv!.user1Id === senderId ? conv!.user2Id : conv!.user1Id;
+      const senderName = senderResult[0]?.name ?? "Your match";
+      domainEvents.emit("MessageSent", {
         conversationId: input.conversationId,
         senderId,
-        content: validation.trimmed,
+        recipientId,
+        senderName,
       });
 
       console.log(


### PR DESCRIPTION
## Summary
- Adds `MessageSent` domain event with `conversationId`, `senderId`, `recipientId`, `senderName` fields
- Emits `MessageSent` in `sendMessage` handler after `persistMessage` — sender name fetched from DB in parallel with message insert
- Adds `handleMessageSent` push handler — sends push to recipient tokens, silently skips if none registered
- 2 passing bun:test scenarios covering happy path and missing-token case

## Test plan
- [x] `notifications-message-sent.test.ts` — 2/2 pass
- [x] No new TypeScript errors in changed files

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)