### PR TITLE
feat(moderation): Student can flag a peer

### DIFF
--- a/.wolf/anatomy.md
+++ b/.wolf/anatomy.md
@@ -1,7 +1,7 @@
 # anatomy.md
 
-> Auto-maintained by OpenWolf. Last scanned: 2026-04-13T21:18:46.871Z
-> Files: 277 tracked | Anatomy hits: 0 | Misses: 0
+> Auto-maintained by OpenWolf. Last scanned: 2026-04-13T23:08:55.195Z
+> Files: 285 tracked | Anatomy hits: 0 | Misses: 0
 
 ## ../../../../tmp/
 
@@ -25,7 +25,7 @@
 
 - `MEMORY.md` — Memory Index (~106 tok)
 - `project_epic3_loop_progress.md` — Completed (merged to main) (~838 tok)
-- `project_epic4_loop_progress.md` — Completed (~583 tok)
+- `project_epic4_loop_progress.md` — Status: COMPLETE ✅ (~477 tok)
 
 ## ./
 
@@ -311,7 +311,13 @@
 
 - `candidate-card.test.tsx` — Tests for task #122 — Send Request action on suggestion card (~830 tok)
 - `compose-ui.test.tsx` — Tests for task #143 — Build message compose UI (~947 tok)
+- `conversation-inbox.test.tsx` — Tests for task #157 — Build conversation inbox listing all open conversations (~1003 tok)
 - `device-token-registration.test.tsx` — Tests for task #130 — Push notification when MatchRequestSent fires (~722 tok)
+- `flag-user.test.tsx` — Tests for task #65 — Build flag submission UI (peer selection + reason) (~1313 tok)
+- `inbox-empty-state.test.tsx` — Tests for task #160 — Handle empty inbox state (~925 tok)
+- `inbox-sort-order.test.tsx` — Tests for task #159 — Sort conversations by most recent message activity (~1173 tok)
+- `inbox-tap-navigate.test.tsx` — Tests for task #161 — Navigate to conversation view on inbox entry tap (~787 tok)
+- `inbox-unread-indicator.test.tsx` — Tests for task #158 — Show unread message indicator per conversation entry in the inbox (~1051 tok)
 - `notification-deep-link.test.tsx` — Tests for task #132 — Deep-link notification tap to requester's full profile (~1012 tok)
 - `notification-match-accepted.test.tsx` — Tests for task #136 — "Connect Now" CTA in acceptance notification (~1085 tok)
 - `notification-match-declined.test.tsx` — Tests for task #137 — Suggestion list deep-link in decline notification (~861 tok)
@@ -321,9 +327,10 @@
 
 ## apps/native/app/
 
-- `_layout.tsx` — Stack root layout, initialRouteName=(tabs) (~1552 tok)
+- `_layout.tsx` — unstable_settings (~1581 tok)
 - `edit-profile.tsx` — LANGUAGES — uses useRouter, useQuery, useMutation (~3810 tok)
 - `enrolment.tsx` — OTP_RESEND_COOLDOWN — uses useRouter, useState, useEffect, useForm (~2699 tok)
+- `flag-user.tsx` — DETAIL_MAX (~1267 tok)
 - `index.tsx` — LANGUAGES (~5398 tok)
 - `propose-meetup.tsx` — ProposeMeetupScreen (~1591 tok)
 - `respond-meetup.tsx` — RespondMeetupScreen (~3171 tok)
@@ -332,7 +339,7 @@
 ## apps/native/app/(tabs)/
 
 - `_layout.tsx` — StyledIonicons (~401 tok)
-- `chats.tsx` — ChatsScreen (~140 tok)
+- `chats.tsx` — ChatsScreen (~575 tok)
 - `confirmed-meetups.tsx` — ConfirmedMeetupsScreen (~996 tok)
 - `profile.tsx` — ProfileScreen (~233 tok)
 - `suggestions.tsx` — APP_SHARE_URL (~2196 tok)
@@ -343,7 +350,7 @@
 
 ## apps/native/app/partner/
 
-- `[id].tsx` — PartnerProfileScreen — uses useRouter, useQuery, useMutation, useEffect (~2824 tok)
+- `[id].tsx` — PartnerProfileScreen (~2944 tok)
 
 ## apps/native/components/
 
@@ -364,7 +371,7 @@
 ## apps/native/jest-mocks/
 
 - `expo-winter.ts` — Stub for Expo 55 "winter" ESM runtime — uses import.meta which is incompatible with Jest CJS (~34 tok)
-- `heroui-native.tsx` — Minimal heroui-native mock for Jest tests. (~358 tok)
+- `heroui-native.tsx` — Minimal heroui-native mock for Jest tests. (~382 tok)
 - `react-native-reanimated.ts` — Minimal reanimated mock — avoids native binaries entirely. (~172 tok)
 - `react-native-safe-area-context.ts` — Stub for react-native-safe-area-context in tests (~81 tok)
 - `react-native-worklets.ts` — Stub for react-native-worklets — native binaries not available in jest environment (~31 tok)
@@ -488,14 +495,15 @@
 
 ## packages/api/src/routers/
 
-- `chat.ts` — tRPC router: 6 procedures (~2592 tok)
-- `index.ts` — tRPC router: 2 procedures (~243 tok)
+- `chat.ts` — Exports chatRouter (~2894 tok)
+- `index.ts` — tRPC router: 2 procedures (~266 tok)
 - `matching-utils.ts` — Haversine distance in km between two lat/lng points (~1049 tok)
 - `matching.ts` — tRPC router: 5 procedures (~4728 tok)
 - `meetup.ts` — All bookable half-hour slots from 08:00 to 20:00 (~10102 tok)
 - `messaging-persist.ts` — #145 — Persistence helpers for the messaging send flow. (~216 tok)
 - `messaging-utils.ts` — Pure helpers for the messaging opt-in router. (~891 tok)
 - `messaging.ts` — #139 — Record a Student's accept/decline response to the messaging opt-in prompt. (~2346 tok)
+- `moderation.ts` — #65 — Flag submission UI stub. (~284 tok)
 - `profile.ts` — tRPC router: 6 procedures (~4644 tok)
 - `venue-admin.ts` — Exports adminVenueRouter (~1166 tok)
 - `venue.ts` — Zod schemas: venueTagEnum (~1054 tok)

--- a/.wolf/buglog.json
+++ b/.wolf/buglog.json
@@ -1794,6 +1794,86 @@
       "related_bugs": [],
       "occurrences": 1,
       "last_seen": "2026-04-13T20:13:21.719Z"
