### PR TITLE
feat(moderation): add flag submission UI with stub tRPC router

### DIFF
--- a/.wolf/anatomy.md
+++ b/.wolf/anatomy.md
@@ -1,7 +1,7 @@
 # anatomy.md
 
-> Auto-maintained by OpenWolf. Last scanned: 2026-04-13T21:18:46.871Z
-> Files: 277 tracked | Anatomy hits: 0 | Misses: 0
+> Auto-maintained by OpenWolf. Last scanned: 2026-04-13T23:08:55.195Z
+> Files: 285 tracked | Anatomy hits: 0 | Misses: 0
 
 ## ../../../../tmp/
 
@@ -25,7 +25,7 @@
 
 - `MEMORY.md` — Memory Index (~106 tok)
 - `project_epic3_loop_progress.md` — Completed (merged to main) (~838 tok)
-- `project_epic4_loop_progress.md` — Completed (~583 tok)
+- `project_epic4_loop_progress.md` — Status: COMPLETE ✅ (~477 tok)
 
 ## ./
 
@@ -311,7 +311,13 @@
 
 - `candidate-card.test.tsx` — Tests for task #122 — Send Request action on suggestion card (~830 tok)
 - `compose-ui.test.tsx` — Tests for task #143 — Build message compose UI (~947 tok)
+- `conversation-inbox.test.tsx` — Tests for task #157 — Build conversation inbox listing all open conversations (~1003 tok)
 - `device-token-registration.test.tsx` — Tests for task #130 — Push notification when MatchRequestSent fires (~722 tok)
+- `flag-user.test.tsx` — Tests for task #65 — Build flag submission UI (peer selection + reason) (~1313 tok)
+- `inbox-empty-state.test.tsx` — Tests for task #160 — Handle empty inbox state (~925 tok)
+- `inbox-sort-order.test.tsx` — Tests for task #159 — Sort conversations by most recent message activity (~1173 tok)
+- `inbox-tap-navigate.test.tsx` — Tests for task #161 — Navigate to conversation view on inbox entry tap (~787 tok)
+- `inbox-unread-indicator.test.tsx` — Tests for task #158 — Show unread message indicator per conversation entry in the inbox (~1051 tok)
 - `notification-deep-link.test.tsx` — Tests for task #132 — Deep-link notification tap to requester's full profile (~1012 tok)
 - `notification-match-accepted.test.tsx` — Tests for task #136 — "Connect Now" CTA in acceptance notification (~1085 tok)
 - `notification-match-declined.test.tsx` — Tests for task #137 — Suggestion list deep-link in decline notification (~861 tok)
@@ -321,9 +327,10 @@
 
 ## apps/native/app/
 
-- `_layout.tsx` — Stack root layout, initialRouteName=(tabs) (~1552 tok)
+- `_layout.tsx` — unstable_settings (~1581 tok)
 - `edit-profile.tsx` — LANGUAGES — uses useRouter, useQuery, useMutation (~3810 tok)
 - `enrolment.tsx` — OTP_RESEND_COOLDOWN — uses useRouter, useState, useEffect, useForm (~2699 tok)
+- `flag-user.tsx` — DETAIL_MAX (~1267 tok)
 - `index.tsx` — LANGUAGES (~5398 tok)
 - `propose-meetup.tsx` — ProposeMeetupScreen (~1591 tok)
 - `respond-meetup.tsx` — RespondMeetupScreen (~3171 tok)
@@ -332,7 +339,7 @@
 ## apps/native/app/(tabs)/
 
 - `_layout.tsx` — StyledIonicons (~401 tok)
-- `chats.tsx` — ChatsScreen (~140 tok)
+- `chats.tsx` — ChatsScreen (~575 tok)
 - `confirmed-meetups.tsx` — ConfirmedMeetupsScreen (~996 tok)
 - `profile.tsx` — ProfileScreen (~233 tok)
 - `suggestions.tsx` — APP_SHARE_URL (~2196 tok)
@@ -343,7 +350,7 @@
 
 ## apps/native/app/partner/
 
