### PR TITLE
feat(moderation): persist flag to DB and emit StudentFlagged domain event

### DIFF
--- a/packages/api/src/__tests__/moderation-persist.test.ts
+++ b/packages/api/src/__tests__/moderation-persist.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Tests for task #72 — Persist flag and add to Moderator review queue
+ *
+ * Covers pure helpers — no DB interaction.
+ *
+ *   - buildFlagValues: produces correct payload with status 'open'
+ *   - buildFlagValues: optional detail is omitted when not provided
+ *   - buildStudentFlaggedEvent: maps persisted flag fields to domain event payload
+ */
+import { describe, it, expect } from "bun:test";
+
+import {
+  buildFlagValues,
+  buildStudentFlaggedEvent,
+} from "../routers/moderation-utils";
+
+describe("#72 — buildFlagValues", () => {
+  it("returns correct payload with status 'open'", () => {
+    const result = buildFlagValues({
+      reporterId: "user-1",
+      targetId: "user-2",
+      reason: "HARASSMENT",
+      detail: "They sent threatening messages.",
+    });
+
+    expect(result).toEqual({
+      reporterId: "user-1",
+      targetId: "user-2",
+      reason: "HARASSMENT",
+      detail: "They sent threatening messages.",
+      status: "open",
+    });
+  });
+
+  it("status is always 'open' regardless of input", () => {
+    const result = buildFlagValues({
+      reporterId: "user-1",
+      targetId: "user-2",
+      reason: "SPAM",
+    });
+
+    expect(result.status).toBe("open");
+  });
+
+  it("detail is undefined when not provided", () => {
+    const result = buildFlagValues({
+      reporterId: "user-1",
+      targetId: "user-2",
+      reason: "OTHER",
+    });
+
+    expect(result.detail).toBeUndefined();
+  });
+});
+
+describe("#72 — buildStudentFlaggedEvent", () => {
+  it("maps flag row to correct domain event payload", () => {
+    const flaggedAt = new Date("2026-04-14T10:00:00Z");
+
+    const result = buildStudentFlaggedEvent(
+      "flag-abc",
+      { reporterId: "user-1", targetId: "user-2", reason: "OFFENSIVE_LANGUAGE" },
+      flaggedAt,
+    );
+
+    expect(result).toEqual({
+      flagId: "flag-abc",
+      reporterId: "user-1",
+      targetId: "user-2",
+      reason: "OFFENSIVE_LANGUAGE",
+      flaggedAt,
+    });
+  });
+});

--- a/packages/api/src/domain-events.ts
+++ b/packages/api/src/domain-events.ts
@@ -187,6 +187,14 @@ export interface MessageSentEvent {
   senderName: string;
 }
 
