### PR TITLE
feat(moderation): add flag validation — self-flag and duplicate open flag

### DIFF
--- a/packages/api/src/__tests__/moderation-validation.test.ts
+++ b/packages/api/src/__tests__/moderation-validation.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Tests for task #67 — Validate flag (no self-flagging, no duplicate open flag)
+ *
+ * Covers:
+ *   - Self-flag rejected
+ *   - Duplicate open flag rejected
+ *   - Valid flag (different users, no existing open flag) passes
+ *   - Rapid duplicate submissions: second request sees count > 0 → rejected
+ *   - Resolved flag does not block new flag (count = 0)
+ */
+import { describe, it, expect } from "bun:test";
+
+import {
+  checkSelfFlag,
+  checkDuplicateOpenFlag,
+  FLAG_VALIDATION_MESSAGES,
+} from "../routers/moderation-utils";
+
+describe("#67 — checkSelfFlag", () => {
+  it("rejects flag where reporter and target are the same user", () => {
+    const result = checkSelfFlag("user-a", "user-a");
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.error).toBe("SELF_FLAG");
+  });
+
+  it("accepts flag where reporter and target are different users", () => {
+    const result = checkSelfFlag("user-a", "user-b");
+    expect(result.valid).toBe(true);
+  });
+
+  it("SELF_FLAG message does not expose internal state", () => {
+    expect(FLAG_VALIDATION_MESSAGES.SELF_FLAG).toBeTruthy();
+    expect(FLAG_VALIDATION_MESSAGES.SELF_FLAG).not.toContain("user_flag");
+    expect(FLAG_VALIDATION_MESSAGES.SELF_FLAG).not.toContain("database");
+  });
+});
+
+describe("#67 — checkDuplicateOpenFlag", () => {
+  it("rejects when an open flag already exists (count = 1)", () => {
+    const result = checkDuplicateOpenFlag(1);
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.error).toBe("DUPLICATE_OPEN_FLAG");
+  });
+
+  it("rejects rapid duplicate (count > 1 from concurrent inserts)", () => {
+    const result = checkDuplicateOpenFlag(2);
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.error).toBe("DUPLICATE_OPEN_FLAG");
+  });
+
+  it("accepts when no open flag exists (count = 0)", () => {
+    const result = checkDuplicateOpenFlag(0);
+    expect(result.valid).toBe(true);
+  });
+
+  it("accepts when prior flag is resolved (count = 0 because only open flags are counted)", () => {
+    // Caller filters by status = 'open' — resolved flags yield count = 0
+    const result = checkDuplicateOpenFlag(0);
+    expect(result.valid).toBe(true);
+  });
+
+  it("DUPLICATE_OPEN_FLAG message does not expose internal state", () => {
+    expect(FLAG_VALIDATION_MESSAGES.DUPLICATE_OPEN_FLAG).toBeTruthy();
+    expect(FLAG_VALIDATION_MESSAGES.DUPLICATE_OPEN_FLAG).not.toContain("user_flag");
+    expect(FLAG_VALIDATION_MESSAGES.DUPLICATE_OPEN_FLAG).not.toContain("database");
+  });
+});

--- a/packages/api/src/routers/moderation-utils.ts
+++ b/packages/api/src/routers/moderation-utils.ts
@@ -1,0 +1,37 @@
+// #67 — Pure validation functions for flag submission
+
+export type FlagValidationError =
+  | { valid: false; error: "SELF_FLAG" }
+  | { valid: false; error: "DUPLICATE_OPEN_FLAG" }
+  | { valid: true };
+
+/**
+ * Rejects a flag where the reporter and target are the same user.
+ */
+export function checkSelfFlag(
+  reporterId: string,
+  targetId: string,
+): FlagValidationError {
+  if (reporterId === targetId) {
+    return { valid: false, error: "SELF_FLAG" };
+  }
+  return { valid: true };
+}
+
+/**
+ * Rejects a flag when an open flag already exists for the same
+ * reporter–target pair. The caller supplies the open-flag count from the DB.
+ */
+export function checkDuplicateOpenFlag(
+  openFlagCount: number,
+): FlagValidationError {
+  if (openFlagCount > 0) {
+    return { valid: false, error: "DUPLICATE_OPEN_FLAG" };
+  }
+  return { valid: true };
+}
+
+export const FLAG_VALIDATION_MESSAGES: Record<"SELF_FLAG" | "DUPLICATE_OPEN_FLAG", string> = {
+  SELF_FLAG: "You cannot flag yourself.",
+  DUPLICATE_OPEN_FLAG: "A report against this Student is already under review.",
+};