-- `[id].tsx` — PartnerProfileScreen — uses useRouter, useQuery, useMutation, useEffect (~2824 tok)
+- `[id].tsx` — PartnerProfileScreen (~2944 tok)
 
 ## apps/native/components/
 
@@ -364,7 +371,7 @@
 ## apps/native/jest-mocks/
 
 - `expo-winter.ts` — Stub for Expo 55 "winter" ESM runtime — uses import.meta which is incompatible with Jest CJS (~34 tok)
-- `heroui-native.tsx` — Minimal heroui-native mock for Jest tests. (~358 tok)
+- `heroui-native.tsx` — Minimal heroui-native mock for Jest tests. (~382 tok)
 - `react-native-reanimated.ts` — Minimal reanimated mock — avoids native binaries entirely. (~172 tok)
 - `react-native-safe-area-context.ts` — Stub for react-native-safe-area-context in tests (~81 tok)
 - `react-native-worklets.ts` — Stub for react-native-worklets — native binaries not available in jest environment (~31 tok)
@@ -488,14 +495,15 @@
 
 ## packages/api/src/routers/
 
-- `chat.ts` — tRPC router: 6 procedures (~2592 tok)
-- `index.ts` — tRPC router: 2 procedures (~243 tok)
+- `chat.ts` — Exports chatRouter (~2894 tok)
+- `index.ts` — tRPC router: 2 procedures (~266 tok)
 - `matching-utils.ts` — Haversine distance in km between two lat/lng points (~1049 tok)
 - `matching.ts` — tRPC router: 5 procedures (~4728 tok)
 - `meetup.ts` — All bookable half-hour slots from 08:00 to 20:00 (~10102 tok)
 - `messaging-persist.ts` — #145 — Persistence helpers for the messaging send flow. (~216 tok)
 - `messaging-utils.ts` — Pure helpers for the messaging opt-in router. (~891 tok)
 - `messaging.ts` — #139 — Record a Student's accept/decline response to the messaging opt-in prompt. (~2346 tok)
+- `moderation.ts` — #65 — Flag submission UI stub. (~284 tok)
 - `profile.ts` — tRPC router: 6 procedures (~4644 tok)
 - `venue-admin.ts` — Exports adminVenueRouter (~1166 tok)
 - `venue.ts` — Zod schemas: venueTagEnum (~1054 tok)

--- a/.wolf/buglog.json
+++ b/.wolf/buglog.json
@@ -1794,6 +1794,86 @@
       "related_bugs": [],
       "occurrences": 1,
       "last_seen": "2026-04-13T20:13:21.719Z"