+export interface StudentFlaggedEvent {
+  flagId: string;
+  reporterId: string;
+  targetId: string;
+  reason: string;
+  flaggedAt: Date;
+}
+
 type DomainEventMap = {
   LanguageProfileUpdated: [LanguageProfileUpdatedEvent];
   InterestProfileUpdated: [InterestProfileUpdatedEvent];
@@ -212,6 +220,7 @@ type DomainEventMap = {
   ConversationOpened: [ConversationOpenedEvent];
   MessagingDeclineOutcome: [MessagingDeclineOutcomeEvent];
   MessageSent: [MessageSentEvent];
+  StudentFlagged: [StudentFlaggedEvent];
 };
 
 class TypedEventEmitter extends EventEmitter {

--- a/packages/api/src/routers/moderation-persist.ts
+++ b/packages/api/src/routers/moderation-persist.ts
@@ -1,0 +1,27 @@
+/**
+ * #72 — Persistence helpers for the flag submission flow.
+ * Extracted for unit testing without requiring a live tRPC context.
+ */
+import { db } from "@sip-and-speak/db";
+import { userFlag } from "@sip-and-speak/db/schema/sip-and-speak";
+import { buildFlagValues } from "./moderation-utils";
+
+export interface PersistFlagInput {
+  reporterId: string;
+  targetId: string;
+  reason: string;
+  detail?: string;
+}
+
+/**
+ * Inserts a flag row with status 'open' and returns the created record.
+ * Throws on DB failure — no partial record is created.
+ */
+export async function persistFlag(input: PersistFlagInput) {
+  const [created] = await db
+    .insert(userFlag)
+    .values(buildFlagValues(input))
+    .returning();
+
+  return created!;
+}

--- a/packages/api/src/routers/moderation-utils.ts
+++ b/packages/api/src/routers/moderation-utils.ts
@@ -35,3 +35,57 @@ export const FLAG_VALIDATION_MESSAGES: Record<"SELF_FLAG" | "DUPLICATE_OPEN_FLAG
   SELF_FLAG: "You cannot flag yourself.",
   DUPLICATE_OPEN_FLAG: "A report against this Student is already under review.",
 };
+
+// #72 — Pure helpers for flag persistence
+
+export interface FlagValues {
+  reporterId: string;
+  targetId: string;
+  reason: string;
+  detail: string | undefined;
+  status: "open";
+}
+
+/**
+ * Builds the DB insert payload for a new flag.
+ * Status is always 'open' on creation.
+ */
+export function buildFlagValues(input: {
+  reporterId: string;
+  targetId: string;
+  reason: string;
+  detail?: string;
+}): FlagValues {
+  return {
+    reporterId: input.reporterId,
+    targetId: input.targetId,
+    reason: input.reason,
+    detail: input.detail,
+    status: "open",
+  };
+}
+
+export interface StudentFlaggedPayload {
+  flagId: string;
+  reporterId: string;
+  targetId: string;
+  reason: string;
+  flaggedAt: Date;
+}
+
+/**
+ * Builds the StudentFlagged domain event payload from the persisted flag row.
+ */
+export function buildStudentFlaggedEvent(
+  flagId: string,
+  input: { reporterId: string; targetId: string; reason: string },
+  flaggedAt: Date,
+): StudentFlaggedPayload {
+  return {
+    flagId,
+    reporterId: input.reporterId,
+    targetId: input.targetId,
+    reason: input.reason,
+    flaggedAt,
+  };
+}

--- a/packages/api/src/routers/moderation.ts
+++ b/packages/api/src/routers/moderation.ts
@@ -9,7 +9,10 @@ import {
   checkSelfFlag,
   checkDuplicateOpenFlag,
   FLAG_VALIDATION_MESSAGES,
+  buildStudentFlaggedEvent,
 } from "./moderation-utils";
+import { persistFlag } from "./moderation-persist";
+import { domainEvents } from "../domain-events";
 
 export const flagReasonSchema = z.enum([
   "OFFENSIVE_LANGUAGE",
@@ -75,7 +78,19 @@ export const moderationRouter = router({
         });
       }
 
-      // Stub — persistence implemented in task #72
+      // #72 — Persist the flag and emit domain event
+      const flag = await persistFlag({
+        reporterId,
+        targetId: input.targetId,
+        reason: input.reason,
+        detail: input.detail,
+      });
+
+      domainEvents.emit(
+        "StudentFlagged",
+        buildStudentFlaggedEvent(flag.id, { reporterId, targetId: input.targetId, reason: input.reason }, flag.createdAt),
+      );
+
       return { ok: true as const };
     }),
 });


### PR DESCRIPTION
## Summary

- Replace stub `return { ok: true }` in `flagStudent` with actual DB insert via `persistFlag` helper
- Add `StudentFlagged` domain event interface and registration
- Extract `buildFlagValues` and `buildStudentFlaggedEvent` pure helpers to `moderation-utils` for unit testing

## Test plan

- [x] `bun test src/__tests__/moderation-persist.test.ts` — 4 pure-function tests pass
- [x] `bun test src/__tests__/moderation-validation.test.ts` — 8 existing tests still pass

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)