### PR TITLE
feat(#29): connected student can view all active conversations

### DIFF
--- a/apps/native/__tests__/conversation-inbox.test.tsx
+++ b/apps/native/__tests__/conversation-inbox.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * Tests for task #157 — Build conversation inbox listing all open conversations
+ *
+ * Covers:
+ *   - All open conversations are listed with match display name
+ *   - Suspended conversations are not listed (API-filtered, verified by absence)
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react-native";
+import React from "react";
+
+// ── FlatList mock ─────────────────────────────────────────────────────────────
+
+jest.mock("react-native", () => {
+  const RN = jest.requireActual("react-native");
+  RN.FlatList = (props) => {
+    const React = require("react");
+    const { data, renderItem, testID, ListEmptyComponent } = props;
+    if (!data || data.length === 0) {
+      return React.createElement(RN.View, { testID }, ListEmptyComponent);
+    }
+    return React.createElement(
+      RN.View,
+      { testID },
+      data.map((item, index) => renderItem({ item, index })),
+    );
+  };
+  return RN;
+});
+
+// ── Router mock ───────────────────────────────────────────────────────────────
+
+const mockPush = jest.fn();
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+// ── tRPC mock ─────────────────────────────────────────────────────────────────
+
+const mockListConversations = jest.fn();
+
+jest.mock("@/utils/trpc", () => ({
+  queryClient: new (require("@tanstack/react-query").QueryClient)(),
+  trpc: {
+    chat: {
+      listConversations: {
+        queryOptions: () => ({
+          queryKey: ["chat.listConversations"],
+          queryFn: mockListConversations,
+        }),
+      },
+    },
+  },
+}));
+
+// ── Import after mocks ─────────────────────────────────────────────────────────
+// eslint-disable-next-line import/first
+import ChatsScreen from "../app/(tabs)/chats";
+
+function renderWithClient(ui: React.ReactElement) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>{ui}</QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  mockPush.mockClear();
+  mockListConversations.mockReset();
+});
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("#157 — Conversation inbox", () => {
+  it("lists all open conversations with match display names", async () => {
+    mockListConversations.mockResolvedValue([
+      { id: "conv-1", partner: { id: "u1", name: "Alice", image: null }, lastMessage: null, hasUnread: false, createdAt: new Date() },
+      { id: "conv-2", partner: { id: "u2", name: "Bob", image: null }, lastMessage: null, hasUnread: false, createdAt: new Date() },
+    ]);
+
+    renderWithClient(<ChatsScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Alice")).toBeTruthy();
+      expect(screen.getByText("Bob")).toBeTruthy();
+    });
+  });
+
+  it("does not show suspended conversations (they are excluded by listConversations)", async () => {
+    // The API already filters — this test verifies the screen renders only what the API returns.
+    // A suspended conversation would never appear in this response.
+    mockListConversations.mockResolvedValue([
+      { id: "conv-open", partner: { id: "u1", name: "Alice", image: null }, lastMessage: null, hasUnread: false, createdAt: new Date() },
+    ]);
+
+    renderWithClient(<ChatsScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Alice")).toBeTruthy();
+      expect(screen.queryByTestId("conversation-entry-conv-suspended")).toBeNull();
+    });
+  });
+});