+    },
+    {
+      "id": "bug-112",
+      "timestamp": "2026-04-13T22:21:33.861Z",
+      "error_message": "CSS fix: item",
+      "file": "apps/native/__tests__/conversation-inbox.test.tsx",
+      "root_cause": "item: unknown → unknown, index: number) => renderItem({ item, index",
+      "fix": "Changed item: unknown → unknown, index: number) => renderItem({ item, index",
+      "tags": [
+        "auto-detected",
+        "style-fix",
+        "tsx"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-04-13T22:21:33.861Z"
+    },
+    {
+      "id": "bug-113",
+      "timestamp": "2026-04-13T22:21:55.840Z",
+      "error_message": "Significant refactor of ",
+      "file": "apps/native/__tests__/conversation-inbox.test.tsx",
+      "root_cause": "2 lines replaced/restructured",
+      "fix": "Rewrote 4→3 lines (2 removed)",
+      "tags": [
+        "auto-detected",
+        "refactor",
+        "tsx"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-04-13T22:21:55.840Z"
+    },
+    {
+      "id": "bug-114",
+      "timestamp": "2026-04-13T22:56:35.933Z",
+      "error_message": "Incorrect value in code",
+      "file": "apps/native/app/_layout.tsx",
+      "root_cause": "Had \"modal\"",
+      "fix": "Changed to \"flag-user\"",
+      "tags": [
+        "auto-detected",
+        "wrong-value",
+        "tsx"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-04-13T22:56:35.933Z"
+    },
+    {
+      "id": "bug-115",
+      "timestamp": "2026-04-13T22:58:17.436Z",
+      "error_message": "Significant refactor of ",
+      "file": "apps/native/app/flag-user.tsx",
+      "root_cause": "2 lines replaced/restructured",
+      "fix": "Rewrote 7→14 lines (2 removed)",
+      "tags": [
+        "auto-detected",
+        "refactor",
+        "tsx"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-04-13T22:58:17.436Z"
+    },
+    {
+      "id": "bug-116",
+      "timestamp": "2026-04-13T23:08:46.611Z",
+      "error_message": "Null/undefined access in ",
+      "file": "apps/native/jest-mocks/heroui-native.tsx",
+      "root_cause": "Property access on potentially null/undefined value",
+      "fix": "Added null safety (optional chaining or null check)",
+      "tags": [
+        "auto-detected",
+        "null-safety",
+        "tsx"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-04-13T23:08:46.611Z"
     }
   ]
 }

--- a/.wolf/cron-state.json
+++ b/.wolf/cron-state.json
@@ -1,5 +1,5 @@
 {
-  "last_heartbeat": "2026-04-13T19:59:08.128Z",
+  "last_heartbeat": "2026-04-13T22:59:08.212Z",
   "engine_status": "running",
   "execution_log": [
     {

--- a/.wolf/hooks/_session.json
+++ b/.wolf/hooks/_session.json
@@ -1,17 +1,11 @@
 {
-  "session_id": "session-2026-04-13-2322",
-  "started": "2026-04-13T21:22:21.892Z",
-  "files_read": {
-    "/Users/sander/.claude/projects/-Users-sander-personal-sip-and-speak/memory/project_epic4_loop_progress.md": {
-      "count": 1,
-      "tokens": 0,
-      "first_read": "2026-04-13T21:22:30.549Z"
-    }
-  },
+  "session_id": "session-2026-04-13-0109",
+  "started": "2026-04-13T23:09:40.469Z",
+  "files_read": {},
   "files_written": [],
   "edit_counts": {},
   "anatomy_hits": 0,
-  "anatomy_misses": 1,
+  "anatomy_misses": 0,
   "repeated_reads_warned": 0,
   "cerebrum_warnings": 0,
   "stop_count": 0

--- a/.wolf/memory.md
+++ b/.wolf/memory.md
@@ -673,3 +673,38 @@
 
 | Time | Action | File(s) | Outcome | ~Tokens |
 |------|--------|---------|---------|--------|
+| 00:20 | Edited packages/api/src/routers/chat.ts | 13→16 lines | ~136 |
+| 00:20 | Created apps/native/app/(tabs)/chats.tsx | — | ~574 |
+| 00:21 | Created apps/native/__tests__/conversation-inbox.test.tsx | — | ~1052 |
+| 00:21 | Edited apps/native/__tests__/conversation-inbox.test.tsx | CSS: props | ~137 |
+| 00:21 | Edited apps/native/__tests__/conversation-inbox.test.tsx | 4→3 lines | ~38 |
+| 00:21 | Edited apps/native/__tests__/conversation-inbox.test.tsx | inline fix | ~18 |
+| 00:28 | Created apps/native/__tests__/inbox-unread-indicator.test.tsx | — | ~1051 |
+| 00:29 | Created apps/native/__tests__/inbox-sort-order.test.tsx | — | ~1173 |
+| 00:29 | Edited apps/native/app/(tabs)/chats.tsx | 4→4 lines | ~77 |
+| 00:29 | Created apps/native/__tests__/inbox-empty-state.test.tsx | — | ~925 |
+| 00:30 | Created apps/native/__tests__/inbox-tap-navigate.test.tsx | — | ~787 |
+| 00:36 | Created ../../.claude/projects/-Users-sander-personal-sip-and-speak/memory/project_epic4_loop_progress.md | — | ~509 |
+| $(date +%H:%M) | Epic #4 complete — Feature #28 (PR #240) and Feature #29 (PR #246) merged to main. All 5 tasks + Epic closed. | apps/native, packages/api, apps/server | ✅ |
+| 00:36 | Session end: 12 writes across 8 files (chat.ts, chats.tsx, conversation-inbox.test.tsx, inbox-unread-indicator.test.tsx, inbox-sort-order.test.tsx) | 6 reads | ~14173 tok |
+
+## Session: 2026-04-13 00:40
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+| 00:55 | Created packages/api/src/routers/moderation.ts | — | ~284 |
+| 00:55 | Edited packages/api/src/routers/index.ts | added 1 import(s) | ~121 |
+| 00:55 | Edited packages/api/src/routers/index.ts | 2→3 lines | ~19 |
+| 00:56 | Created apps/native/__tests__/flag-user.test.tsx | — | ~1333 |
+| 00:56 | Created apps/native/app/flag-user.tsx | — | ~1241 |
+| 00:56 | Edited apps/native/app/_layout.tsx | 1→2 lines | ~54 |
+| 00:56 | Edited apps/native/app/partner/[id].tsx | expanded (+14 lines) | ~133 |
+| 00:58 | Edited apps/native/app/flag-user.tsx | expanded (+7 lines) | ~106 |
+| 01:08 | Edited apps/native/jest-mocks/heroui-native.tsx | added nullish coalescing | ~63 |
+| 01:08 | Edited apps/native/__tests__/flag-user.test.tsx | reduced (-6 lines) | ~24 |
+| 01:08 | Edited apps/native/__tests__/flag-user.test.tsx | 1→4 lines | ~41 |
+
+## Session: 2026-04-13 01:09
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|

--- a/.wolf/token-ledger.json
+++ b/.wolf/token-ledger.json
@@ -2,14 +2,14 @@
   "version": 1,
   "created_at": "2026-04-10T10:02:44.507Z",
   "lifetime": {
-    "total_tokens_estimated": 758409,
-    "total_reads": 452,
-    "total_writes": 674,
-    "total_sessions": 40,
-    "anatomy_hits": 357,
-    "anatomy_misses": 95,
-    "repeated_reads_blocked": 116,
-    "estimated_savings_vs_bare_cli": 417363
+    "total_tokens_estimated": 772582,
+    "total_reads": 458,
+    "total_writes": 686,
+    "total_sessions": 42,
+    "anatomy_hits": 361,
+    "anatomy_misses": 97,
+    "repeated_reads_blocked": 118,
+    "estimated_savings_vs_bare_cli": 418737
   },
   "sessions": [
     {
@@ -7040,6 +7040,119 @@
         "writes_count": 1,
         "repeated_reads_blocked": 0,
         "anatomy_lookups": 0
+      }
+    },
+    {
+      "id": "session-2026-04-13-2322",
+      "started": "2026-04-13T21:22:21.892Z",
+      "ended": "2026-04-13T22:36:54.404Z",
+      "reads": [
+        {
+          "file": "/Users/sander/.claude/projects/-Users-sander-personal-sip-and-speak/memory/project_epic4_loop_progress.md",
+          "tokens_estimated": 0,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/packages/api/src/routers/chat.ts",
+          "tokens_estimated": 2592,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/apps/native/app/(tabs)/chats.tsx",
+          "tokens_estimated": 574,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/packages/db/src/schema/sip-and-speak.ts",
+          "tokens_estimated": 4170,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/apps/native/__tests__/conversation-history.test.tsx",
+          "tokens_estimated": 0,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/apps/native/jest.config.ts",
+          "tokens_estimated": 324,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        }
+      ],
+      "writes": [
+        {
+          "file": "/Users/sander/personal/sip-and-speak/packages/api/src/routers/chat.ts",
+          "tokens_estimated": 136,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/apps/native/app/(tabs)/chats.tsx",
+          "tokens_estimated": 574,
+          "action": "create"
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/apps/native/__tests__/conversation-inbox.test.tsx",
+          "tokens_estimated": 1052,
+          "action": "create"
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/apps/native/__tests__/conversation-inbox.test.tsx",
+          "tokens_estimated": 137,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/apps/native/__tests__/conversation-inbox.test.tsx",
+          "tokens_estimated": 38,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/apps/native/__tests__/conversation-inbox.test.tsx",
+          "tokens_estimated": 18,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/apps/native/__tests__/inbox-unread-indicator.test.tsx",
+          "tokens_estimated": 1051,
+          "action": "create"
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/apps/native/__tests__/inbox-sort-order.test.tsx",
+          "tokens_estimated": 1173,
+          "action": "create"
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/apps/native/app/(tabs)/chats.tsx",
+          "tokens_estimated": 77,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/apps/native/__tests__/inbox-empty-state.test.tsx",
+          "tokens_estimated": 925,
+          "action": "create"
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/apps/native/__tests__/inbox-tap-navigate.test.tsx",
+          "tokens_estimated": 787,
+          "action": "create"
+        },
+        {
+          "file": "/Users/sander/.claude/projects/-Users-sander-personal-sip-and-speak/memory/project_epic4_loop_progress.md",
+          "tokens_estimated": 545,
+          "action": "create"
+        }
+      ],
+      "totals": {
+        "input_tokens_estimated": 7660,
+        "output_tokens_estimated": 6513,
+        "reads_count": 6,
+        "writes_count": 12,
+        "repeated_reads_blocked": 2,
+        "anatomy_lookups": 4
       }
     }
   ],

--- a/apps/native/__tests__/flag-user.test.tsx
+++ b/apps/native/__tests__/flag-user.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * Tests for task #65 — Build flag submission UI (peer selection + reason)
+ *
+ * Covers:
+ *   - Student selects a predefined reason and submits → mutation called with correct args
+ *   - Student adds free-text detail alongside reason → mutation called with detail
+ *   - Student taps Submit with no reason → blocked + inline validation error shown
+ *   - Free-text detail exceeds 450 chars → character count warning + Submit disabled
+ *   - Submission is in-flight → Submit button disabled
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react-native";
+import React from "react";
+
+// ── Router mock ───────────────────────────────────────────────────────────────
+
+jest.mock("expo-router", () => ({
+  useLocalSearchParams: () => ({ targetId: "user-2", targetName: "Alice" }),
+  useRouter: () => ({ back: jest.fn() }),
+}));
+
+// ── tRPC / query mock ─────────────────────────────────────────────────────────
+
+const mockFlagStudent = jest.fn();
+let flagStudentCallbacks: { onSuccess?: () => void; onError?: (e: Error) => void } = {};
+
+jest.mock("@/utils/trpc", () => ({
+  trpc: {
+    moderation: {
+      flagStudent: {
+        mutationOptions: (opts: { onSuccess?: () => void; onError?: (e: Error) => void }) => {
+          flagStudentCallbacks = opts ?? {};
+          return {
+            mutationFn: mockFlagStudent,
+            onSuccess: opts?.onSuccess,
+            onError: opts?.onError,
+          };
+        },
+      },
+    },
+  },
+  queryClient: { invalidateQueries: jest.fn() },
+}));
+
+import { Alert } from "react-native";
+import FlagUserScreen from "../app/flag-user";
+
+jest.spyOn(Alert, "alert").mockImplementation(() => {});
+
+function renderWithQuery(ui: React.ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+}
+
+beforeEach(() => {
+  mockFlagStudent.mockReset();
+  flagStudentCallbacks = {};
+});
+
+// ── #65: Flag submission UI scenarios ─────────────────────────────────────────
+
+describe("#65 — Flag submission UI", () => {
+  it("calls mutation with targetId and selected reason on submit", async () => {
+    mockFlagStudent.mockResolvedValue({ ok: true });
+    renderWithQuery(<FlagUserScreen />);
+
+    fireEvent.press(screen.getByTestId("reason-HARASSMENT"));
+    fireEvent.press(screen.getByTestId("flag-submit-btn"));
+
+    await waitFor(() => {
+      expect(mockFlagStudent).toHaveBeenCalledWith(
+        expect.objectContaining({ targetId: "user-2", reason: "HARASSMENT" }),
+        expect.anything(),
+      );
+    });
+  });
+
+  it("includes free-text detail in mutation when provided", async () => {
+    mockFlagStudent.mockResolvedValue({ ok: true });
+    renderWithQuery(<FlagUserScreen />);
+
+    fireEvent.press(screen.getByTestId("reason-SPAM"));
+    fireEvent.changeText(screen.getByTestId("flag-detail-input"), "They kept sending irrelevant links.");
+    fireEvent.press(screen.getByTestId("flag-submit-btn"));
+
+    await waitFor(() => {
+      expect(mockFlagStudent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          targetId: "user-2",
+          reason: "SPAM",
+          detail: "They kept sending irrelevant links.",
+        }),
+        expect.anything(),
+      );
+    });
+  });
+
+  it("blocks submission and shows validation error when no reason is selected", () => {
+    renderWithQuery(<FlagUserScreen />);
+
+    fireEvent.press(screen.getByTestId("flag-submit-btn"));
+
+    expect(mockFlagStudent).not.toHaveBeenCalled();
+    expect(screen.getByTestId("no-reason-error")).toBeTruthy();
+  });
+
+  it("shows character count warning and disables Submit when detail exceeds 450 chars", () => {
+    renderWithQuery(<FlagUserScreen />);
+
+    fireEvent.changeText(screen.getByTestId("flag-detail-input"), "a".repeat(451));
+
+    expect(screen.getByTestId("char-count-warning")).toBeTruthy();
+    const btn = screen.getByTestId("flag-submit-btn");
+    expect(btn.props.accessibilityState?.disabled).toBe(true);
+  });
+
+  it("disables Submit button while mutation is in-flight", async () => {
+    mockFlagStudent.mockReturnValue(new Promise(() => {}));
+    renderWithQuery(<FlagUserScreen />);
+
+    fireEvent.press(screen.getByTestId("reason-OFFENSIVE_LANGUAGE"));
+    fireEvent.press(screen.getByTestId("flag-submit-btn"));
+
+    await waitFor(() => {
+      const btn = screen.getByTestId("flag-submit-btn");
+      expect(btn.props.accessibilityState?.disabled).toBe(true);
+    });
+  });
+});

--- a/apps/native/app/_layout.tsx
+++ b/apps/native/app/_layout.tsx
@@ -117,6 +117,7 @@ function StackLayout() {
       <Stack.Screen name="chat/[conversationId]" options={{ title: "Chat" }} />
       <Stack.Screen name="map" options={{ title: "Campus Map" }} />
       <Stack.Screen name="respond-meetup" options={{ title: "Respond to Proposal" }} />
+      <Stack.Screen name="flag-user" options={{ title: "Report Student", presentation: "modal" }} />
       <Stack.Screen name="modal" options={{ title: "Modal", presentation: "modal" }} />
     </Stack>
   );

--- a/apps/native/app/flag-user.tsx
+++ b/apps/native/app/flag-user.tsx
@@ -1,0 +1,144 @@
+import { useMutation } from "@tanstack/react-query";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { Button } from "heroui-native";
+import { useState } from "react";
+import { Alert, ScrollView, Text, TextInput, TouchableOpacity, View } from "react-native";
+
+import { Container } from "@/components/container";
+import { trpc } from "@/utils/trpc";
+
+const DETAIL_MAX = 450;
+
+const REASONS = [
+  ["OFFENSIVE_LANGUAGE", "Offensive language"],
+  ["HARASSMENT", "Harassment"],
+  ["SPAM", "Spam"],
+  ["INAPPROPRIATE_BEHAVIOR", "Inappropriate behaviour"],
+  ["OTHER", "Other"],
+] as const;
+
+type FlagReason = (typeof REASONS)[number][0];
+
+export default function FlagUserScreen() {
+  const { targetId, targetName } = useLocalSearchParams<{
+    targetId: string;
+    targetName: string;
+  }>();
+  const router = useRouter();
+
+  const [selectedReason, setSelectedReason] = useState<FlagReason | null>(null);
+  const [detail, setDetail] = useState("");
+  const [noReasonError, setNoReasonError] = useState(false);
+
+  const flagMutation = useMutation(
+    trpc.moderation.flagStudent.mutationOptions({
+      onSuccess: () => {
+        Alert.alert(
+          "Report submitted",
+          "Thank you. A Moderator will review your report.",
+        );
+        router.back();
+      },
+      onError: (err) => {
+        Alert.alert("Something went wrong", err.message);
+      },
+    }),
+  );
+
+  const detailTooLong = detail.length > DETAIL_MAX;
+  const isDisabled = flagMutation.isPending || detailTooLong;
+
+  function handleSubmit() {
+    if (!selectedReason) {
+      setNoReasonError(true);
+      return;
+    }
+    setNoReasonError(false);
+    if (!targetId) return;
+    flagMutation.mutate({
+      targetId,
+      reason: selectedReason,
+      detail: detail.trim() || undefined,
+    });
+  }
+
+  return (
+    <Container>
+      <ScrollView contentContainerStyle={{ padding: 16 }}>
+        <Text className="text-foreground text-2xl font-bold mb-2">
+          Report {targetName ?? "Student"}
+        </Text>
+        <Text className="text-muted-foreground text-sm mb-6">
+          Select a reason for reporting this Student. A Moderator will review your report.
+        </Text>
+
+        <Text className="text-foreground font-semibold mb-3">Reason</Text>
+        <View className="flex flex-col gap-2 mb-4">
+          {REASONS.map(([key, label]) => (
+            <TouchableOpacity
+              key={key}
+              testID={`reason-${key}`}
+              onPress={() => {
+                setSelectedReason(key);
+                setNoReasonError(false);
+              }}
+              className={`border rounded-xl p-3 ${
+                selectedReason === key
+                  ? "border-primary bg-primary/10"
+                  : "border-border bg-card"
+              }`}
+            >
+              <Text
+                className={`font-medium ${
+                  selectedReason === key ? "text-primary" : "text-foreground"
+                }`}
+              >
+                {label}
+              </Text>
+            </TouchableOpacity>
+          ))}
+        </View>
+
+        {noReasonError && (
+          <Text testID="no-reason-error" className="text-destructive text-sm mb-4">
+            Please select a reason before submitting.
+          </Text>
+        )}
+
+        <Text className="text-foreground font-semibold mb-2">
+          Additional detail (optional)
+        </Text>
+        <TextInput
+          testID="flag-detail-input"
+          value={detail}
+          onChangeText={setDetail}
+          placeholder="Describe what happened…"
+          multiline
+          numberOfLines={4}
+          maxLength={DETAIL_MAX + 10}
+          className="border border-border rounded-xl px-3 py-2 text-foreground bg-card mb-1"
+          placeholderTextColor="#888"
+        />
+        <Text
+          testID={detailTooLong ? "char-count-warning" : "char-count"}
+          className={`text-xs mb-4 text-right ${
+            detailTooLong ? "text-destructive" : "text-muted-foreground"
+          }`}
+        >
+          {detail.length}/{DETAIL_MAX}
+          {detailTooLong ? " — too long" : ""}
+        </Text>
+
+        <Button
+          testID="flag-submit-btn"
+          onPress={handleSubmit}
+          isDisabled={isDisabled}
+        >
+          <Button.Label>
+            {flagMutation.isPending ? "Submitting…" : "Submit report"}
+          </Button.Label>
+        </Button>
+      </ScrollView>
+    </Container>
+  );
+}

--- a/apps/native/app/partner/[id].tsx
+++ b/apps/native/app/partner/[id].tsx
@@ -263,6 +263,20 @@ export default function PartnerProfileScreen() {
             </Button>
           )
         )}
+        {/* #65 — Report / flag this Student */}
+        <Button
+          testID="report-student-btn"
+          variant="ghost"
+          className="mb-2"
+          onPress={() =>
+            router.push({
+              pathname: "/flag-user",
+              params: { targetId: id, targetName: profile.name },
+            })
+          }
+        >
+          <Button.Label>Report Student</Button.Label>
+        </Button>
       </ScrollView>
     </Container>
   );

--- a/apps/native/jest-mocks/heroui-native.tsx
+++ b/apps/native/jest-mocks/heroui-native.tsx
@@ -13,7 +13,12 @@ function Button({ children, onPress, isDisabled, testID, ...rest }: {
   [key: string]: unknown;
 }) {
   return (
-    <Pressable testID={testID} onPress={!isDisabled ? onPress : undefined} {...rest}>
+    <Pressable
+      testID={testID}
+      onPress={!isDisabled ? onPress : undefined}
+      accessibilityState={{ disabled: isDisabled ?? false }}
+      {...rest}
+    >
       {children}
     </Pressable>
   );

--- a/packages/api/src/routers/index.ts
+++ b/packages/api/src/routers/index.ts
@@ -6,6 +6,7 @@ import { adminVenueRouter } from "./venue-admin";
 import { meetupRouter } from "./meetup";
 import { chatRouter } from "./chat";
 import { messagingRouter } from "./messaging";
+import { moderationRouter } from "./moderation";
 
 export const appRouter = router({
   healthCheck: publicProcedure.query(() => {
@@ -24,5 +25,6 @@ export const appRouter = router({
   meetup: meetupRouter,
   chat: chatRouter,
   messaging: messagingRouter,
+  moderation: moderationRouter,
 });
 export type AppRouter = typeof appRouter;

--- a/packages/api/src/routers/moderation.ts
+++ b/packages/api/src/routers/moderation.ts
@@ -1,0 +1,40 @@
+import { z } from "zod";
+
+import { protectedProcedure, router } from "../index";
+
+export const flagReasonSchema = z.enum([
+  "OFFENSIVE_LANGUAGE",
+  "HARASSMENT",
+  "SPAM",
+  "INAPPROPRIATE_BEHAVIOR",
+  "OTHER",
+]);
+
+export type FlagReason = z.infer<typeof flagReasonSchema>;
+
+export const flagReasonLabels: Record<FlagReason, string> = {
+  OFFENSIVE_LANGUAGE: "Offensive language",
+  HARASSMENT: "Harassment",
+  SPAM: "Spam",
+  INAPPROPRIATE_BEHAVIOR: "Inappropriate behaviour",
+  OTHER: "Other",
+};
+
+export const moderationRouter = router({
+  /**
+   * #65 — Flag submission UI stub.
+   * Validation (#67) and persistence (#72) are implemented in subsequent tasks.
+   */
+  flagStudent: protectedProcedure
+    .input(
+      z.object({
+        targetId: z.string(),
+        reason: flagReasonSchema,
+        detail: z.string().max(450).optional(),
+      }),
+    )
+    .mutation(async () => {
+      // Stub — persistence implemented in task #72
+      return { ok: true as const };
+    }),
+});


### PR DESCRIPTION
## Summary

Adds the flag submission modal screen so Students can report a peer as disruptive. This is the first step in the Trust & Moderation epic (Epic #5) — a Student taps "Report Student" on a peer's profile, selects a predefined reason, optionally adds detail, and submits. A stub tRPC procedure (`moderation.flagStudent`) provides end-to-end type safety ahead of backend persistence (task #72) and validation (task #67).

## Changes

- **New modal screen** `apps/native/app/flag-user.tsx` — reason picker (5 predefined options as tappable tiles), optional free-text detail (450-char limit with live count), loading state, Alert on success
- **Report button** added to `apps/native/app/partner/[id].tsx` — navigates to flag-user modal with targetId + targetName params
- **Layout registration** in `apps/native/app/_layout.tsx` — flag-user screen with `presentation: "modal"`
- **Stub tRPC router** `packages/api/src/routers/moderation.ts` — `flagStudent` procedure with Zod-validated input; returns `{ ok: true }` until persistence is wired in #72
- **heroui-native mock** updated to propagate `accessibilityState.disabled` so `isDisabled` tests work correctly

## Test plan

- [ ] Student opens flag form from partner profile → modal opens with peer pre-selected
- [ ] Student selects a predefined reason and submits → mutation called with correct targetId + reason
- [ ] Student adds free-text detail alongside reason → detail included in mutation call
- [ ] Student taps Submit with no reason selected → mutation NOT called, inline validation error shown
- [ ] Free-text detail exceeds 450 chars → character count warning shown, Submit disabled
- [ ] Submission is in-flight → Submit button disabled (no double-submit)

## Related

Closes #65