+    },
+    {
+      "id": "bug-112",
+      "timestamp": "2026-04-13T22:21:33.861Z",
+      "error_message": "CSS fix: item",
+      "file": "apps/native/__tests__/conversation-inbox.test.tsx",
+      "root_cause": "item: unknown → unknown, index: number) => renderItem({ item, index",
+      "fix": "Changed item: unknown → unknown, index: number) => renderItem({ item, index",
+      "tags": [
+        "auto-detected",
+        "style-fix",
+        "tsx"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-04-13T22:21:33.861Z"
+    },
+    {
+      "id": "bug-113",
+      "timestamp": "2026-04-13T22:21:55.840Z",
+      "error_message": "Significant refactor of ",
+      "file": "apps/native/__tests__/conversation-inbox.test.tsx",
+      "root_cause": "2 lines replaced/restructured",
+      "fix": "Rewrote 4→3 lines (2 removed)",
+      "tags": [
+        "auto-detected",
+        "refactor",
+        "tsx"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-04-13T22:21:55.840Z"
+    },
+    {
+      "id": "bug-114",
+      "timestamp": "2026-04-13T22:56:35.933Z",
+      "error_message": "Incorrect value in code",
+      "file": "apps/native/app/_layout.tsx",
+      "root_cause": "Had \"modal\"",
+      "fix": "Changed to \"flag-user\"",
+      "tags": [
+        "auto-detected",
+        "wrong-value",
+        "tsx"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-04-13T22:56:35.933Z"
+    },
+    {
+      "id": "bug-115",
+      "timestamp": "2026-04-13T22:58:17.436Z",
+      "error_message": "Significant refactor of ",
+      "file": "apps/native/app/flag-user.tsx",
+      "root_cause": "2 lines replaced/restructured",
+      "fix": "Rewrote 7→14 lines (2 removed)",
+      "tags": [
+        "auto-detected",
+        "refactor",
+        "tsx"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-04-13T22:58:17.436Z"
+    },
+    {
+      "id": "bug-116",
+      "timestamp": "2026-04-13T23:08:46.611Z",
+      "error_message": "Null/undefined access in ",
+      "file": "apps/native/jest-mocks/heroui-native.tsx",
+      "root_cause": "Property access on potentially null/undefined value",
+      "fix": "Added null safety (optional chaining or null check)",
+      "tags": [
+        "auto-detected",
+        "null-safety",
+        "tsx"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-04-13T23:08:46.611Z"
     }
   ]
 }

--- a/.wolf/cron-state.json
+++ b/.wolf/cron-state.json
@@ -1,5 +1,5 @@
 {
-  "last_heartbeat": "2026-04-13T19:59:08.128Z",
+  "last_heartbeat": "2026-04-13T22:59:08.212Z",
   "engine_status": "running",
   "execution_log": [
     {

--- a/.wolf/hooks/_session.json
+++ b/.wolf/hooks/_session.json
@@ -1,17 +1,11 @@
 {
-  "session_id": "session-2026-04-13-2322",
-  "started": "2026-04-13T21:22:21.892Z",
-  "files_read": {
-    "/Users/sander/.claude/projects/-Users-sander-personal-sip-and-speak/memory/project_epic4_loop_progress.md": {
-      "count": 1,
-      "tokens": 0,
-      "first_read": "2026-04-13T21:22:30.549Z"
-    }
-  },
+  "session_id": "session-2026-04-13-0109",
+  "started": "2026-04-13T23:09:40.469Z",
+  "files_read": {},
   "files_written": [],
   "edit_counts": {},
   "anatomy_hits": 0,
-  "anatomy_misses": 1,
+  "anatomy_misses": 0,
   "repeated_reads_warned": 0,
   "cerebrum_warnings": 0,
   "stop_count": 0

--- a/.wolf/memory.md
+++ b/.wolf/memory.md
@@ -673,3 +673,38 @@
 
 | Time | Action | File(s) | Outcome | ~Tokens |
 |------|--------|---------|---------|--------|
+| 00:20 | Edited packages/api/src/routers/chat.ts | 13→16 lines | ~136 |
+| 00:20 | Created apps/native/app/(tabs)/chats.tsx | — | ~574 |
+| 00:21 | Created apps/native/__tests__/conversation-inbox.test.tsx | — | ~1052 |
+| 00:21 | Edited apps/native/__tests__/conversation-inbox.test.tsx | CSS: props | ~137 |
+| 00:21 | Edited apps/native/__tests__/conversation-inbox.test.tsx | 4→3 lines | ~38 |
+| 00:21 | Edited apps/native/__tests__/conversation-inbox.test.tsx | inline fix | ~18 |
+| 00:28 | Created apps/native/__tests__/inbox-unread-indicator.test.tsx | — | ~1051 |
+| 00:29 | Created apps/native/__tests__/inbox-sort-order.test.tsx | — | ~1173 |
+| 00:29 | Edited apps/native/app/(tabs)/chats.tsx | 4→4 lines | ~77 |
+| 00:29 | Created apps/native/__tests__/inbox-empty-state.test.tsx | — | ~925 |
+| 00:30 | Created apps/native/__tests__/inbox-tap-navigate.test.tsx | — | ~787 |
+| 00:36 | Created ../../.claude/projects/-Users-sander-personal-sip-and-speak/memory/project_epic4_loop_progress.md | — | ~509 |
+| $(date +%H:%M) | Epic #4 complete — Feature #28 (PR #240) and Feature #29 (PR #246) merged to main. All 5 tasks + Epic closed. | apps/native, packages/api, apps/server | ✅ |
+| 00:36 | Session end: 12 writes across 8 files (chat.ts, chats.tsx, conversation-inbox.test.tsx, inbox-unread-indicator.test.tsx, inbox-sort-order.test.tsx) | 6 reads | ~14173 tok |
+
+## Session: 2026-04-13 00:40
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+| 00:55 | Created packages/api/src/routers/moderation.ts | — | ~284 |
+| 00:55 | Edited packages/api/src/routers/index.ts | added 1 import(s) | ~121 |
+| 00:55 | Edited packages/api/src/routers/index.ts | 2→3 lines | ~19 |
+| 00:56 | Created apps/native/__tests__/flag-user.test.tsx | — | ~1333 |
+| 00:56 | Created apps/native/app/flag-user.tsx | — | ~1241 |
+| 00:56 | Edited apps/native/app/_layout.tsx | 1→2 lines | ~54 |
+| 00:56 | Edited apps/native/app/partner/[id].tsx | expanded (+14 lines) | ~133 |
+| 00:58 | Edited apps/native/app/flag-user.tsx | expanded (+7 lines) | ~106 |
+| 01:08 | Edited apps/native/jest-mocks/heroui-native.tsx | added nullish coalescing | ~63 |
+| 01:08 | Edited apps/native/__tests__/flag-user.test.tsx | reduced (-6 lines) | ~24 |
+| 01:08 | Edited apps/native/__tests__/flag-user.test.tsx | 1→4 lines | ~41 |
+
+## Session: 2026-04-13 01:09
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|

--- a/.wolf/token-ledger.json
+++ b/.wolf/token-ledger.json
@@ -2,14 +2,14 @@
   "version": 1,
   "created_at": "2026-04-10T10:02:44.507Z",
   "lifetime": {
-    "total_tokens_estimated": 758409,
-    "total_reads": 452,
-    "total_writes": 674,
-    "total_sessions": 40,
-    "anatomy_hits": 357,
-    "anatomy_misses": 95,
-    "repeated_reads_blocked": 116,
-    "estimated_savings_vs_bare_cli": 417363
+    "total_tokens_estimated": 772582,
+    "total_reads": 458,
+    "total_writes": 686,
+    "total_sessions": 42,
+    "anatomy_hits": 361,
+    "anatomy_misses": 97,
+    "repeated_reads_blocked": 118,
+    "estimated_savings_vs_bare_cli": 418737
   },
   "sessions": [
     {
@@ -7040,6 +7040,119 @@
         "writes_count": 1,
         "repeated_reads_blocked": 0,
         "anatomy_lookups": 0
+      }
+    },
+    {
+      "id": "session-2026-04-13-2322",
+      "started": "2026-04-13T21:22:21.892Z",
+      "ended": "2026-04-13T22:36:54.404Z",
+      "reads": [
+        {
+          "file": "/Users/sander/.claude/projects/-Users-sander-personal-sip-and-speak/memory/project_epic4_loop_progress.md",
+          "tokens_estimated": 0,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/packages/api/src/routers/chat.ts",
+          "tokens_estimated": 2592,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/apps/native/app/(tabs)/chats.tsx",
+          "tokens_estimated": 574,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/packages/db/src/schema/sip-and-speak.ts",
+          "tokens_estimated": 4170,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/apps/native/__tests__/conversation-history.test.tsx",
+          "tokens_estimated": 0,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/apps/native/jest.config.ts",
+          "tokens_estimated": 324,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        }
+      ],
+      "writes": [
+        {
+          "file": "/Users/sander/personal/sip-and-speak/packages/api/src/routers/chat.ts",
+          "tokens_estimated": 136,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/apps/native/app/(tabs)/chats.tsx",
+          "tokens_estimated": 574,
+          "action": "create"
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/apps/native/__tests__/conversation-inbox.test.tsx",
+          "tokens_estimated": 1052,
+          "action": "create"
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/apps/native/__tests__/conversation-inbox.test.tsx",
+          "tokens_estimated": 137,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/apps/native/__tests__/conversation-inbox.test.tsx",
+          "tokens_estimated": 38,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/apps/native/__tests__/conversation-inbox.test.tsx",
+          "tokens_estimated": 18,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/apps/native/__tests__/inbox-unread-indicator.test.tsx",
+          "tokens_estimated": 1051,
+          "action": "create"
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/apps/native/__tests__/inbox-sort-order.test.tsx",
+          "tokens_estimated": 1173,
+          "action": "create"
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/apps/native/app/(tabs)/chats.tsx",
+          "tokens_estimated": 77,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/apps/native/__tests__/inbox-empty-state.test.tsx",
+          "tokens_estimated": 925,
+          "action": "create"
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/apps/native/__tests__/inbox-tap-navigate.test.tsx",
+          "tokens_estimated": 787,
+          "action": "create"
+        },
+        {
+          "file": "/Users/sander/.claude/projects/-Users-sander-personal-sip-and-speak/memory/project_epic4_loop_progress.md",
+          "tokens_estimated": 545,
+          "action": "create"
+        }
+      ],
+      "totals": {
+        "input_tokens_estimated": 7660,
+        "output_tokens_estimated": 6513,
+        "reads_count": 6,
+        "writes_count": 12,
+        "repeated_reads_blocked": 2,
+        "anatomy_lookups": 4
       }
     }
   ],

--- a/apps/native/__tests__/flag-submission-confirm.test.tsx
+++ b/apps/native/__tests__/flag-submission-confirm.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * Tests for task #74 — Confirm flag submission to the flagging Student
+ *
+ * Covers:
+ *   - Successful submission → confirmation screen shown (not the form)
+ *   - Confirmation screen contains "Moderator will review" message
+ *   - Done button on confirmation screen calls router.back()
+ *   - Backend error → inline error message shown (not confirmation)
+ *   - Backend error → confirmation screen NOT shown
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react-native";
+import React from "react";
+
+// ── Router mock ───────────────────────────────────────────────────────────────
+
+const mockBack = jest.fn();
+jest.mock("expo-router", () => ({
+  useLocalSearchParams: () => ({ targetId: "user-2", targetName: "Alice" }),
+  useRouter: () => ({ back: mockBack }),
+}));
+
+// ── tRPC / query mock ─────────────────────────────────────────────────────────
+
+const mockFlagStudent = jest.fn();
+let flagStudentCallbacks: { onSuccess?: () => void; onError?: (e: Error) => void } = {};
+
+jest.mock("@/utils/trpc", () => ({
+  trpc: {
+    moderation: {
+      flagStudent: {
+        mutationOptions: (opts: { onSuccess?: () => void; onError?: (e: Error) => void }) => {
+          flagStudentCallbacks = opts ?? {};
+          return {
+            mutationFn: mockFlagStudent,
+            onSuccess: opts?.onSuccess,
+            onError: opts?.onError,
+          };
+        },
+      },
+    },
+  },
+  queryClient: { invalidateQueries: jest.fn() },
+}));
+
+import FlagUserScreen from "../app/flag-user";
+
+function renderWithQuery(ui: React.ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+}
+
+beforeEach(() => {
+  mockFlagStudent.mockReset();
+  mockBack.mockReset();
+  flagStudentCallbacks = {};
+});
+
+// ── #74: Confirmation screen scenarios ────────────────────────────────────────
+
+describe("#74 — Flag submission confirmation", () => {
+  it("shows confirmation screen after successful submission", async () => {
+    mockFlagStudent.mockResolvedValue({ ok: true });
+    renderWithQuery(<FlagUserScreen />);
+
+    fireEvent.press(screen.getByTestId("reason-HARASSMENT"));
+    fireEvent.press(screen.getByTestId("flag-submit-btn"));
+
+    await waitFor(() => {
+      expect(flagStudentCallbacks.onSuccess).toBeDefined();
+    });
+    flagStudentCallbacks.onSuccess?.();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("flag-confirmation")).toBeTruthy();
+    });
+  });
+
+  it("confirmation message informs Student that Moderator will review", async () => {
+    mockFlagStudent.mockResolvedValue({ ok: true });
+    renderWithQuery(<FlagUserScreen />);
+
+    fireEvent.press(screen.getByTestId("reason-SPAM"));
+    fireEvent.press(screen.getByTestId("flag-submit-btn"));
+
+    flagStudentCallbacks.onSuccess?.();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Moderator will review/i)).toBeTruthy();
+    });
+  });
+
+  it("Done button on confirmation screen calls router.back()", async () => {
+    mockFlagStudent.mockResolvedValue({ ok: true });
+    renderWithQuery(<FlagUserScreen />);
+
+    fireEvent.press(screen.getByTestId("reason-OTHER"));
+    fireEvent.press(screen.getByTestId("flag-submit-btn"));
+
+    flagStudentCallbacks.onSuccess?.();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("flag-confirmation-done")).toBeTruthy();
+    });
+
+    fireEvent.press(screen.getByTestId("flag-confirmation-done"));
+    expect(mockBack).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows inline error when backend returns an error", async () => {
+    mockFlagStudent.mockRejectedValue(new Error("Something went wrong"));
+    renderWithQuery(<FlagUserScreen />);
+
+    fireEvent.press(screen.getByTestId("reason-SPAM"));
+    fireEvent.press(screen.getByTestId("flag-submit-btn"));
+
+    flagStudentCallbacks.onError?.(new Error("Something went wrong"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("flag-submit-error")).toBeTruthy();
+    });
+  });
+
+  it("does not show confirmation when backend returns an error", async () => {
+    mockFlagStudent.mockRejectedValue(new Error("Network error"));
+    renderWithQuery(<FlagUserScreen />);
+
+    fireEvent.press(screen.getByTestId("reason-HARASSMENT"));
+    fireEvent.press(screen.getByTestId("flag-submit-btn"));
+
+    flagStudentCallbacks.onError?.(new Error("Network error"));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("flag-confirmation")).toBeNull();
+    });
+  });
+});