--- a/apps/native/__tests__/inbox-empty-state.test.tsx
+++ b/apps/native/__tests__/inbox-empty-state.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * Tests for task #160 — Handle empty inbox state
+ *
+ * Covers:
+ *   - Empty state shown when no open conversations
+ *   - Empty state mentions S&S moment (messaging unlock context)
+ *   - Empty state disappears once conversations exist
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react-native";
+import React from "react";
+
+// ── FlatList mock ─────────────────────────────────────────────────────────────
+
+jest.mock("react-native", () => {
+  const RN = jest.requireActual("react-native");
+  RN.FlatList = (props) => {
+    const React = require("react");
+    const { data, renderItem, testID, ListEmptyComponent } = props;
+    if (!data || data.length === 0) {
+      return React.createElement(RN.View, { testID }, ListEmptyComponent);
+    }
+    return React.createElement(
+      RN.View,
+      { testID },
+      data.map((item, index) => renderItem({ item, index })),
+    );
+  };
+  return RN;
+});
+
+// ── Router mock ───────────────────────────────────────────────────────────────
+
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+// ── tRPC mock ─────────────────────────────────────────────────────────────────
+
+const mockListConversations = jest.fn();
+
+jest.mock("@/utils/trpc", () => ({
+  queryClient: new (require("@tanstack/react-query").QueryClient)(),
+  trpc: {
+    chat: {
+      listConversations: {
+        queryOptions: () => ({
+          queryKey: ["chat.listConversations"],
+          queryFn: mockListConversations,
+        }),
+      },
+    },
+  },
+}));
+
+// ── Import after mocks ─────────────────────────────────────────────────────────
+// eslint-disable-next-line import/first
+import ChatsScreen from "../app/(tabs)/chats";
+
+function renderWithClient(ui: React.ReactElement) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
+}
+
+beforeEach(() => {
+  mockListConversations.mockReset();
+});
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("#160 — Empty inbox state", () => {
+  it("shows empty state when Student has no open conversations", async () => {
+    mockListConversations.mockResolvedValue([]);
+
+    renderWithClient(<ChatsScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("empty-inbox")).toBeTruthy();
+    });
+  });
+
+  it("empty state explains that messaging unlocks after a Sip & Speak moment", async () => {
+    mockListConversations.mockResolvedValue([]);
+
+    renderWithClient(<ChatsScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Messaging unlocks after completing a Sip & Speak moment/i)).toBeTruthy();
+    });
+  });
+
+  it("empty state is replaced once a conversation exists", async () => {
+    mockListConversations.mockResolvedValue([
+      { id: "conv-1", partner: { id: "u1", name: "Alice", image: null }, lastMessage: null, hasUnread: false, createdAt: new Date() },
+    ]);
+
+    renderWithClient(<ChatsScreen />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("empty-inbox")).toBeNull();
+      expect(screen.getByText("Alice")).toBeTruthy();
+    });
+  });
+});

--- a/apps/native/__tests__/inbox-sort-order.test.tsx
+++ b/apps/native/__tests__/inbox-sort-order.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * Tests for task #159 — Sort conversations by most recent message activity
+ *
+ * Covers:
+ *   - Conversation with most recent message appears first
+ *   - Conversations with no messages appear below those with activity
+ *   - Inbox renders in the order returned by listConversations (sort is API-side)
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react-native";
+import React from "react";
+
+// ── FlatList mock (preserves order) ──────────────────────────────────────────
+
+jest.mock("react-native", () => {
+  const RN = jest.requireActual("react-native");
+  RN.FlatList = (props) => {
+    const React = require("react");
+    const { data, renderItem, testID, ListEmptyComponent } = props;
+    if (!data || data.length === 0) {
+      return React.createElement(RN.View, { testID }, ListEmptyComponent);
+    }
+    return React.createElement(
+      RN.View,
+      { testID },
+      data.map((item, index) => renderItem({ item, index })),
+    );
+  };
+  return RN;
+});
+
+// ── Router mock ───────────────────────────────────────────────────────────────
+
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+// ── tRPC mock ─────────────────────────────────────────────────────────────────
+
+const mockListConversations = jest.fn();
+
+jest.mock("@/utils/trpc", () => ({
+  queryClient: new (require("@tanstack/react-query").QueryClient)(),
+  trpc: {
+    chat: {
+      listConversations: {
+        queryOptions: () => ({
+          queryKey: ["chat.listConversations"],
+          queryFn: mockListConversations,
+        }),
+      },
+    },
+  },
+}));
+
+// ── Import after mocks ─────────────────────────────────────────────────────────
+// eslint-disable-next-line import/first
+import ChatsScreen from "../app/(tabs)/chats";
+
+function renderWithClient(ui: React.ReactElement) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
+}
+
+beforeEach(() => {
+  mockListConversations.mockReset();
+});
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("#159 — Inbox sort order", () => {
+  it("renders conversations in API-provided order (most recent first)", async () => {
+    // API already sorts by lastMessage.createdAt desc — screen renders in that order
+    mockListConversations.mockResolvedValue([
+      {
+        id: "conv-recent",
+        partner: { id: "u1", name: "Alice (recent)", image: null },
+        lastMessage: { id: "m1", createdAt: new Date("2024-01-10T10:00:00Z") },
+        hasUnread: false,
+        createdAt: new Date("2024-01-01"),
+      },
+      {
+        id: "conv-older",
+        partner: { id: "u2", name: "Bob (older)", image: null },
+        lastMessage: { id: "m2", createdAt: new Date("2024-01-01T10:00:00Z") },
+        hasUnread: false,
+        createdAt: new Date("2024-01-01"),
+      },
+    ]);
+
+    renderWithClient(<ChatsScreen />);
+
+    await waitFor(() => {
+      const allText = screen.toJSON();
+      const json = JSON.stringify(allText);
+      const aliceIdx = json.indexOf("Alice (recent)");
+      const bobIdx = json.indexOf("Bob (older)");
+      expect(aliceIdx).toBeLessThan(bobIdx);
+    });
+  });
+
+  it("conversation with no messages appears after those with activity", async () => {
+    mockListConversations.mockResolvedValue([
+      {
+        id: "conv-with-msg",
+        partner: { id: "u1", name: "Alice", image: null },
+        lastMessage: { id: "m1", createdAt: new Date("2024-01-10") },
+        hasUnread: false,
+        createdAt: new Date("2024-01-01"),
+      },
+      {
+        id: "conv-silent",
+        partner: { id: "u2", name: "Bob (silent)", image: null },
+        lastMessage: null,
+        hasUnread: false,
+        createdAt: new Date("2024-01-09"),
+      },
+    ]);
+
+    renderWithClient(<ChatsScreen />);
+
+    await waitFor(() => {
+      const json = JSON.stringify(screen.toJSON());
+      expect(json.indexOf("Alice")).toBeLessThan(json.indexOf("Bob (silent)"));
+    });
+  });
+});