--- a/packages/api/src/routers/moderation.ts
+++ b/packages/api/src/routers/moderation.ts
@@ -1,6 +1,15 @@
 import { z } from "zod";
+import { TRPCError } from "@trpc/server";
+import { and, eq, count } from "drizzle-orm";
 
 import { protectedProcedure, router } from "../index";
+import { db } from "@sip-and-speak/db";
+import { userFlag } from "@sip-and-speak/db/schema/sip-and-speak";
+import {
+  checkSelfFlag,
+  checkDuplicateOpenFlag,
+  FLAG_VALIDATION_MESSAGES,
+} from "./moderation-utils";
 
 export const flagReasonSchema = z.enum([
   "OFFENSIVE_LANGUAGE",
@@ -22,8 +31,8 @@ export const flagReasonLabels: Record<FlagReason, string> = {
 
 export const moderationRouter = router({
   /**
-   * #65 — Flag submission UI stub.
-   * Validation (#67) and persistence (#72) are implemented in subsequent tasks.
+   * #65/#67 — Flag submission with validation.
+   * Persistence (#72) is implemented in a subsequent task.
    */
   flagStudent: protectedProcedure
     .input(
@@ -33,7 +42,39 @@ export const moderationRouter = router({
         detail: z.string().max(450).optional(),
       }),
     )
-    .mutation(async () => {
+    .mutation(async ({ ctx, input }) => {
+      const reporterId = ctx.session.user.id;
+
+      // #67 — Self-flag check
+      const selfCheck = checkSelfFlag(reporterId, input.targetId);
+      if (!selfCheck.valid) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: FLAG_VALIDATION_MESSAGES[selfCheck.error],
+        });
+      }
+
+      // #67 — Duplicate open flag check
+      const rows = await db
+        .select({ count: count() })
+        .from(userFlag)
+        .where(
+          and(
+            eq(userFlag.reporterId, reporterId),
+            eq(userFlag.targetId, input.targetId),
+            eq(userFlag.status, "open"),
+          ),
+        );
+
+      const openCount = rows[0]?.count ?? 0;
+      const dupCheck = checkDuplicateOpenFlag(Number(openCount));
+      if (!dupCheck.valid) {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message: FLAG_VALIDATION_MESSAGES[dupCheck.error],
+        });
+      }
+
       // Stub — persistence implemented in task #72
       return { ok: true as const };
     }),

--- a/packages/db/src/schema/sip-and-speak.ts
+++ b/packages/db/src/schema/sip-and-speak.ts
@@ -503,3 +503,28 @@ export const conversationPresence = pgTable(
     index("conversation_presence_studentId_idx").on(table.studentId),
   ],
 );
+
+// #67/#72 — Flag: a Student reports a peer as disruptive for Moderator review
+export const userFlag = pgTable(
+  "user_flag",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    reporterId: text("reporter_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    targetId: text("target_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    reason: text("reason").notNull(),
+    detail: text("detail"),
+    status: text("status").notNull().default("open"), // open | resolved
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+  },
+  (table) => [
+    index("user_flag_reporter_idx").on(table.reporterId),
+    index("user_flag_target_idx").on(table.targetId),
+    index("user_flag_status_idx").on(table.status),
+  ],
+);


### PR DESCRIPTION
## Summary

Implements backend validation for flag submission (task #67). Prevents Students from flagging themselves and from submitting a duplicate flag against the same peer while a previous open flag exists. Error messages are informative but do not expose internal state.

Also adds the `userFlag` DB schema table — prerequisite for persistence in task #72.

## Changes

- `moderation-utils.ts` — pure `checkSelfFlag` / `checkDuplicateOpenFlag` functions
- `moderation.ts` — validation wired into `flagStudent` procedure (BAD_REQUEST for self-flag, CONFLICT for duplicate)
- `sip-and-speak.ts` — `userFlag` table schema
- `moderation-validation.test.ts` — 8 Bun unit tests

## Test plan

- [ ] Self-flag rejected with informative error
- [ ] Duplicate open flag rejected
- [ ] Valid flag (different users, no open flag) passes both checks
- [ ] Rapid duplicate (count > 1) rejected
- [ ] Resolved prior flag does not block new flag (count = 0)

## Related

Closes #67