--- a/apps/native/__tests__/flag-user.test.tsx
+++ b/apps/native/__tests__/flag-user.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * Tests for task #65 — Build flag submission UI (peer selection + reason)
+ *
+ * Covers:
+ *   - Student selects a predefined reason and submits → mutation called with correct args
+ *   - Student adds free-text detail alongside reason → mutation called with detail
+ *   - Student taps Submit with no reason → blocked + inline validation error shown
+ *   - Free-text detail exceeds 450 chars → character count warning + Submit disabled
+ *   - Submission is in-flight → Submit button disabled
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react-native";
+import React from "react";
+
+// ── Router mock ───────────────────────────────────────────────────────────────
+
+jest.mock("expo-router", () => ({
+  useLocalSearchParams: () => ({ targetId: "user-2", targetName: "Alice" }),
+  useRouter: () => ({ back: jest.fn() }),
+}));
+
+// ── tRPC / query mock ─────────────────────────────────────────────────────────
+
+const mockFlagStudent = jest.fn();
+let flagStudentCallbacks: { onSuccess?: () => void; onError?: (e: Error) => void } = {};
+
+jest.mock("@/utils/trpc", () => ({
+  trpc: {
+    moderation: {
+      flagStudent: {
+        mutationOptions: (opts: { onSuccess?: () => void; onError?: (e: Error) => void }) => {
+          flagStudentCallbacks = opts ?? {};
+          return {
+            mutationFn: mockFlagStudent,
+            onSuccess: opts?.onSuccess,
+            onError: opts?.onError,
+          };
+        },
+      },
+    },
+  },
+  queryClient: { invalidateQueries: jest.fn() },
+}));
+
+import { Alert } from "react-native";
+import FlagUserScreen from "../app/flag-user";
+
+jest.spyOn(Alert, "alert").mockImplementation(() => {});
+
+function renderWithQuery(ui: React.ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+}
+
+beforeEach(() => {
+  mockFlagStudent.mockReset();
+  flagStudentCallbacks = {};
+});
+
+// ── #65: Flag submission UI scenarios ─────────────────────────────────────────
+
+describe("#65 — Flag submission UI", () => {
+  it("calls mutation with targetId and selected reason on submit", async () => {
+    mockFlagStudent.mockResolvedValue({ ok: true });
+    renderWithQuery(<FlagUserScreen />);
+
+    fireEvent.press(screen.getByTestId("reason-HARASSMENT"));
+    fireEvent.press(screen.getByTestId("flag-submit-btn"));
+
+    await waitFor(() => {
+      expect(mockFlagStudent).toHaveBeenCalledWith(
+        expect.objectContaining({ targetId: "user-2", reason: "HARASSMENT" }),
+        expect.anything(),
+      );
+    });
+  });
+
+  it("includes free-text detail in mutation when provided", async () => {
+    mockFlagStudent.mockResolvedValue({ ok: true });
+    renderWithQuery(<FlagUserScreen />);
+
+    fireEvent.press(screen.getByTestId("reason-SPAM"));
+    fireEvent.changeText(screen.getByTestId("flag-detail-input"), "They kept sending irrelevant links.");
+    fireEvent.press(screen.getByTestId("flag-submit-btn"));
+
+    await waitFor(() => {
+      expect(mockFlagStudent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          targetId: "user-2",
+          reason: "SPAM",
+          detail: "They kept sending irrelevant links.",
+        }),
+        expect.anything(),
+      );
+    });
+  });
+
+  it("blocks submission and shows validation error when no reason is selected", () => {
+    renderWithQuery(<FlagUserScreen />);
+
+    fireEvent.press(screen.getByTestId("flag-submit-btn"));
+
+    expect(mockFlagStudent).not.toHaveBeenCalled();
+    expect(screen.getByTestId("no-reason-error")).toBeTruthy();
+  });
+
+  it("shows character count warning and disables Submit when detail exceeds 450 chars", () => {
+    renderWithQuery(<FlagUserScreen />);
+
+    fireEvent.changeText(screen.getByTestId("flag-detail-input"), "a".repeat(451));
+
+    expect(screen.getByTestId("char-count-warning")).toBeTruthy();
+    const btn = screen.getByTestId("flag-submit-btn");
+    expect(btn.props.accessibilityState?.disabled).toBe(true);
+  });
+
+  it("disables Submit button while mutation is in-flight", async () => {
+    mockFlagStudent.mockReturnValue(new Promise(() => {}));
+    renderWithQuery(<FlagUserScreen />);
+
+    fireEvent.press(screen.getByTestId("reason-OFFENSIVE_LANGUAGE"));
+    fireEvent.press(screen.getByTestId("flag-submit-btn"));
+
+    await waitFor(() => {
+      const btn = screen.getByTestId("flag-submit-btn");
+      expect(btn.props.accessibilityState?.disabled).toBe(true);
+    });
+  });
+});