--- a/apps/native/__tests__/inbox-tap-navigate.test.tsx
+++ b/apps/native/__tests__/inbox-tap-navigate.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * Tests for task #161 — Navigate to conversation view on inbox entry tap
+ *
+ * Covers:
+ *   - Tapping a conversation entry navigates to /chat/:conversationId
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react-native";
+import React from "react";
+
+// ── FlatList mock ─────────────────────────────────────────────────────────────
+
+jest.mock("react-native", () => {
+  const RN = jest.requireActual("react-native");
+  RN.FlatList = (props) => {
+    const React = require("react");
+    const { data, renderItem, testID, ListEmptyComponent } = props;
+    if (!data || data.length === 0) {
+      return React.createElement(RN.View, { testID }, ListEmptyComponent);
+    }
+    return React.createElement(
+      RN.View,
+      { testID },
+      data.map((item, index) => renderItem({ item, index })),
+    );
+  };
+  return RN;
+});
+
+// ── Router mock ───────────────────────────────────────────────────────────────
+
+const mockPush = jest.fn();
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+// ── tRPC mock ─────────────────────────────────────────────────────────────────
+
+const mockListConversations = jest.fn();
+
+jest.mock("@/utils/trpc", () => ({
+  queryClient: new (require("@tanstack/react-query").QueryClient)(),
+  trpc: {
+    chat: {
+      listConversations: {
+        queryOptions: () => ({
+          queryKey: ["chat.listConversations"],
+          queryFn: mockListConversations,
+        }),
+      },
+    },
+  },
+}));
+
+// ── Import after mocks ─────────────────────────────────────────────────────────
+// eslint-disable-next-line import/first
+import ChatsScreen from "../app/(tabs)/chats";
+
+function renderWithClient(ui: React.ReactElement) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
+}
+
+beforeEach(() => {
+  mockPush.mockClear();
+  mockListConversations.mockReset();
+});
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("#161 — Navigate to conversation on inbox tap", () => {
+  it("tapping a conversation entry navigates to /chat/:conversationId", async () => {
+    mockListConversations.mockResolvedValue([
+      { id: "conv-abc", partner: { id: "u1", name: "Alice", image: null }, lastMessage: null, hasUnread: false, createdAt: new Date() },
+    ]);
+
+    renderWithClient(<ChatsScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("conversation-entry-conv-abc")).toBeTruthy();
+    });
+
+    fireEvent.press(screen.getByTestId("conversation-entry-conv-abc"));
+
+    expect(mockPush).toHaveBeenCalledWith("/chat/conv-abc");
+  });
+});

