### PR TITLE
feat(#155): deep-link notification tap to conversation view

### DIFF
--- a/apps/native/__tests__/notification-message-deep-link.test.tsx
+++ b/apps/native/__tests__/notification-message-deep-link.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * Tests for task #155 — Deep-link notification tap to the relevant conversation view
+ *
+ * Covers:
+ *   - Background/foreground tap with message_received navigates to /chat/:conversationId
+ *   - Cold-start tap navigates to /chat/:conversationId
+ *   - Malformed payload (missing conversationId) is silently ignored
+ */
+import { act, renderHook } from "@testing-library/react-native";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const mockPush = jest.fn();
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+let tapListener: ((response: unknown) => void) | null = null;
+const mockRemove = jest.fn();
+const mockGetLastNotificationResponseAsync = jest.fn();
+
+jest.mock("expo-notifications", () => ({
+  addNotificationResponseReceivedListener: jest.fn((cb) => {
+    tapListener = cb;
+    return { remove: mockRemove };
+  }),
+  getLastNotificationResponseAsync: (...args: unknown[]) =>
+    mockGetLastNotificationResponseAsync(...args),
+}));
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function makeNotificationResponse(data: Record<string, unknown>) {
+  return {
+    notification: {
+      request: {
+        content: { data },
+      },
+    },
+  };
+}
+
+// ── Import after mocks ─────────────────────────────────────────────────────────
+// eslint-disable-next-line import/first
+import { useNotificationTapHandler } from "../hooks/use-notification-tap-handler";
+
+beforeEach(() => {
+  tapListener = null;
+  mockPush.mockClear();
+  mockRemove.mockClear();
+  mockGetLastNotificationResponseAsync.mockResolvedValue(null);
+});
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("#155 — Notification tap deep-links to conversation view", () => {
+  it("navigates to /chat/:conversationId when message_received notification is tapped (background/foreground)", async () => {
+    renderHook(() => useNotificationTapHandler());
+
+    await act(async () => {
+      tapListener?.(
+        makeNotificationResponse({ type: "message_received", conversationId: "conv-123" }),
+      );
+    });
+
+    expect(mockPush).toHaveBeenCalledWith("/chat/conv-123");
+  });
+
+  it("navigates to /chat/:conversationId on cold-start tap", async () => {
+    mockGetLastNotificationResponseAsync.mockResolvedValue(
+      makeNotificationResponse({ type: "message_received", conversationId: "conv-cold" }),
+    );
+
+    renderHook(() => useNotificationTapHandler());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockPush).toHaveBeenCalledWith("/chat/conv-cold");
+  });
+
+  it("does not navigate when conversationId is missing from message_received payload", async () => {
+    renderHook(() => useNotificationTapHandler());
+
+    await act(async () => {
+      tapListener?.(makeNotificationResponse({ type: "message_received" }));
+    });
+
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+});

--- a/apps/native/hooks/use-notification-tap-handler.ts
+++ b/apps/native/hooks/use-notification-tap-handler.ts
@@ -25,6 +25,12 @@ export function useNotificationTapHandler() {
       return;
     }
 
+    if (type === "message_received") {
+      const conversationId = typeof data?.conversationId === "string" ? data.conversationId : undefined;
+      if (conversationId) router.push(`/chat/${conversationId}`);
+      return;
+    }
+
     const matchRequestId = typeof data?.matchRequestId === "string" ? data.matchRequestId : undefined;
     const requesterId = typeof data?.requesterId === "string" ? data.requesterId : undefined;
 


### PR DESCRIPTION
## Summary

- Add `message_received` branch in `useNotificationTapHandler` — extracts `conversationId` from payload and pushes to `/chat/:conversationId`
- Handles background/foreground tap, cold-start (`getLastNotificationResponseAsync`), and malformed payload (silently ignored)
- 3 new Jest tests covering all Gherkin scenarios

Closes #155

## Test plan

- [x] `notification-message-deep-link.test.tsx` — 3/3 passing
  - Background/foreground tap navigates to `/chat/:conversationId`
  - Cold-start tap navigates to `/chat/:conversationId`
  - Missing `conversationId` → no navigation, no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)