### PR TITLE
feat(#28): connected student receives notification when new message arrives

### DIFF
--- a/apps/native/__tests__/compose-ui.test.tsx
+++ b/apps/native/__tests__/compose-ui.test.tsx
@@ -24,6 +24,17 @@ let sendMessageCallbacks: { onSuccess?: () => void; onError?: (e: Error) => void
 
 jest.mock("@/utils/trpc", () => ({
   trpc: {
+    chat: {
+      getMessages: {
+        queryOptions: (_input: unknown, _opts: unknown) => ({
+          queryKey: ["chat.getMessages"],
+          queryFn: async () => ({ messages: [] }),
+        }),
+      },
+      markRead: {
+        mutationOptions: () => ({ mutationFn: jest.fn().mockResolvedValue({}) }),
+      },
+    },
     messaging: {
       sendMessage: {
         mutationOptions: (opts: { onSuccess?: () => void; onError?: (e: Error) => void }) => {
@@ -34,6 +45,9 @@ jest.mock("@/utils/trpc", () => ({
             onError: opts?.onError,
           };
         },
+      },
+      setPresence: {
+        mutationOptions: () => ({ mutationFn: jest.fn().mockResolvedValue({ ok: true }) }),
       },
     },
   },

--- a/apps/native/__tests__/conversation-history.test.tsx
+++ b/apps/native/__tests__/conversation-history.test.tsx
@@ -32,10 +32,14 @@ jest.mock("react-native", () => {
 
 // ── Router mock ───────────────────────────────────────────────────────────────
 
-jest.mock("expo-router", () => ({
-  useLocalSearchParams: () => ({ conversationId: "conv-1" }),
-  useRouter: () => ({ back: jest.fn() }),
-}));
+jest.mock("expo-router", () => {
+  const { useEffect } = require("react");
+  return {
+    useLocalSearchParams: () => ({ conversationId: "conv-1" }),
+    useRouter: () => ({ back: jest.fn() }),
+    useFocusEffect: (cb: () => void) => { useEffect(() => { cb(); }, []); }, // eslint-disable-line react-hooks/exhaustive-deps
+  };
+});
 
 // ── Auth mock ─────────────────────────────────────────────────────────────────
 
@@ -62,6 +66,9 @@ jest.mock("@/utils/trpc", () => ({
           queryFn: async () => ({ messages: mockMessages }),
         }),
       },
+      markRead: {
+        mutationOptions: () => ({ mutationFn: jest.fn().mockResolvedValue({}) }),
+      },
     },
     messaging: {
       sendMessage: {
@@ -70,6 +77,9 @@ jest.mock("@/utils/trpc", () => ({
           onSuccess: opts.onSuccess,
           onError: opts.onError,
         }),
+      },
+      setPresence: {
+        mutationOptions: () => ({ mutationFn: jest.fn().mockResolvedValue({ ok: true }) }),
       },
     },
   },

--- a/apps/native/__tests__/mark-messages-as-read.test.tsx
+++ b/apps/native/__tests__/mark-messages-as-read.test.tsx
@@ -84,6 +84,11 @@ jest.mock("@/utils/trpc", () => ({
           onError: opts.onError,
         }),
       },
+      setPresence: {
+        mutationOptions: () => ({
+          mutationFn: jest.fn().mockResolvedValue({ ok: true }),
+        }),
+      },
     },
   },
 }));

--- a/apps/native/__tests__/notification-message-deep-link.test.tsx
+++ b/apps/native/__tests__/notification-message-deep-link.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * Tests for task #155 — Deep-link notification tap to the relevant conversation view
+ *
+ * Covers:
+ *   - Background/foreground tap with message_received navigates to /chat/:conversationId
+ *   - Cold-start tap navigates to /chat/:conversationId
+ *   - Malformed payload (missing conversationId) is silently ignored
+ */
+import { act, renderHook } from "@testing-library/react-native";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const mockPush = jest.fn();
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+let tapListener: ((response: unknown) => void) | null = null;
+const mockRemove = jest.fn();
+const mockGetLastNotificationResponseAsync = jest.fn();
+
+jest.mock("expo-notifications", () => ({
+  addNotificationResponseReceivedListener: jest.fn((cb) => {
+    tapListener = cb;
+    return { remove: mockRemove };
+  }),
+  getLastNotificationResponseAsync: (...args: unknown[]) =>
+    mockGetLastNotificationResponseAsync(...args),
+}));
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function makeNotificationResponse(data: Record<string, unknown>) {
+  return {
+    notification: {
+      request: {
+        content: { data },
+      },
+    },
+  };
+}
+
+// ── Import after mocks ─────────────────────────────────────────────────────────
+// eslint-disable-next-line import/first
+import { useNotificationTapHandler } from "../hooks/use-notification-tap-handler";
+
+beforeEach(() => {
+  tapListener = null;
+  mockPush.mockClear();
+  mockRemove.mockClear();
+  mockGetLastNotificationResponseAsync.mockResolvedValue(null);
+});
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("#155 — Notification tap deep-links to conversation view", () => {
+  it("navigates to /chat/:conversationId when message_received notification is tapped (background/foreground)", async () => {
+    renderHook(() => useNotificationTapHandler());
+
+    await act(async () => {
+      tapListener?.(
+        makeNotificationResponse({ type: "message_received", conversationId: "conv-123" }),
+      );
+    });
+
+    expect(mockPush).toHaveBeenCalledWith("/chat/conv-123");
+  });
+
+  it("navigates to /chat/:conversationId on cold-start tap", async () => {
+    mockGetLastNotificationResponseAsync.mockResolvedValue(
+      makeNotificationResponse({ type: "message_received", conversationId: "conv-cold" }),
+    );
+
+    renderHook(() => useNotificationTapHandler());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockPush).toHaveBeenCalledWith("/chat/conv-cold");
+  });
+
+  it("does not navigate when conversationId is missing from message_received payload", async () => {
+    renderHook(() => useNotificationTapHandler());
+
+    await act(async () => {
+      tapListener?.(makeNotificationResponse({ type: "message_received" }));
+    });
+
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+});

--- a/apps/native/__tests__/push-suppression-presence.test.tsx
+++ b/apps/native/__tests__/push-suppression-presence.test.tsx
@@ -1,12 +1,14 @@
 /**
- * Tests for task #150 — Handle empty conversation state
+ * Tests for task #153 — Suppress push notification when recipient is actively viewing
+ * (client-side: presence signals sent to server on screen focus/blur)
  *
  * Covers:
- *   - Empty state shown when conversation has no messages
- *   - Empty state disappears once messages are returned
+ *   - setPresence(active: true) called when conversation screen gets focus
+ *   - setPresence(active: false) called when screen loses focus (cleanup)
+ *   - setPresence(active: false) called when app moves to background
  */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor } from "@testing-library/react-native";
+import { render, waitFor } from "@testing-library/react-native";
 import React from "react";
 
 // ── FlatList mock ─────────────────────────────────────────────────────────────
@@ -34,12 +36,21 @@ jest.mock("react-native", () => {
 
 // ── Router mock ───────────────────────────────────────────────────────────────
 
+type CleanupFn = () => void;
+let capturedCleanup: CleanupFn | null = null;
+
 jest.mock("expo-router", () => {
   const { useEffect } = require("react");
   return {
     useLocalSearchParams: () => ({ conversationId: "conv-1" }),
     useRouter: () => ({ back: jest.fn() }),
-    useFocusEffect: (cb: () => void) => { useEffect(() => { cb(); }, []); }, // eslint-disable-line react-hooks/exhaustive-deps
+    useFocusEffect: (cb: () => CleanupFn | void) => {
+      useEffect(() => {
+        const cleanup = cb();
+        if (typeof cleanup === "function") capturedCleanup = cleanup;
+        return cleanup ?? undefined;
+      }, []); // eslint-disable-line react-hooks/exhaustive-deps
+    },
   };
 });
 
@@ -51,19 +62,24 @@ jest.mock("@/lib/auth-client", () => ({
   },
 }));
 
-// ── tRPC mock — empty conversation ────────────────────────────────────────────
+// ── tRPC mock ─────────────────────────────────────────────────────────────────
+
+const mockSetPresence = jest.fn().mockResolvedValue({ ok: true });
+const mockMarkRead = jest.fn().mockResolvedValue({ lastReadAt: new Date() });
 
 jest.mock("@/utils/trpc", () => ({
   trpc: {
     chat: {
       getMessages: {
         queryOptions: (_input: unknown, _opts: unknown) => ({
-          queryKey: ["chat.getMessages", "conv-1-empty"],
+          queryKey: ["chat.getMessages", "conv-1"],
           queryFn: async () => ({ messages: [] }),
         }),
       },
       markRead: {
-        mutationOptions: () => ({ mutationFn: jest.fn().mockResolvedValue({}) }),
+        mutationOptions: () => ({
+          mutationFn: mockMarkRead,
+        }),
       },
     },
     messaging: {
@@ -75,7 +91,9 @@ jest.mock("@/utils/trpc", () => ({
         }),
       },
       setPresence: {
-        mutationOptions: () => ({ mutationFn: jest.fn().mockResolvedValue({ ok: true }) }),
+        mutationOptions: () => ({
+          mutationFn: mockSetPresence,
+        }),
       },
     },
   },
@@ -90,19 +108,40 @@ function Wrapper({ children }: { children: React.ReactNode }) {
   return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
 }
 
-describe("#150 — Empty conversation state", () => {
-  it("shows empty state when conversation has no messages", async () => {
+beforeEach(() => {
+  mockSetPresence.mockClear();
+  mockMarkRead.mockClear();
+  capturedCleanup = null;
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("#153 — Presence signals from conversation screen", () => {
+  it("calls setPresence(active: true) when conversation screen gets focus", async () => {
     render(<ChatScreen />, { wrapper: Wrapper });
+
     await waitFor(() => {
-      expect(screen.getByTestId("empty-conversation-state")).toBeTruthy();
+      expect(mockSetPresence).toHaveBeenCalledWith(
+        { conversationId: "conv-1", active: true },
+        expect.anything(),
+      );
     });
   });
 
-  it("does not show any message bubbles in an empty conversation", async () => {
+  it("calls setPresence(active: false) when screen loses focus", async () => {
     render(<ChatScreen />, { wrapper: Wrapper });
+
+    // Wait for initial focus
+    await waitFor(() => expect(mockSetPresence).toHaveBeenCalled());
+
+    // Simulate cleanup (blur/unmount)
+    if (capturedCleanup) capturedCleanup();
+
     await waitFor(() => {
-      expect(screen.getByTestId("empty-conversation-state")).toBeTruthy();
+      expect(mockSetPresence).toHaveBeenCalledWith(
+        { conversationId: "conv-1", active: false },
+        expect.anything(),
+      );
     });
-    expect(screen.queryAllByTestId("message-bubble")).toHaveLength(0);
   });
 });

--- a/apps/native/__tests__/read-unread-indicators.test.tsx
+++ b/apps/native/__tests__/read-unread-indicators.test.tsx
@@ -31,10 +31,14 @@ jest.mock("react-native", () => {
 
 // ── Router mock ───────────────────────────────────────────────────────────────
 
-jest.mock("expo-router", () => ({
-  useLocalSearchParams: () => ({ conversationId: "conv-1" }),
-  useRouter: () => ({ back: jest.fn() }),
-}));
+jest.mock("expo-router", () => {
+  const { useEffect } = require("react");
+  return {
+    useLocalSearchParams: () => ({ conversationId: "conv-1" }),
+    useRouter: () => ({ back: jest.fn() }),
+    useFocusEffect: (cb: () => void) => { useEffect(() => { cb(); }, []); }, // eslint-disable-line react-hooks/exhaustive-deps
+  };
+});
 
 // ── Auth mock ─────────────────────────────────────────────────────────────────
 
@@ -61,6 +65,9 @@ jest.mock("@/utils/trpc", () => ({
           }),
         }),
       },
+      markRead: {
+        mutationOptions: () => ({ mutationFn: jest.fn().mockResolvedValue({}) }),
+      },
     },
     messaging: {
       sendMessage: {
@@ -69,6 +76,9 @@ jest.mock("@/utils/trpc", () => ({
           onSuccess: opts.onSuccess,
           onError: opts.onError,
         }),
+      },
+      setPresence: {
+        mutationOptions: () => ({ mutationFn: jest.fn().mockResolvedValue({ ok: true }) }),
       },
     },
   },

--- a/apps/native/app/chat/[conversationId].tsx
+++ b/apps/native/app/chat/[conversationId].tsx
@@ -2,7 +2,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useLocalSearchParams } from "expo-router";
 import { useFocusEffect } from "expo-router";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { FlatList, Text, TextInput, TouchableOpacity, View } from "react-native";
+import { AppState, FlatList, Text, TextInput, TouchableOpacity, View } from "react-native";
 
 import { authClient } from "@/lib/auth-client";
 import { Container } from "@/components/container";
@@ -28,6 +28,10 @@ export default function ChatScreen() {
     trpc.chat.markRead.mutationOptions(),
   );
 
+  const setPresence = useMutation(
+    trpc.messaging.setPresence.mutationOptions(),
+  );
+
   useFocusEffect(
     useCallback(() => {
       markRead.mutate(
@@ -39,6 +43,22 @@ export default function ChatScreen() {
           },
         },
       );
+
+      // #153 — Signal active presence so push notifications are suppressed while viewing
+      setPresence.mutate({ conversationId, active: true });
+
+      const appStateSub = AppState.addEventListener("change", (nextState) => {
+        if (nextState === "background" || nextState === "inactive") {
+          setPresence.mutate({ conversationId, active: false });
+        } else if (nextState === "active") {
+          setPresence.mutate({ conversationId, active: true });
+        }
+      });
+
+      return () => {
+        setPresence.mutate({ conversationId, active: false });
+        appStateSub.remove();
+      };
     }, [conversationId]),
   );
 

--- a/apps/native/hooks/use-notification-tap-handler.ts
+++ b/apps/native/hooks/use-notification-tap-handler.ts
@@ -25,6 +25,12 @@ export function useNotificationTapHandler() {
       return;
     }
 
+    if (type === "message_received") {
+      const conversationId = typeof data?.conversationId === "string" ? data.conversationId : undefined;
+      if (conversationId) router.push(`/chat/${conversationId}`);
+      return;
+    }
+
     const matchRequestId = typeof data?.matchRequestId === "string" ? data.matchRequestId : undefined;
     const requesterId = typeof data?.requesterId === "string" ? data.requesterId : undefined;
 

--- a/apps/server/src/__tests__/notifications-message-sent-suppression.test.ts
+++ b/apps/server/src/__tests__/notifications-message-sent-suppression.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Tests for task #153 — Suppress push notification when recipient is actively viewing
+ *
+ * Covers:
+ *   - No push sent when recipient has an active (non-stale) presence record
+ *   - Push sent when recipient is not viewing (no presence record)
+ *   - Push sent when presence record is stale (activeUntil in the past)
+ */
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+// ── Fetch mock ────────────────────────────────────────────────────────────────
+
+interface CapturedFetchCall {
+  url: string;
+  messages: Array<{ to: string; title?: string; body?: string; data?: Record<string, unknown> }>;
+}
+
+const fetchCalls: CapturedFetchCall[] = [];
+
+(global as unknown as { fetch: unknown }).fetch = mock(async (url: string, options: RequestInit) => {
+  fetchCalls.push({
+    url,
+    messages: JSON.parse(options.body as string) as CapturedFetchCall["messages"],
+  });
+  return {
+    json: async () => ({ data: [{ status: "ok", id: "ticket-1" }] }),
+  };
+});
+
+// ── Schema mocks ──────────────────────────────────────────────────────────────
+
+const DEVICE_TOKEN_TABLE = "userDeviceToken";
+const PRESENCE_TABLE = "conversationPresence";
+
+mock.module("@sip-and-speak/db/schema/sip-and-speak", () => ({
+  userDeviceToken: DEVICE_TOKEN_TABLE,
+  conversationPresence: PRESENCE_TABLE,
+  userLanguage: "userLanguage",
+}));
+
+mock.module("@sip-and-speak/db/schema/auth", () => ({
+  user: "user",
+}));
+
+// ── drizzle-orm mock ──────────────────────────────────────────────────────────
+
+mock.module("drizzle-orm", () => ({
+  eq: (_col: unknown, val: unknown) => ({ _col: _col, _val: val }),
+  and: (...args: unknown[]) => ({ _and: args }),
+}));
+
+// ── DB mock ───────────────────────────────────────────────────────────────────
+
+const RECIPIENT_ID = "recipient-id";
+const SENDER_ID = "sender-id";
+const CONVERSATION_ID = "conv-1";
+
+const RECIPIENT_TOKEN = [{ id: "tok-1", token: "ExponentPushToken[recipient]" }];
+
+// Presence record control — null means no record
+let mockPresence: { activeUntil: Date } | null = null;
+
+mock.module("@sip-and-speak/db", () => ({
+  db: {
+    select: (fields: Record<string, unknown>) => {
+      const isPresenceQuery = "activeUntil" in fields;
+      return {
+        from: (_table: unknown) => ({
+          where: (_clause: unknown) => {
+            if (isPresenceQuery) {
+              return {
+                limit: (_n: number) => Promise.resolve(mockPresence ? [mockPresence] : []),
+              };
+            }
+            // Token query — always return recipient token for simplicity
+            return Promise.resolve(RECIPIENT_TOKEN);
+          },
+        }),
+      };
+    },
+    delete: (_table: unknown) => ({
+      where: (_clause: unknown) => Promise.resolve([]),
+    }),
+  },
+}));
+
+// ── Domain events mock ────────────────────────────────────────────────────────
+
+mock.module("@sip-and-speak/api/domain-events", () => ({
+  domainEvents: { on: mock((_evt: string, _fn: unknown) => undefined), emit: mock(() => undefined) },
+}));
+
+// ── Import under test (after mocks) ──────────────────────────────────────────
+
+// eslint-disable-next-line import/first
+import { handleMessageSent } from "../notifications";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeEvent() {
+  return {
+    conversationId: CONVERSATION_ID,
+    senderId: SENDER_ID,
+    recipientId: RECIPIENT_ID,
+    senderName: "Alice",
+  };
+}
+
+beforeEach(() => {
+  fetchCalls.length = 0;
+  mockPresence = null;
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("#153 — Suppress push when recipient is actively viewing", () => {
+  it("suppresses push when recipient has an active presence record", async () => {
+    mockPresence = { activeUntil: new Date(Date.now() + 30_000) };
+
+    await handleMessageSent(makeEvent());
+
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  it("sends push when recipient is not viewing (no presence record)", async () => {
+    mockPresence = null;
+
+    await handleMessageSent(makeEvent());
+
+    expect(fetchCalls).toHaveLength(1);
+  });
+
+  it("sends push when recipient presence record is stale (activeUntil in past)", async () => {
+    mockPresence = { activeUntil: new Date(Date.now() - 1_000) };
+
+    await handleMessageSent(makeEvent());
+
+    expect(fetchCalls).toHaveLength(1);
+  });
+});

--- a/apps/server/src/__tests__/notifications-message-sent.test.ts
+++ b/apps/server/src/__tests__/notifications-message-sent.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for task #152 — Send push notification to recipient when a new message arrives
+ *
+ * Covers:
+ *   - Recipient receives a push identifying the sender (no message content)
+ *   - No push sent when recipient has no registered device token
+ */
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+// ── Fetch mock ────────────────────────────────────────────────────────────────
+
+interface CapturedFetchCall {
+  url: string;
+  messages: Array<{ to: string; title?: string; body?: string; data?: Record<string, unknown> }>;
+}
+
+const fetchCalls: CapturedFetchCall[] = [];
+
+(global as unknown as { fetch: unknown }).fetch = mock(async (url: string, options: RequestInit) => {
+  fetchCalls.push({
+    url,
+    messages: JSON.parse(options.body as string) as CapturedFetchCall["messages"],
+  });
+  return {
+    json: async () => ({ data: [{ status: "ok", id: "ticket-1" }] }),
+  };
+});
+
+// ── Schema mocks ──────────────────────────────────────────────────────────────
+
+const DEVICE_TOKEN_TABLE = "userDeviceToken";
+
+mock.module("@sip-and-speak/db/schema/sip-and-speak", () => ({
+  userDeviceToken: DEVICE_TOKEN_TABLE,
+  userLanguage: "userLanguage",
+}));
+
+mock.module("@sip-and-speak/db/schema/auth", () => ({
+  user: "user",
+}));
+
+// ── drizzle-orm mock ──────────────────────────────────────────────────────────
+
+mock.module("drizzle-orm", () => ({
+  eq: (_col: unknown, val: unknown) => ({ _val: val }),
+}));
+
+// ── DB mock ───────────────────────────────────────────────────────────────────
+
+const SENDER_ID = "sender-id";
+const RECIPIENT_ID = "recipient-id";
+
+let mockRecipientTokens: Array<{ id: string; token: string }> = [];
+
+mock.module("@sip-and-speak/db", () => ({
+  db: {
+    select: (_fields: Record<string, unknown>) => ({
+      from: (_table: unknown) => ({
+        where: (clause: { _val: string }) => {
+          const rows = clause._val === RECIPIENT_ID ? mockRecipientTokens : [];
+          return Promise.resolve(rows);
+        },
+      }),
+    }),
+    delete: (_table: unknown) => ({
+      where: (_clause: unknown) => Promise.resolve([]),
+    }),
+  },
+}));
+
+// ── Domain events mock ────────────────────────────────────────────────────────
+
+mock.module("@sip-and-speak/api/domain-events", () => ({
+  domainEvents: { on: mock((_evt: string, _fn: unknown) => undefined), emit: mock(() => undefined) },
+}));
+
+// ── Import under test (after mocks) ──────────────────────────────────────────
+
+// eslint-disable-next-line import/first
+import { handleMessageSent } from "../notifications";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeMessageSentEvent(
+  overrides: Partial<{
+    conversationId: string;
+    senderId: string;
+    recipientId: string;
+    senderName: string;
+  }> = {},
+) {
+  return {
+    conversationId: overrides.conversationId ?? "conv-1",
+    senderId: overrides.senderId ?? SENDER_ID,
+    recipientId: overrides.recipientId ?? RECIPIENT_ID,
+    senderName: overrides.senderName ?? "Alice",
+  };
+}
+
+beforeEach(() => {
+  fetchCalls.length = 0;
+  mockRecipientTokens = [];
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("#152 — Send push notification to recipient when a new message arrives", () => {
+  it("sends a push to the recipient identifying the sender without message content", async () => {
+    mockRecipientTokens = [{ id: "tok-1", token: "ExponentPushToken[recipient]" }];
+
+    await handleMessageSent(makeMessageSentEvent());
+
+    expect(fetchCalls).toHaveLength(1);
+
+    const call = fetchCalls[0];
+    if (!call) throw new Error("Expected a fetch call");
+
+    expect(call.messages).toHaveLength(1);
+    const msg = call.messages[0];
+    if (!msg) throw new Error("Expected a message");
+
+    expect(msg.to).toBe("ExponentPushToken[recipient]");
+    expect(msg.title).toContain("Alice");
+    expect(msg.body).toBeUndefined();
+    expect(msg.data?.type).toBe("message_received");
+    expect(msg.data?.conversationId).toBe("conv-1");
+    expect(msg.data?.senderId).toBe(SENDER_ID);
+  });
+
+  it("sends no notification when recipient has no registered device token", async () => {
+    mockRecipientTokens = [];
+
+    await handleMessageSent(makeMessageSentEvent());
+
+    expect(fetchCalls).toHaveLength(0);
+  });
+});

--- a/apps/server/src/__tests__/notifications-message-sent.test.ts
+++ b/apps/server/src/__tests__/notifications-message-sent.test.ts
@@ -1,9 +1,13 @@
 /**
  * Tests for task #152 — Send push notification to recipient when a new message arrives
+ * Tests for task #156 — Handle gracefully when recipient has not granted push permissions
+ * Tests for task #154 — Include match identity in notification payload without message content
  *
  * Covers:
  *   - Recipient receives a push identifying the sender (no message content)
  *   - No push sent when recipient has no registered device token
+ *   - DeviceNotRegistered receipt error is handled gracefully (stale token removed)
+ *   - Notification payload shape: title = sender name, body = generic, conversationId in data
  */
 import { describe, it, expect, mock, beforeEach } from "bun:test";
 
@@ -15,6 +19,9 @@ interface CapturedFetchCall {
 }
 
 const fetchCalls: CapturedFetchCall[] = [];
+let mockFetchTickets: Array<{ status: string; id?: string; details?: { error?: string } }> = [
+  { status: "ok", id: "ticket-1" },
+];
 
 (global as unknown as { fetch: unknown }).fetch = mock(async (url: string, options: RequestInit) => {
   fetchCalls.push({
@@ -22,7 +29,7 @@ const fetchCalls: CapturedFetchCall[] = [];
     messages: JSON.parse(options.body as string) as CapturedFetchCall["messages"],
   });
   return {
-    json: async () => ({ data: [{ status: "ok", id: "ticket-1" }] }),
+    json: async () => ({ data: mockFetchTickets }),
   };
 });
 
@@ -51,6 +58,7 @@ const SENDER_ID = "sender-id";
 const RECIPIENT_ID = "recipient-id";
 
 let mockRecipientTokens: Array<{ id: string; token: string }> = [];
+const deletedTokenIds: string[] = [];
 
 mock.module("@sip-and-speak/db", () => ({
   db: {
@@ -63,7 +71,10 @@ mock.module("@sip-and-speak/db", () => ({
       }),
     }),
     delete: (_table: unknown) => ({
-      where: (_clause: unknown) => Promise.resolve([]),
+      where: (clause: { _val: string }) => {
+        deletedTokenIds.push(clause._val);
+        return Promise.resolve([]);
+      },
     }),
   },
 }));
@@ -99,7 +110,9 @@ function makeMessageSentEvent(
 
 beforeEach(() => {
   fetchCalls.length = 0;
+  deletedTokenIds.length = 0;
   mockRecipientTokens = [];
+  mockFetchTickets = [{ status: "ok", id: "ticket-1" }];
 });
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -121,7 +134,6 @@ describe("#152 — Send push notification to recipient when a new message arrive
 
     expect(msg.to).toBe("ExponentPushToken[recipient]");
     expect(msg.title).toContain("Alice");
-    expect(msg.body).toBeUndefined();
     expect(msg.data?.type).toBe("message_received");
     expect(msg.data?.conversationId).toBe("conv-1");
     expect(msg.data?.senderId).toBe(SENDER_ID);
@@ -132,6 +144,54 @@ describe("#152 — Send push notification to recipient when a new message arrive
 
     await handleMessageSent(makeMessageSentEvent());
 
+    expect(fetchCalls).toHaveLength(0);
+  });
+});
+
+describe("#154 — Notification payload includes sender identity but not message content", () => {
+  it("sets title to sender display name and body to a generic string", async () => {
+    mockRecipientTokens = [{ id: "tok-1", token: "ExponentPushToken[recipient]" }];
+
+    await handleMessageSent(makeMessageSentEvent({ senderName: "Bob" }));
+
+    const msg = fetchCalls[0]?.messages[0];
+    if (!msg) throw new Error("Expected a message");
+
+    expect(msg.title).toContain("Bob");
+    // Body must never expose message content
+    expect(String(msg.body ?? "")).not.toContain("Let's meet again");
+  });
+
+  it("payload contains conversationId for deep-linking", async () => {
+    mockRecipientTokens = [{ id: "tok-1", token: "ExponentPushToken[recipient]" }];
+
+    await handleMessageSent(makeMessageSentEvent({ conversationId: "conv-deep-link" }));
+
+    const msg = fetchCalls[0]?.messages[0];
+    if (!msg) throw new Error("Expected a message");
+
+    expect(msg.data?.conversationId).toBe("conv-deep-link");
+  });
+});
+
+describe("#156 — Handle gracefully when recipient has not granted push permissions", () => {
+  it("removes stale token and does not throw when Expo returns DeviceNotRegistered", async () => {
+    mockRecipientTokens = [{ id: "stale-tok-id", token: "ExponentPushToken[stale]" }];
+    mockFetchTickets = [{ status: "error", details: { error: "DeviceNotRegistered" } }];
+
+    await expect(handleMessageSent(makeMessageSentEvent())).resolves.toBeUndefined();
+
+    expect(deletedTokenIds).toContain("stale-tok-id");
+  });
+
+  it("still resolves when fetch returns DeviceNotRegistered for all tokens", async () => {
+    mockRecipientTokens = [{ id: "tok-bad", token: "ExponentPushToken[bad]" }];
+    mockFetchTickets = [{ status: "error", details: { error: "DeviceNotRegistered" } }];
+
+    // Second call — token already removed, no tokens left, so no push attempt
+    mockRecipientTokens = [];
+
+    await expect(handleMessageSent(makeMessageSentEvent())).resolves.toBeUndefined();
     expect(fetchCalls).toHaveLength(0);
   });
 });

--- a/apps/server/src/__tests__/notifications-message-sent.test.ts
+++ b/apps/server/src/__tests__/notifications-message-sent.test.ts
@@ -120,8 +120,9 @@ describe("#152 — Send push notification to recipient when a new message arrive
     if (!msg) throw new Error("Expected a message");
 
     expect(msg.to).toBe("ExponentPushToken[recipient]");
-    expect(msg.title).toContain("Alice");
-    expect(msg.body).toBeUndefined();
+    // #154 — title is sender's display name; body is generic (no message content)
+    expect(msg.title).toBe("Alice");
+    expect(msg.body).toBe("sent you a message");
     expect(msg.data?.type).toBe("message_received");
     expect(msg.data?.conversationId).toBe("conv-1");
     expect(msg.data?.senderId).toBe(SENDER_ID);
@@ -133,5 +134,30 @@ describe("#152 — Send push notification to recipient when a new message arrive
     await handleMessageSent(makeMessageSentEvent());
 
     expect(fetchCalls).toHaveLength(0);
+  });
+});
+
+describe("#154 — Notification payload includes sender identity but not message content", () => {
+  it("sets title to sender display name and body to a generic string", async () => {
+    mockRecipientTokens = [{ id: "tok-1", token: "ExponentPushToken[recipient]" }];
+
+    await handleMessageSent(makeMessageSentEvent({ senderName: "Bob" }));
+
+    const msg = fetchCalls[0]?.messages[0];
+    if (!msg) throw new Error("Expected a message");
+
+    expect(msg.title).toBe("Bob");
+    expect(msg.body).toBe("sent you a message");
+  });
+
+  it("payload contains conversationId for deep-linking", async () => {
+    mockRecipientTokens = [{ id: "tok-1", token: "ExponentPushToken[recipient]" }];
+
+    await handleMessageSent(makeMessageSentEvent({ conversationId: "conv-deep-link" }));
+
+    const msg = fetchCalls[0]?.messages[0];
+    if (!msg) throw new Error("Expected a message");
+
+    expect(msg.data?.conversationId).toBe("conv-deep-link");
   });
 });

--- a/apps/server/src/notifications.ts
+++ b/apps/server/src/notifications.ts
@@ -708,8 +708,8 @@ export async function handleMessageSent(event: MessageSentEvent): Promise<void> 
 
   const messages: ExpoPushMessage[] = tokens.map(({ token }) => ({
     to: token,
-    title: `${senderName} sent you a message`,
-    body: undefined,
+    title: senderName,
+    body: "sent you a message",
     data: { conversationId, senderId, type: "message_received" },
   }));
 

--- a/apps/server/src/notifications.ts
+++ b/apps/server/src/notifications.ts
@@ -4,9 +4,9 @@
  * Wires domain events to Expo Push API calls.
  * Fire-and-forget: errors are logged but never thrown to callers.
  */
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { db } from "@sip-and-speak/db";
-import { userDeviceToken, userLanguage } from "@sip-and-speak/db/schema/sip-and-speak";
+import { userDeviceToken, userLanguage, conversationPresence } from "@sip-and-speak/db/schema/sip-and-speak";
 import { user } from "@sip-and-speak/db/schema/auth";
 import { domainEvents, type MatchRequestSentEvent, type MatchRequestAcceptedEvent, type MatchRequestDeclinedEvent, type MeetupProposedEvent, type MeetupConfirmedEvent, type MeetupCounterProposedEvent, type MeetupDeclinedEvent, type MeetupCancelledEvent, type MeetupRescheduleProposedEvent, type MeetupRescheduledEvent, type MeetupRescheduleDeclinedEvent, type SipAndSpeakMomentCompletedEvent, type MeetupNotAttendedEvent, type MessagingOptInPromptedEvent, type MessagingNudgeNeededEvent, type ConversationOpenedEvent, type MessagingDeclineOutcomeEvent, type MessageSentEvent } from "@sip-and-speak/api/domain-events";
 import { buildMatchRequestNotificationBody } from "@sip-and-speak/api/routers/matching-utils";
@@ -692,6 +692,26 @@ export async function handleMessagingDeclineOutcome(event: MessagingDeclineOutco
 // #152 — Notify recipient when a new message arrives
 export async function handleMessageSent(event: MessageSentEvent): Promise<void> {
   const { conversationId, senderId, recipientId, senderName } = event;
+
+  // #153 — Suppress push if recipient is actively viewing this conversation
+  const [presence] = await db
+    .select({ activeUntil: conversationPresence.activeUntil })
+    .from(conversationPresence)
+    .where(
+      and(
+        eq(conversationPresence.studentId, recipientId),
+        eq(conversationPresence.conversationId, conversationId),
+      ),
+    )
+    .limit(1);
+
+  if (presence && presence.activeUntil > new Date()) {
+    console.info("[push] Recipient is actively viewing — suppressing push", {
+      conversationId,
+      recipientId,
+    });
+    return;
+  }
 
   const tokens = await db
     .select({ id: userDeviceToken.id, token: userDeviceToken.token })

--- a/apps/server/src/notifications.ts
+++ b/apps/server/src/notifications.ts
@@ -8,7 +8,7 @@ import { eq } from "drizzle-orm";
 import { db } from "@sip-and-speak/db";
 import { userDeviceToken, userLanguage } from "@sip-and-speak/db/schema/sip-and-speak";
 import { user } from "@sip-and-speak/db/schema/auth";
-import { domainEvents, type MatchRequestSentEvent, type MatchRequestAcceptedEvent, type MatchRequestDeclinedEvent, type MeetupProposedEvent, type MeetupConfirmedEvent, type MeetupCounterProposedEvent, type MeetupDeclinedEvent, type MeetupCancelledEvent, type MeetupRescheduleProposedEvent, type MeetupRescheduledEvent, type MeetupRescheduleDeclinedEvent, type SipAndSpeakMomentCompletedEvent, type MeetupNotAttendedEvent, type MessagingOptInPromptedEvent, type MessagingNudgeNeededEvent, type ConversationOpenedEvent, type MessagingDeclineOutcomeEvent } from "@sip-and-speak/api/domain-events";
+import { domainEvents, type MatchRequestSentEvent, type MatchRequestAcceptedEvent, type MatchRequestDeclinedEvent, type MeetupProposedEvent, type MeetupConfirmedEvent, type MeetupCounterProposedEvent, type MeetupDeclinedEvent, type MeetupCancelledEvent, type MeetupRescheduleProposedEvent, type MeetupRescheduledEvent, type MeetupRescheduleDeclinedEvent, type SipAndSpeakMomentCompletedEvent, type MeetupNotAttendedEvent, type MessagingOptInPromptedEvent, type MessagingNudgeNeededEvent, type ConversationOpenedEvent, type MessagingDeclineOutcomeEvent, type MessageSentEvent } from "@sip-and-speak/api/domain-events";
 import { buildMatchRequestNotificationBody } from "@sip-and-speak/api/routers/matching-utils";
 
 const EXPO_PUSH_URL = "https://exp.host/--/api/v2/push/send";
@@ -388,6 +388,9 @@ export function registerNotificationHandlers(): void {
   domainEvents.on("MessagingDeclineOutcome", (event) => {
     void handleMessagingDeclineOutcome(event);
   });
+  domainEvents.on("MessageSent", (event) => {
+    void handleMessageSent(event);
+  });
 }
 
 // #91 — Notify both Students when a reschedule is accepted and meetup details are updated
@@ -683,6 +686,64 @@ export async function handleMessagingDeclineOutcome(event: MessagingDeclineOutco
     await sendExpoPushNotification(messages);
   } catch (err) {
     console.error("[push] Failed to send MessagingDeclineOutcome notification", { meetupId, err });
+  }
+}
+
+// #152 — Notify recipient when a new message arrives
+export async function handleMessageSent(event: MessageSentEvent): Promise<void> {
+  const { conversationId, senderId, recipientId, senderName } = event;
+
+  const tokens = await db
+    .select({ id: userDeviceToken.id, token: userDeviceToken.token })
+    .from(userDeviceToken)
+    .where(eq(userDeviceToken.userId, recipientId));
+
+  if (tokens.length === 0) {
+    console.info("[push] No device token for recipient — skipping new message notification", {
+      conversationId,
+      recipientId,
+    });
+    return;
+  }
+
+  const messages: ExpoPushMessage[] = tokens.map(({ token }) => ({
+    to: token,
+    title: `${senderName} sent you a message`,
+    body: undefined,
+    data: { conversationId, senderId, type: "message_received" },
+  }));
+
+  console.info("[push] Sending MessageSent notification", {
+    conversationId,
+    recipientId,
+    tokenCount: messages.length,
+  });
+
+  try {
+    const tickets = await sendExpoPushNotification(messages);
+
+    const staleTokenIds: string[] = [];
+    for (let i = 0; i < tickets.length; i++) {
+      const ticket = tickets[i];
+      if (ticket?.status === "error" && ticket.details?.error === "DeviceNotRegistered") {
+        const staleId = tokens[i]?.id;
+        if (staleId) staleTokenIds.push(staleId);
+      }
+    }
+
+    if (staleTokenIds.length > 0) {
+      await Promise.all(
+        staleTokenIds.map((id) => db.delete(userDeviceToken).where(eq(userDeviceToken.id, id))),
+      );
+      console.info("[push] Removed stale device tokens", { staleTokenIds });
+    }
+
+    console.info("[push] MessageSent notification delivery complete", {
+      conversationId,
+      tickets: tickets.map((t) => ({ status: t.status, id: t.id })),
+    });
+  } catch (err) {
+    console.error("[push] Failed to send MessageSent notification", { conversationId, err });
   }
 }
 

--- a/packages/api/src/domain-events.ts
+++ b/packages/api/src/domain-events.ts
@@ -180,6 +180,13 @@ export interface MessagingNudgeNeededEvent {
   pendingStudentId: string;
 }
 
+export interface MessageSentEvent {
+  conversationId: string;
+  senderId: string;
+  recipientId: string;
+  senderName: string;
+}
+
 type DomainEventMap = {
   LanguageProfileUpdated: [LanguageProfileUpdatedEvent];
   InterestProfileUpdated: [InterestProfileUpdatedEvent];
@@ -204,6 +211,7 @@ type DomainEventMap = {
   MessagingNudgeNeeded: [MessagingNudgeNeededEvent];
   ConversationOpened: [ConversationOpenedEvent];
   MessagingDeclineOutcome: [MessagingDeclineOutcomeEvent];
+  MessageSent: [MessageSentEvent];
 };
 
 class TypedEventEmitter extends EventEmitter {

--- a/packages/api/src/routers/messaging.ts
+++ b/packages/api/src/routers/messaging.ts
@@ -6,6 +6,7 @@ import { protectedProcedure, router } from "../index";
 import { domainEvents } from "../domain-events";
 import { db } from "@sip-and-speak/db";
 import { meetup, messagingOptIn, conversation } from "@sip-and-speak/db/schema/sip-and-speak";
+import { user } from "@sip-and-speak/db/schema/auth";
 import { hasAlreadyResponded, getPartnerId, shouldSendNudge, bothAccepted, isDeclineOutcome, validateMessageContent, checkConversationAccess } from "./messaging-utils";
 import { persistMessage } from "./messaging-persist";
 
@@ -233,10 +234,23 @@ export const messagingRouter = router({
       }
 
       // #145 — Persist and return the created message
-      const created = await persistMessage({
+      const [created, senderResult] = await Promise.all([
+        persistMessage({
+          conversationId: input.conversationId,
+          senderId,
+          content: validation.trimmed,
+        }),
+        db.select({ name: user.name }).from(user).where(eq(user.id, senderId)).limit(1),
+      ]);
+
+      // #152 — Notify recipient about new message
+      const recipientId = conv!.user1Id === senderId ? conv!.user2Id : conv!.user1Id;
+      const senderName = senderResult[0]?.name ?? "Your match";
+      domainEvents.emit("MessageSent", {
         conversationId: input.conversationId,
         senderId,
-        content: validation.trimmed,
+        recipientId,
+        senderName,
       });
 
       console.log(

--- a/packages/api/src/routers/messaging.ts
+++ b/packages/api/src/routers/messaging.ts
@@ -5,7 +5,7 @@ import { and, eq, isNull } from "drizzle-orm";
 import { protectedProcedure, router } from "../index";
 import { domainEvents } from "../domain-events";
 import { db } from "@sip-and-speak/db";
-import { meetup, messagingOptIn, conversation } from "@sip-and-speak/db/schema/sip-and-speak";
+import { meetup, messagingOptIn, conversation, conversationPresence } from "@sip-and-speak/db/schema/sip-and-speak";
 import { user } from "@sip-and-speak/db/schema/auth";
 import { hasAlreadyResponded, getPartnerId, shouldSendNudge, bothAccepted, isDeclineOutcome, validateMessageContent, checkConversationAccess } from "./messaging-utils";
 import { persistMessage } from "./messaging-persist";
@@ -258,5 +258,51 @@ export const messagingRouter = router({
       );
 
       return created;
+    }),
+
+  /**
+   * #153 — Record whether the current Student is actively viewing a conversation.
+   * Active: upserts a presence record with a 30-second TTL.
+   * Inactive: sets activeUntil to epoch (immediately stale) so push resumes.
+   */
+  setPresence: protectedProcedure
+    .input(
+      z.object({
+        conversationId: z.string(),
+        active: z.boolean(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const studentId = ctx.session.user.id;
+      const PRESENCE_TTL_MS = 30_000;
+
+      if (input.active) {
+        const activeUntil = new Date(Date.now() + PRESENCE_TTL_MS);
+        await db
+          .insert(conversationPresence)
+          .values({ studentId, conversationId: input.conversationId, activeUntil })
+          .onConflictDoUpdate({
+            target: [conversationPresence.studentId, conversationPresence.conversationId],
+            set: { activeUntil },
+          });
+        console.log(
+          `[messaging] presence set active conversationId=${input.conversationId} studentId=${studentId} until=${activeUntil.toISOString()}`,
+        );
+      } else {
+        await db
+          .update(conversationPresence)
+          .set({ activeUntil: new Date(0) })
+          .where(
+            and(
+              eq(conversationPresence.studentId, studentId),
+              eq(conversationPresence.conversationId, input.conversationId),
+            ),
+          );
+        console.log(
+          `[messaging] presence set inactive conversationId=${input.conversationId} studentId=${studentId}`,
+        );
+      }
+
+      return { ok: true as const };
     }),
 });

--- a/packages/db/src/schema/sip-and-speak.ts
+++ b/packages/db/src/schema/sip-and-speak.ts
@@ -484,3 +484,22 @@ export const studentMatchRelations = relations(studentMatch, ({ one }) => ({
     references: [matchRequest.id],
   }),
 }));
+
+// #153 — Presence record: tracks whether a Student is actively viewing a conversation
+// activeUntil acts as a TTL — stale records (past activeUntil) are treated as inactive
+export const conversationPresence = pgTable(
+  "conversation_presence",
+  {
+    studentId: text("student_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    conversationId: text("conversation_id")
+      .notNull()
+      .references(() => conversation.id, { onDelete: "cascade" }),
+    activeUntil: timestamp("active_until").notNull(),
+  },
+  (table) => [
+    unique("conversation_presence_student_conv_unique").on(table.studentId, table.conversationId),
+    index("conversation_presence_studentId_idx").on(table.studentId),
+  ],
+);


### PR DESCRIPTION
## Summary

- Push notification sent to recipient on `MessageSent` domain event
- Notification suppressed if recipient is actively viewing the conversation (conversationPresence table + TTL check)
- Match identity in notification payload (title = sender name, no message content)
- Notification tap deep-links directly to the conversation screen (`/chat/:conversationId`)
- Graceful handling when recipient has no push token or push permissions denied

Closes #28
Closes #152
Closes #153
Closes #154
Closes #155
Closes #156

## Test plan

- [x] `notifications-message-sent.test.ts` — push sent on MessageSent
- [x] `notifications-message-sent-suppression.test.ts` — push suppressed when viewing
- [x] `push-suppression-presence.test.tsx` — native setPresence hook
- [x] `notification-message-deep-link.test.tsx` — tap navigates to /chat/:conversationId

🤖 Generated with [Claude Code](https://claude.com/claude-code)