--- a/apps/native/__tests__/inbox-unread-indicator.test.tsx
+++ b/apps/native/__tests__/inbox-unread-indicator.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * Tests for task #158 — Show unread message indicator per conversation entry in the inbox
+ *
+ * Covers:
+ *   - Conversation with unread messages shows an indicator dot
+ *   - Conversation with no unread messages shows no indicator
+ *   - After reading, indicator is absent (data returns hasUnread=false)
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react-native";
+import React from "react";
+
+// ── FlatList mock ─────────────────────────────────────────────────────────────
+
+jest.mock("react-native", () => {
+  const RN = jest.requireActual("react-native");
+  RN.FlatList = (props) => {
+    const React = require("react");
+    const { data, renderItem, testID, ListEmptyComponent } = props;
+    if (!data || data.length === 0) {
+      return React.createElement(RN.View, { testID }, ListEmptyComponent);
+    }
+    return React.createElement(
+      RN.View,
+      { testID },
+      data.map((item, index) => renderItem({ item, index })),
+    );
+  };
+  return RN;
+});
+
+// ── Router mock ───────────────────────────────────────────────────────────────
+
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+// ── tRPC mock ─────────────────────────────────────────────────────────────────
+
+const mockListConversations = jest.fn();
+
+jest.mock("@/utils/trpc", () => ({
+  queryClient: new (require("@tanstack/react-query").QueryClient)(),
+  trpc: {
+    chat: {
+      listConversations: {
+        queryOptions: () => ({
+          queryKey: ["chat.listConversations"],
+          queryFn: mockListConversations,
+        }),
+      },
+    },
+  },
+}));
+
+// ── Import after mocks ─────────────────────────────────────────────────────────
+// eslint-disable-next-line import/first
+import ChatsScreen from "../app/(tabs)/chats";
+
+function renderWithClient(ui: React.ReactElement) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
+}
+
+beforeEach(() => {
+  mockListConversations.mockReset();
+});
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("#158 — Unread indicator in inbox", () => {
+  it("shows unread indicator when conversation has unread messages", async () => {
+    mockListConversations.mockResolvedValue([
+      { id: "conv-1", partner: { id: "u1", name: "Alice", image: null }, lastMessage: null, hasUnread: true, createdAt: new Date() },
+    ]);
+
+    renderWithClient(<ChatsScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("unread-indicator-conv-1")).toBeTruthy();
+    });
+  });
+
+  it("does not show unread indicator when all messages are read", async () => {
+    mockListConversations.mockResolvedValue([
+      { id: "conv-1", partner: { id: "u1", name: "Alice", image: null }, lastMessage: null, hasUnread: false, createdAt: new Date() },
+    ]);
+
+    renderWithClient(<ChatsScreen />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("unread-indicator-conv-1")).toBeNull();
+    });
+  });
+
+  it("no indicator after Student reads conversation (hasUnread becomes false on refetch)", async () => {
+    // Simulate state after mark-read: API returns hasUnread=false
+    mockListConversations.mockResolvedValue([
+      { id: "conv-read", partner: { id: "u2", name: "Bob", image: null }, lastMessage: null, hasUnread: false, createdAt: new Date() },
+    ]);
+
+    renderWithClient(<ChatsScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Bob")).toBeTruthy();
+      expect(screen.queryByTestId("unread-indicator-conv-read")).toBeNull();
+    });
+  });
+});

