### PR TITLE
feat(moderation): show inline confirmation after flag submission

### DIFF
--- a/apps/native/__tests__/flag-submission-confirm.test.tsx
+++ b/apps/native/__tests__/flag-submission-confirm.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * Tests for task #74 — Confirm flag submission to the flagging Student
+ *
+ * Covers:
+ *   - Successful submission → confirmation screen shown (not the form)
+ *   - Confirmation screen contains "Moderator will review" message
+ *   - Done button on confirmation screen calls router.back()
+ *   - Backend error → inline error message shown (not confirmation)
+ *   - Backend error → confirmation screen NOT shown
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react-native";
+import React from "react";
+
+// ── Router mock ───────────────────────────────────────────────────────────────
+
+const mockBack = jest.fn();
+jest.mock("expo-router", () => ({
+  useLocalSearchParams: () => ({ targetId: "user-2", targetName: "Alice" }),
+  useRouter: () => ({ back: mockBack }),
+}));
+
+// ── tRPC / query mock ─────────────────────────────────────────────────────────
+
+const mockFlagStudent = jest.fn();
+let flagStudentCallbacks: { onSuccess?: () => void; onError?: (e: Error) => void } = {};
+
+jest.mock("@/utils/trpc", () => ({
+  trpc: {
+    moderation: {
+      flagStudent: {
+        mutationOptions: (opts: { onSuccess?: () => void; onError?: (e: Error) => void }) => {
+          flagStudentCallbacks = opts ?? {};
+          return {
+            mutationFn: mockFlagStudent,
+            onSuccess: opts?.onSuccess,
+            onError: opts?.onError,
+          };
+        },
+      },
+    },
+  },
+  queryClient: { invalidateQueries: jest.fn() },
+}));
+
+import FlagUserScreen from "../app/flag-user";
+
+function renderWithQuery(ui: React.ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+}
+
+beforeEach(() => {
+  mockFlagStudent.mockReset();
+  mockBack.mockReset();
+  flagStudentCallbacks = {};
+});
+
+// ── #74: Confirmation screen scenarios ────────────────────────────────────────
+
+describe("#74 — Flag submission confirmation", () => {
+  it("shows confirmation screen after successful submission", async () => {
+    mockFlagStudent.mockResolvedValue({ ok: true });
+    renderWithQuery(<FlagUserScreen />);
+
+    fireEvent.press(screen.getByTestId("reason-HARASSMENT"));
+    fireEvent.press(screen.getByTestId("flag-submit-btn"));
+
+    await waitFor(() => {
+      expect(flagStudentCallbacks.onSuccess).toBeDefined();
+    });
+    flagStudentCallbacks.onSuccess?.();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("flag-confirmation")).toBeTruthy();
+    });
+  });
+
+  it("confirmation message informs Student that Moderator will review", async () => {
+    mockFlagStudent.mockResolvedValue({ ok: true });
+    renderWithQuery(<FlagUserScreen />);
+
+    fireEvent.press(screen.getByTestId("reason-SPAM"));
+    fireEvent.press(screen.getByTestId("flag-submit-btn"));
+
+    flagStudentCallbacks.onSuccess?.();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Moderator will review/i)).toBeTruthy();
+    });
+  });
+
+  it("Done button on confirmation screen calls router.back()", async () => {
+    mockFlagStudent.mockResolvedValue({ ok: true });
+    renderWithQuery(<FlagUserScreen />);
+
+    fireEvent.press(screen.getByTestId("reason-OTHER"));
+    fireEvent.press(screen.getByTestId("flag-submit-btn"));
+
+    flagStudentCallbacks.onSuccess?.();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("flag-confirmation-done")).toBeTruthy();
+    });
+
+    fireEvent.press(screen.getByTestId("flag-confirmation-done"));
+    expect(mockBack).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows inline error when backend returns an error", async () => {
+    mockFlagStudent.mockRejectedValue(new Error("Something went wrong"));
+    renderWithQuery(<FlagUserScreen />);
+
+    fireEvent.press(screen.getByTestId("reason-SPAM"));
+    fireEvent.press(screen.getByTestId("flag-submit-btn"));
+
+    flagStudentCallbacks.onError?.(new Error("Something went wrong"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("flag-submit-error")).toBeTruthy();
+    });
+  });
+
+  it("does not show confirmation when backend returns an error", async () => {
+    mockFlagStudent.mockRejectedValue(new Error("Network error"));
+    renderWithQuery(<FlagUserScreen />);
+
+    fireEvent.press(screen.getByTestId("reason-HARASSMENT"));
+    fireEvent.press(screen.getByTestId("flag-submit-btn"));
+
+    flagStudentCallbacks.onError?.(new Error("Network error"));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("flag-confirmation")).toBeNull();
+    });
+  });
+});

--- a/apps/native/app/flag-user.tsx
+++ b/apps/native/app/flag-user.tsx
@@ -2,7 +2,7 @@ import { useMutation } from "@tanstack/react-query";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { Button } from "heroui-native";
 import { useState } from "react";
-import { Alert, ScrollView, Text, TextInput, TouchableOpacity, View } from "react-native";
+import { ScrollView, Text, TextInput, TouchableOpacity, View } from "react-native";
 
 import { Container } from "@/components/container";
 import { trpc } from "@/utils/trpc";
@@ -29,24 +29,40 @@ export default function FlagUserScreen() {
   const [selectedReason, setSelectedReason] = useState<FlagReason | null>(null);
   const [detail, setDetail] = useState("");
   const [noReasonError, setNoReasonError] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
 
   const flagMutation = useMutation(
     trpc.moderation.flagStudent.mutationOptions({
       onSuccess: () => {
-        Alert.alert(
-          "Report submitted",
-          "Thank you. A Moderator will review your report.",
-        );
-        router.back();
+        setSubmitted(true);
       },
       onError: (err) => {
-        Alert.alert("Something went wrong", err.message);
+        setSubmitError(err.message);
       },
     }),
   );
 
   const detailTooLong = detail.length > DETAIL_MAX;
   const isDisabled = flagMutation.isPending || detailTooLong;
+
+  if (submitted) {
+    return (
+      <Container>
+        <View testID="flag-confirmation" className="flex-1 items-center justify-center px-8">
+          <Text className="text-foreground text-2xl font-bold mb-4 text-center">
+            Report submitted
+          </Text>
+          <Text className="text-muted-foreground text-base text-center mb-8">
+            Thank you. A Moderator will review your report.
+          </Text>
+          <Button testID="flag-confirmation-done" onPress={() => router.back()}>
+            <Button.Label>Done</Button.Label>
+          </Button>
+        </View>
+      </Container>
+    );
+  }
 
   function handleSubmit() {
     if (!selectedReason) {
@@ -128,6 +144,12 @@ export default function FlagUserScreen() {
           {detail.length}/{DETAIL_MAX}
           {detailTooLong ? " — too long" : ""}
         </Text>
+
+        {submitError && (
+          <Text testID="flag-submit-error" className="text-destructive text-sm mb-4">
+            {submitError}
+          </Text>
+        )}
 
         <Button
           testID="flag-submit-btn"


### PR DESCRIPTION
## Summary

- Replace `Alert.alert` confirmation with inline confirmation screen (`submitted` state)
- Add `submitError` state for inline error display on backend failure
- Done button on confirmation screen calls `router.back()`

## Test plan

- [x] `npx jest __tests__/flag-submission-confirm.test.tsx` — 5 tests pass
- [x] `npx jest __tests__/flag-user.test.tsx` — 5 existing tests still pass

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)