--- a/apps/native/app/_layout.tsx
+++ b/apps/native/app/_layout.tsx
@@ -117,6 +117,7 @@ function StackLayout() {
       <Stack.Screen name="chat/[conversationId]" options={{ title: "Chat" }} />
       <Stack.Screen name="map" options={{ title: "Campus Map" }} />
       <Stack.Screen name="respond-meetup" options={{ title: "Respond to Proposal" }} />
+      <Stack.Screen name="flag-user" options={{ title: "Report Student", presentation: "modal" }} />
       <Stack.Screen name="modal" options={{ title: "Modal", presentation: "modal" }} />
     </Stack>
   );

--- a/apps/native/app/flag-user.tsx
+++ b/apps/native/app/flag-user.tsx
@@ -1,0 +1,144 @@
+import { useMutation } from "@tanstack/react-query";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { Button } from "heroui-native";
+import { useState } from "react";
+import { Alert, ScrollView, Text, TextInput, TouchableOpacity, View } from "react-native";
+
+import { Container } from "@/components/container";
+import { trpc } from "@/utils/trpc";
+
+const DETAIL_MAX = 450;
+
+const REASONS = [
+  ["OFFENSIVE_LANGUAGE", "Offensive language"],
+  ["HARASSMENT", "Harassment"],
+  ["SPAM", "Spam"],
+  ["INAPPROPRIATE_BEHAVIOR", "Inappropriate behaviour"],
+  ["OTHER", "Other"],
+] as const;
+
+type FlagReason = (typeof REASONS)[number][0];
+
+export default function FlagUserScreen() {
+  const { targetId, targetName } = useLocalSearchParams<{
+    targetId: string;
+    targetName: string;
+  }>();
+  const router = useRouter();
+
+  const [selectedReason, setSelectedReason] = useState<FlagReason | null>(null);
+  const [detail, setDetail] = useState("");
+  const [noReasonError, setNoReasonError] = useState(false);
+
+  const flagMutation = useMutation(
+    trpc.moderation.flagStudent.mutationOptions({
+      onSuccess: () => {
+        Alert.alert(
+          "Report submitted",
+          "Thank you. A Moderator will review your report.",
+        );
+        router.back();
+      },
+      onError: (err) => {
+        Alert.alert("Something went wrong", err.message);
+      },
+    }),
+  );
+
+  const detailTooLong = detail.length > DETAIL_MAX;
+  const isDisabled = flagMutation.isPending || detailTooLong;
+
+  function handleSubmit() {
+    if (!selectedReason) {
+      setNoReasonError(true);
+      return;
+    }
+    setNoReasonError(false);
+    if (!targetId) return;
+    flagMutation.mutate({
+      targetId,
+      reason: selectedReason,
+      detail: detail.trim() || undefined,
+    });
+  }
+
+  return (
+    <Container>
+      <ScrollView contentContainerStyle={{ padding: 16 }}>
+        <Text className="text-foreground text-2xl font-bold mb-2">
+          Report {targetName ?? "Student"}
+        </Text>
+        <Text className="text-muted-foreground text-sm mb-6">
+          Select a reason for reporting this Student. A Moderator will review your report.
+        </Text>
+
+        <Text className="text-foreground font-semibold mb-3">Reason</Text>
+        <View className="flex flex-col gap-2 mb-4">
+          {REASONS.map(([key, label]) => (
+            <TouchableOpacity
+              key={key}
+              testID={`reason-${key}`}
+              onPress={() => {
+                setSelectedReason(key);
+                setNoReasonError(false);
+              }}
+              className={`border rounded-xl p-3 ${
+                selectedReason === key
+                  ? "border-primary bg-primary/10"
+                  : "border-border bg-card"
+              }`}
+            >
+              <Text
+                className={`font-medium ${
+                  selectedReason === key ? "text-primary" : "text-foreground"
+                }`}
+              >
+                {label}
+              </Text>
+            </TouchableOpacity>
+          ))}
+        </View>
+
+        {noReasonError && (
+          <Text testID="no-reason-error" className="text-destructive text-sm mb-4">
+            Please select a reason before submitting.
+          </Text>
+        )}
+
+        <Text className="text-foreground font-semibold mb-2">
+          Additional detail (optional)
+        </Text>
+        <TextInput
+          testID="flag-detail-input"
+          value={detail}
+          onChangeText={setDetail}
+          placeholder="Describe what happened…"
+          multiline
+          numberOfLines={4}
+          maxLength={DETAIL_MAX + 10}
+          className="border border-border rounded-xl px-3 py-2 text-foreground bg-card mb-1"
+          placeholderTextColor="#888"
+        />
+        <Text
+          testID={detailTooLong ? "char-count-warning" : "char-count"}
+          className={`text-xs mb-4 text-right ${
+            detailTooLong ? "text-destructive" : "text-muted-foreground"
+          }`}
+        >
+          {detail.length}/{DETAIL_MAX}
+          {detailTooLong ? " — too long" : ""}
+        </Text>
+
+        <Button
+          testID="flag-submit-btn"
+          onPress={handleSubmit}
+          isDisabled={isDisabled}
+        >
+          <Button.Label>
+            {flagMutation.isPending ? "Submitting…" : "Submit report"}
+          </Button.Label>
+        </Button>
+      </ScrollView>
+    </Container>
+  );
+}