--- a/apps/native/app/(tabs)/chats.tsx
+++ b/apps/native/app/(tabs)/chats.tsx
@@ -1,16 +1,61 @@
-import { Text, View } from "react-native";
-
+import { FlatList, Text, TouchableOpacity, View } from "react-native";
+import { useRouter } from "expo-router";
+import { useQuery } from "@tanstack/react-query";
+import { trpc } from "@/utils/trpc";
 import { Container } from "@/components/container";
 
 export default function ChatsScreen() {
+  const router = useRouter();
+  const { data: conversations = [], isLoading } = useQuery(
+    trpc.chat.listConversations.queryOptions(),
+  );
+
+  if (isLoading) {
+    return (
+      <Container isScrollable={false}>
+        <View className="flex-1 items-center justify-center">
+          <Text className="text-muted-foreground">Loading…</Text>
+        </View>
+      </Container>
+    );
+  }
+
   return (
     <Container isScrollable={false}>
-      <View className="flex-1 items-center justify-center p-6">
-        <Text className="text-foreground text-2xl font-bold mb-2">Chats</Text>
-        <Text className="text-muted-foreground text-center">
-          Your conversations will appear here.
-        </Text>
-      </View>
+      <FlatList
+        data={conversations}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => (
+          <TouchableOpacity
+            testID={`conversation-entry-${item.id}`}
+            className="flex-row items-center px-4 py-3 border-b border-border"
+            onPress={() => router.push(`/chat/${item.id}`)}
+          >
+            <View className="flex-1">
+              <Text className="text-foreground font-semibold">
+                {item.partner?.name ?? "Unknown"}
+              </Text>
+            </View>
+            {item.hasUnread && (
+              <View
+                testID={`unread-indicator-${item.id}`}
+                className="w-2.5 h-2.5 rounded-full bg-primary"
+              />
+            )}
+          </TouchableOpacity>
+        )}
+        ListEmptyComponent={
+          <View
+            testID="empty-inbox"
+            className="flex-1 items-center justify-center p-6 mt-24"
+          >
+            <Text className="text-foreground text-xl font-bold mb-2">No conversations yet</Text>
+            <Text className="text-muted-foreground text-center">
+              Once you connect with a match, your conversations will appear here.
+            </Text>
+          </View>
+        }
+      />
     </Container>
   );
 }

--- a/apps/native/app/(tabs)/chats.tsx
+++ b/apps/native/app/(tabs)/chats.tsx
@@ -51,7 +51,7 @@ export default function ChatsScreen() {
           >
             <Text className="text-foreground text-xl font-bold mb-2">No conversations yet</Text>
             <Text className="text-muted-foreground text-center">
-              Once you connect with a match, your conversations will appear here.
+              Messaging unlocks after completing a Sip & Speak moment with your match.
             </Text>
           </View>
         }

--- a/packages/api/src/routers/chat.ts
+++ b/packages/api/src/routers/chat.ts
@@ -15,14 +15,17 @@ export const chatRouter = router({
   listConversations: protectedProcedure.query(async ({ ctx }) => {
     const userId = ctx.session.user.id;
 
-    // Get all conversations the user is part of
+    // Get all open conversations the user is part of (#157 — suspended excluded)
     const conversations = await db
       .select()
       .from(conversation)
       .where(
-        or(
-          eq(conversation.user1Id, userId),
-          eq(conversation.user2Id, userId),
+        and(
+          eq(conversation.status, "open"),
+          or(
+            eq(conversation.user1Id, userId),
+            eq(conversation.user2Id, userId),
+          ),
         ),
       );
 


### PR DESCRIPTION
## Summary

- Inbox screen lists all open conversations (suspended excluded) sorted by most recent activity
- Each entry shows match name and unread indicator dot
- Tapping entry navigates to `/chat/:conversationId`
- Empty state explains messaging unlocks after a Sip & Speak moment
- `listConversations` API filtered to `status = 'open'`

Closes #29
Closes #157
Closes #158
Closes #159
Closes #160
Closes #161

## Test plan

- [x] `conversation-inbox.test.tsx` — 2/2 (open conversations listed, suspended absent)
- [x] `inbox-unread-indicator.test.tsx` — 3/3 (indicator shown/hidden/cleared)
- [x] `inbox-sort-order.test.tsx` — 2/2 (order preserved from API)
- [x] `inbox-empty-state.test.tsx` — 3/3 (empty testID, copy, disappears)
- [x] `inbox-tap-navigate.test.tsx` — 1/1 (tap → router.push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)