--- a/apps/native/app/flag-user.tsx
+++ b/apps/native/app/flag-user.tsx
@@ -2,7 +2,7 @@ import { useMutation } from "@tanstack/react-query";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { Button } from "heroui-native";
 import { useState } from "react";
-import { Alert, ScrollView, Text, TextInput, TouchableOpacity, View } from "react-native";
+import { ScrollView, Text, TextInput, TouchableOpacity, View } from "react-native";
 
 import { Container } from "@/components/container";
 import { trpc } from "@/utils/trpc";
@@ -29,24 +29,40 @@ export default function FlagUserScreen() {
   const [selectedReason, setSelectedReason] = useState<FlagReason | null>(null);
   const [detail, setDetail] = useState("");
   const [noReasonError, setNoReasonError] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
 
   const flagMutation = useMutation(
     trpc.moderation.flagStudent.mutationOptions({
       onSuccess: () => {
-        Alert.alert(
-          "Report submitted",
-          "Thank you. A Moderator will review your report.",
-        );
-        router.back();
+        setSubmitted(true);
       },
       onError: (err) => {
-        Alert.alert("Something went wrong", err.message);
+        setSubmitError(err.message);
       },
     }),
   );
 
   const detailTooLong = detail.length > DETAIL_MAX;
   const isDisabled = flagMutation.isPending || detailTooLong;
+
+  if (submitted) {
+    return (
+      <Container>
+        <View testID="flag-confirmation" className="flex-1 items-center justify-center px-8">
+          <Text className="text-foreground text-2xl font-bold mb-4 text-center">
+            Report submitted
+          </Text>
+          <Text className="text-muted-foreground text-base text-center mb-8">
+            Thank you. A Moderator will review your report.
+          </Text>
+          <Button testID="flag-confirmation-done" onPress={() => router.back()}>
+            <Button.Label>Done</Button.Label>
+          </Button>
+        </View>
+      </Container>
+    );
+  }
 
   function handleSubmit() {
     if (!selectedReason) {
@@ -128,6 +144,12 @@ export default function FlagUserScreen() {
           {detail.length}/{DETAIL_MAX}
           {detailTooLong ? " — too long" : ""}
         </Text>
+
+        {submitError && (
+          <Text testID="flag-submit-error" className="text-destructive text-sm mb-4">
+            {submitError}
+          </Text>
+        )}
 
         <Button
           testID="flag-submit-btn"

--- a/apps/native/app/partner/[id].tsx
+++ b/apps/native/app/partner/[id].tsx
@@ -263,6 +263,20 @@ export default function PartnerProfileScreen() {
             </Button>
           )
         )}
+        {/* #65 — Report / flag this Student */}
+        <Button
+          testID="report-student-btn"
+          variant="ghost"
+          className="mb-2"
+          onPress={() =>
+            router.push({
+              pathname: "/flag-user",
+              params: { targetId: id, targetName: profile.name },
+            })
+          }
+        >
+          <Button.Label>Report Student</Button.Label>
+        </Button>
       </ScrollView>
     </Container>
   );

--- a/apps/native/jest-mocks/heroui-native.tsx
+++ b/apps/native/jest-mocks/heroui-native.tsx
@@ -13,7 +13,12 @@ function Button({ children, onPress, isDisabled, testID, ...rest }: {
   [key: string]: unknown;
 }) {
   return (
-    <Pressable testID={testID} onPress={!isDisabled ? onPress : undefined} {...rest}>
+    <Pressable
+      testID={testID}
+      onPress={!isDisabled ? onPress : undefined}
+      accessibilityState={{ disabled: isDisabled ?? false }}
+      {...rest}
+    >
       {children}
     </Pressable>
   );

--- a/packages/api/src/__tests__/moderation-persist.test.ts
+++ b/packages/api/src/__tests__/moderation-persist.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Tests for task #72 — Persist flag and add to Moderator review queue
+ *
+ * Covers pure helpers — no DB interaction.
+ *
+ *   - buildFlagValues: produces correct payload with status 'open'
+ *   - buildFlagValues: optional detail is omitted when not provided
+ *   - buildStudentFlaggedEvent: maps persisted flag fields to domain event payload
+ */
+import { describe, it, expect } from "bun:test";
+
+import {
+  buildFlagValues,
+  buildStudentFlaggedEvent,
+} from "../routers/moderation-utils";
+
+describe("#72 — buildFlagValues", () => {
+  it("returns correct payload with status 'open'", () => {
+    const result = buildFlagValues({
+      reporterId: "user-1",
+      targetId: "user-2",
+      reason: "HARASSMENT",
+      detail: "They sent threatening messages.",
+    });
+
+    expect(result).toEqual({
+      reporterId: "user-1",
+      targetId: "user-2",
+      reason: "HARASSMENT",
+      detail: "They sent threatening messages.",
+      status: "open",
+    });
+  });
+
+  it("status is always 'open' regardless of input", () => {
+    const result = buildFlagValues({
+      reporterId: "user-1",
+      targetId: "user-2",
+      reason: "SPAM",
+    });
+
+    expect(result.status).toBe("open");
+  });
+
+  it("detail is undefined when not provided", () => {
+    const result = buildFlagValues({
+      reporterId: "user-1",
+      targetId: "user-2",
+      reason: "OTHER",
+    });
+
+    expect(result.detail).toBeUndefined();
+  });
+});
+
+describe("#72 — buildStudentFlaggedEvent", () => {
+  it("maps flag row to correct domain event payload", () => {
+    const flaggedAt = new Date("2026-04-14T10:00:00Z");
+
+    const result = buildStudentFlaggedEvent(
+      "flag-abc",
+      { reporterId: "user-1", targetId: "user-2", reason: "OFFENSIVE_LANGUAGE" },
+      flaggedAt,
+    );
+
+    expect(result).toEqual({
+      flagId: "flag-abc",
+      reporterId: "user-1",
+      targetId: "user-2",
+      reason: "OFFENSIVE_LANGUAGE",
+      flaggedAt,
+    });
+  });
+});

--- a/packages/api/src/__tests__/moderation-validation.test.ts
+++ b/packages/api/src/__tests__/moderation-validation.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Tests for task #67 — Validate flag (no self-flagging, no duplicate open flag)
+ *
+ * Covers:
+ *   - Self-flag rejected
+ *   - Duplicate open flag rejected
+ *   - Valid flag (different users, no existing open flag) passes
+ *   - Rapid duplicate submissions: second request sees count > 0 → rejected
+ *   - Resolved flag does not block new flag (count = 0)
+ */
+import { describe, it, expect } from "bun:test";
+
+import {
+  checkSelfFlag,
+  checkDuplicateOpenFlag,
+  FLAG_VALIDATION_MESSAGES,
+} from "../routers/moderation-utils";
+
+describe("#67 — checkSelfFlag", () => {
+  it("rejects flag where reporter and target are the same user", () => {
+    const result = checkSelfFlag("user-a", "user-a");
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.error).toBe("SELF_FLAG");
+  });
+
+  it("accepts flag where reporter and target are different users", () => {
+    const result = checkSelfFlag("user-a", "user-b");
+    expect(result.valid).toBe(true);
+  });
+
+  it("SELF_FLAG message does not expose internal state", () => {
+    expect(FLAG_VALIDATION_MESSAGES.SELF_FLAG).toBeTruthy();
+    expect(FLAG_VALIDATION_MESSAGES.SELF_FLAG).not.toContain("user_flag");
+    expect(FLAG_VALIDATION_MESSAGES.SELF_FLAG).not.toContain("database");
+  });
+});
+
+describe("#67 — checkDuplicateOpenFlag", () => {
+  it("rejects when an open flag already exists (count = 1)", () => {
+    const result = checkDuplicateOpenFlag(1);
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.error).toBe("DUPLICATE_OPEN_FLAG");
+  });
+
+  it("rejects rapid duplicate (count > 1 from concurrent inserts)", () => {
+    const result = checkDuplicateOpenFlag(2);
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.error).toBe("DUPLICATE_OPEN_FLAG");
+  });
+
+  it("accepts when no open flag exists (count = 0)", () => {
+    const result = checkDuplicateOpenFlag(0);
+    expect(result.valid).toBe(true);
+  });
+
+  it("accepts when prior flag is resolved (count = 0 because only open flags are counted)", () => {
+    // Caller filters by status = 'open' — resolved flags yield count = 0
+    const result = checkDuplicateOpenFlag(0);
+    expect(result.valid).toBe(true);
+  });
+
+  it("DUPLICATE_OPEN_FLAG message does not expose internal state", () => {
+    expect(FLAG_VALIDATION_MESSAGES.DUPLICATE_OPEN_FLAG).toBeTruthy();
+    expect(FLAG_VALIDATION_MESSAGES.DUPLICATE_OPEN_FLAG).not.toContain("user_flag");
+    expect(FLAG_VALIDATION_MESSAGES.DUPLICATE_OPEN_FLAG).not.toContain("database");
+  });
+});

--- a/packages/api/src/domain-events.ts
+++ b/packages/api/src/domain-events.ts
@@ -187,6 +187,14 @@ export interface MessageSentEvent {
   senderName: string;
 }
 
+export interface StudentFlaggedEvent {
+  flagId: string;
+  reporterId: string;
+  targetId: string;
+  reason: string;
+  flaggedAt: Date;
+}
+
 type DomainEventMap = {
   LanguageProfileUpdated: [LanguageProfileUpdatedEvent];
   InterestProfileUpdated: [InterestProfileUpdatedEvent];
@@ -212,6 +220,7 @@ type DomainEventMap = {
   ConversationOpened: [ConversationOpenedEvent];
   MessagingDeclineOutcome: [MessagingDeclineOutcomeEvent];
   MessageSent: [MessageSentEvent];
+  StudentFlagged: [StudentFlaggedEvent];
 };
 
 class TypedEventEmitter extends EventEmitter {

--- a/packages/api/src/routers/index.ts
+++ b/packages/api/src/routers/index.ts
@@ -6,6 +6,7 @@ import { adminVenueRouter } from "./venue-admin";
 import { meetupRouter } from "./meetup";
 import { chatRouter } from "./chat";
 import { messagingRouter } from "./messaging";
+import { moderationRouter } from "./moderation";
 
 export const appRouter = router({
   healthCheck: publicProcedure.query(() => {
@@ -24,5 +25,6 @@ export const appRouter = router({
   meetup: meetupRouter,
   chat: chatRouter,
   messaging: messagingRouter,
+  moderation: moderationRouter,
 });
 export type AppRouter = typeof appRouter;

--- a/packages/api/src/routers/moderation-persist.ts
+++ b/packages/api/src/routers/moderation-persist.ts
@@ -1,0 +1,27 @@
+/**
+ * #72 — Persistence helpers for the flag submission flow.
+ * Extracted for unit testing without requiring a live tRPC context.
+ */
+import { db } from "@sip-and-speak/db";
+import { userFlag } from "@sip-and-speak/db/schema/sip-and-speak";
+import { buildFlagValues } from "./moderation-utils";
+
+export interface PersistFlagInput {
+  reporterId: string;
+  targetId: string;
+  reason: string;
+  detail?: string;
+}
+
+/**
+ * Inserts a flag row with status 'open' and returns the created record.
+ * Throws on DB failure — no partial record is created.
+ */
+export async function persistFlag(input: PersistFlagInput) {
+  const [created] = await db
+    .insert(userFlag)
+    .values(buildFlagValues(input))
+    .returning();
+
+  return created!;
+}

--- a/packages/api/src/routers/moderation-utils.ts
+++ b/packages/api/src/routers/moderation-utils.ts
@@ -35,3 +35,57 @@ export const FLAG_VALIDATION_MESSAGES: Record<"SELF_FLAG" | "DUPLICATE_OPEN_FLAG
   SELF_FLAG: "You cannot flag yourself.",
   DUPLICATE_OPEN_FLAG: "A report against this Student is already under review.",
 };
+
+// #72 — Pure helpers for flag persistence
+
+export interface FlagValues {
+  reporterId: string;
+  targetId: string;
+  reason: string;
+  detail: string | undefined;
+  status: "open";
+}
+
+/**
+ * Builds the DB insert payload for a new flag.
+ * Status is always 'open' on creation.
+ */
+export function buildFlagValues(input: {
+  reporterId: string;
+  targetId: string;
+  reason: string;
+  detail?: string;
+}): FlagValues {
+  return {
+    reporterId: input.reporterId,
+    targetId: input.targetId,
+    reason: input.reason,
+    detail: input.detail,
+    status: "open",
+  };
+}
+
+export interface StudentFlaggedPayload {
+  flagId: string;
+  reporterId: string;
+  targetId: string;
+  reason: string;
+  flaggedAt: Date;
+}
+
+/**
+ * Builds the StudentFlagged domain event payload from the persisted flag row.
+ */
+export function buildStudentFlaggedEvent(
+  flagId: string,
+  input: { reporterId: string; targetId: string; reason: string },
+  flaggedAt: Date,
+): StudentFlaggedPayload {
+  return {
+    flagId,
+    reporterId: input.reporterId,
+    targetId: input.targetId,
+    reason: input.reason,
+    flaggedAt,
+  };
+}

--- a/packages/api/src/routers/moderation-utils.ts
+++ b/packages/api/src/routers/moderation-utils.ts
@@ -1,0 +1,37 @@
+// #67 — Pure validation functions for flag submission
+
+export type FlagValidationError =
+  | { valid: false; error: "SELF_FLAG" }
+  | { valid: false; error: "DUPLICATE_OPEN_FLAG" }
+  | { valid: true };
+
+/**
+ * Rejects a flag where the reporter and target are the same user.
+ */
+export function checkSelfFlag(
+  reporterId: string,
+  targetId: string,
+): FlagValidationError {
+  if (reporterId === targetId) {
+    return { valid: false, error: "SELF_FLAG" };
+  }
+  return { valid: true };
+}
+
+/**
+ * Rejects a flag when an open flag already exists for the same
+ * reporter–target pair. The caller supplies the open-flag count from the DB.
+ */
+export function checkDuplicateOpenFlag(
+  openFlagCount: number,
+): FlagValidationError {
+  if (openFlagCount > 0) {
+    return { valid: false, error: "DUPLICATE_OPEN_FLAG" };
+  }
+  return { valid: true };
+}
+
+export const FLAG_VALIDATION_MESSAGES: Record<"SELF_FLAG" | "DUPLICATE_OPEN_FLAG", string> = {
+  SELF_FLAG: "You cannot flag yourself.",
+  DUPLICATE_OPEN_FLAG: "A report against this Student is already under review.",
+};

--- a/packages/api/src/routers/moderation.ts
+++ b/packages/api/src/routers/moderation.ts
@@ -9,7 +9,10 @@ import {
   checkSelfFlag,
   checkDuplicateOpenFlag,
   FLAG_VALIDATION_MESSAGES,
+  buildStudentFlaggedEvent,
 } from "./moderation-utils";
+import { persistFlag } from "./moderation-persist";
+import { domainEvents } from "../domain-events";
 
 export const flagReasonSchema = z.enum([
   "OFFENSIVE_LANGUAGE",
@@ -75,7 +78,19 @@ export const moderationRouter = router({
         });
       }
 
-      // Stub — persistence implemented in task #72
+      // #72 — Persist the flag and emit domain event
+      const flag = await persistFlag({
+        reporterId,
+        targetId: input.targetId,
+        reason: input.reason,
+        detail: input.detail,
+      });
+
+      domainEvents.emit(
+        "StudentFlagged",
+        buildStudentFlaggedEvent(flag.id, { reporterId, targetId: input.targetId, reason: input.reason }, flag.createdAt),
+      );
+
       return { ok: true as const };
     }),
 });

--- a/packages/api/src/routers/moderation.ts
+++ b/packages/api/src/routers/moderation.ts
@@ -1,6 +1,15 @@
 import { z } from "zod";
+import { TRPCError } from "@trpc/server";
+import { and, eq, count } from "drizzle-orm";
 
 import { protectedProcedure, router } from "../index";
+import { db } from "@sip-and-speak/db";
+import { userFlag } from "@sip-and-speak/db/schema/sip-and-speak";
+import {
+  checkSelfFlag,
+  checkDuplicateOpenFlag,
+  FLAG_VALIDATION_MESSAGES,
+} from "./moderation-utils";
 
 export const flagReasonSchema = z.enum([
   "OFFENSIVE_LANGUAGE",
@@ -22,8 +31,8 @@ export const flagReasonLabels: Record<FlagReason, string> = {
 
 export const moderationRouter = router({
   /**
-   * #65 — Flag submission UI stub.
-   * Validation (#67) and persistence (#72) are implemented in subsequent tasks.
+   * #65/#67 — Flag submission with validation.
+   * Persistence (#72) is implemented in a subsequent task.
    */
   flagStudent: protectedProcedure
     .input(
@@ -33,7 +42,39 @@ export const moderationRouter = router({
         detail: z.string().max(450).optional(),
       }),
     )
-    .mutation(async () => {
+    .mutation(async ({ ctx, input }) => {
+      const reporterId = ctx.session.user.id;
+
+      // #67 — Self-flag check
+      const selfCheck = checkSelfFlag(reporterId, input.targetId);
+      if (!selfCheck.valid) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: FLAG_VALIDATION_MESSAGES[selfCheck.error],
+        });
+      }
+
+      // #67 — Duplicate open flag check
+      const rows = await db
+        .select({ count: count() })
+        .from(userFlag)
+        .where(
+          and(
+            eq(userFlag.reporterId, reporterId),
+            eq(userFlag.targetId, input.targetId),
+            eq(userFlag.status, "open"),
+          ),
+        );
+
+      const openCount = rows[0]?.count ?? 0;
+      const dupCheck = checkDuplicateOpenFlag(Number(openCount));
+      if (!dupCheck.valid) {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message: FLAG_VALIDATION_MESSAGES[dupCheck.error],
+        });
+      }
+
       // Stub — persistence implemented in task #72
       return { ok: true as const };
     }),

--- a/packages/api/src/routers/moderation.ts
+++ b/packages/api/src/routers/moderation.ts
@@ -1,0 +1,40 @@
+import { z } from "zod";
+
+import { protectedProcedure, router } from "../index";
+
+export const flagReasonSchema = z.enum([
+  "OFFENSIVE_LANGUAGE",
+  "HARASSMENT",
+  "SPAM",
+  "INAPPROPRIATE_BEHAVIOR",
+  "OTHER",
+]);
+
+export type FlagReason = z.infer<typeof flagReasonSchema>;
+
+export const flagReasonLabels: Record<FlagReason, string> = {
+  OFFENSIVE_LANGUAGE: "Offensive language",
+  HARASSMENT: "Harassment",
+  SPAM: "Spam",
+  INAPPROPRIATE_BEHAVIOR: "Inappropriate behaviour",
+  OTHER: "Other",
+};
+
+export const moderationRouter = router({
+  /**
+   * #65 — Flag submission UI stub.
+   * Validation (#67) and persistence (#72) are implemented in subsequent tasks.
+   */
+  flagStudent: protectedProcedure
+    .input(
+      z.object({
+        targetId: z.string(),
+        reason: flagReasonSchema,
+        detail: z.string().max(450).optional(),
+      }),
+    )
+    .mutation(async () => {
+      // Stub — persistence implemented in task #72
+      return { ok: true as const };
+    }),
+});

--- a/packages/db/src/schema/sip-and-speak.ts
+++ b/packages/db/src/schema/sip-and-speak.ts
@@ -503,3 +503,28 @@ export const conversationPresence = pgTable(
     index("conversation_presence_studentId_idx").on(table.studentId),
   ],
 );
+
+// #67/#72 — Flag: a Student reports a peer as disruptive for Moderator review
+export const userFlag = pgTable(
+  "user_flag",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    reporterId: text("reporter_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    targetId: text("target_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    reason: text("reason").notNull(),
+    detail: text("detail"),
+    status: text("status").notNull().default("open"), // open | resolved
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+  },
+  (table) => [
+    index("user_flag_reporter_idx").on(table.reporterId),
+    index("user_flag_target_idx").on(table.targetId),
+    index("user_flag_status_idx").on(table.status),
+  ],
+);


### PR DESCRIPTION
## Summary

Implements Feature #30 — Student can flag a peer for moderation review.

- Flag submission UI with reason selection and optional free-text detail
- Backend validation: blocks self-flags and duplicate open flags
- Flag persisted to DB with status `open` and `StudentFlagged` domain event emitted
- Inline confirmation screen shown after successful submission; inline error on failure

## Tasks

- Closes #65 — Build flag submission UI (peer selection + reason)
- Closes #67 — Validate flag (no self-flagging, no duplicate open flag)
- Closes #72 — Persist flag and add to Moderator review queue
- Closes #74 — Confirm flag submission to the flagging Student
- Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)