### PR TITLE
feat(moderation): add warn action to flag detail view

### DIFF
--- a/apps/web/src/__tests__/moderator-flag-detail.test.tsx
+++ b/apps/web/src/__tests__/moderator-flag-detail.test.tsx
@@ -53,7 +53,7 @@ function FlagDetailView({
 }: {
   flag?: {
     flagId: string;
-    flaggedStudent: { id: string; name: string | null; removed: boolean };
+    flaggedStudent: { id: string; name: string | null; removed: boolean; suspended: boolean };
     reason: string;
     detail: string | null;
     submittedAt: string;
@@ -96,7 +96,10 @@ function FlagDetailView({
         )}
       </section>
 
-      <button disabled={flag.flaggedStudent.removed} data-testid="btn-warn">
+      <button
+        disabled={flag.flaggedStudent.suspended || flag.flaggedStudent.removed}
+        data-testid="btn-warn"
+      >
         Warn
       </button>
       <button disabled={flag.flaggedStudent.removed} data-testid="btn-suspend">
@@ -106,9 +109,48 @@ function FlagDetailView({
   );
 }
 
+// #88 — Warn action inline component (includes mutation state props)
+function WarnActionView({
+  flag,
+  warnPending = false,
+  warnSuccess = false,
+  onWarn,
+}: {
+  flag: {
+    flagId: string;
+    flaggedStudent: { id: string; name: string | null; removed: boolean; suspended: boolean };
+  };
+  warnPending?: boolean;
+  warnSuccess?: boolean;
+  onWarn: () => void;
+}) {
+  if (warnSuccess) {
+    return <p data-testid="warn-success">Warning issued. The flag has been resolved.</p>;
+  }
+
+  const studentDisabled = flag.flaggedStudent.suspended || flag.flaggedStudent.removed;
+  const disabledReason = flag.flaggedStudent.removed
+    ? "Student has already been removed"
+    : flag.flaggedStudent.suspended
+      ? "Student is already suspended"
+      : undefined;
+
+  return (
+    <span title={disabledReason}>
+      <button
+        data-testid="btn-warn"
+        disabled={studentDisabled || warnPending}
+        onClick={onWarn}
+      >
+        {warnPending ? "Warning…" : "Warn"}
+      </button>
+    </span>
+  );
+}
+
 const baseFlag = {
   flagId: "flag-abc",
-  flaggedStudent: { id: "user-2", name: "Jane Doe", removed: false },
+  flaggedStudent: { id: "user-2", name: "Jane Doe", removed: false, suspended: false },
   reason: "Disruptive behaviour",
   detail: "Kept interrupting",
   submittedAt: "2026-04-10T09:15:00.000Z",
@@ -162,7 +204,7 @@ describe("#80 — Flag detail view", () => {
   it("shows removed-Student notice and disables warn/suspend when removed is true", () => {
     const removedStudentFlag = {
       ...baseFlag,
-      flaggedStudent: { id: "user-2", name: null, removed: true },
+      flaggedStudent: { id: "user-2", name: null, removed: true, suspended: false },
     };
 
     render(<FlagDetailView flag={removedStudentFlag} isLoading={false} />);
@@ -178,5 +220,62 @@ describe("#80 — Flag detail view", () => {
     render(<FlagDetailView flag={baseFlag} isLoading={false} />);
 
     expect(screen.queryByTestId("removed-notice")).not.toBeInTheDocument();
+  });
+});
+
+describe("#88 — Warn action on flag detail view", () => {
+  const warnFlag = {
+    flagId: "flag-abc",
+    flaggedStudent: { id: "user-2", name: "Jane Doe", removed: false, suspended: false },
+  };
+
+  it("Warn button is visible and enabled for an active Student", () => {
+    render(<WarnActionView flag={warnFlag} onWarn={vi.fn()} />);
+
+    const btn = screen.getByTestId("btn-warn");
+    expect(btn).toBeInTheDocument();
+    expect(btn).not.toBeDisabled();
+    expect(btn).toHaveTextContent("Warn");
+  });
+
+  it("Warn button is disabled with tooltip for a suspended Student", () => {
+    const suspendedFlag = {
+      ...warnFlag,
+      flaggedStudent: { ...warnFlag.flaggedStudent, suspended: true },
+    };
+
+    render(<WarnActionView flag={suspendedFlag} onWarn={vi.fn()} />);
+
+    expect(screen.getByTestId("btn-warn")).toBeDisabled();
+    expect(screen.getByTitle("Student is already suspended")).toBeInTheDocument();
+  });
+
+  it("Warn button is disabled with tooltip for a removed Student", () => {
+    const removedFlag = {
+      ...warnFlag,
+      flaggedStudent: { ...warnFlag.flaggedStudent, removed: true },
+    };
+
+    render(<WarnActionView flag={removedFlag} onWarn={vi.fn()} />);
+
+    expect(screen.getByTestId("btn-warn")).toBeDisabled();
+    expect(screen.getByTitle("Student has already been removed")).toBeInTheDocument();
+  });
+
+  it("shows loading state while warn is pending", () => {
+    render(<WarnActionView flag={warnFlag} warnPending={true} onWarn={vi.fn()} />);
+
+    const btn = screen.getByTestId("btn-warn");
+    expect(btn).toBeDisabled();
+    expect(btn).toHaveTextContent("Warning…");
+  });
+
+  it("shows resolved confirmation on warn success", () => {
+    render(<WarnActionView flag={warnFlag} warnSuccess={true} onWarn={vi.fn()} />);
+
+    expect(screen.getByTestId("warn-success")).toHaveTextContent(
+      "Warning issued. The flag has been resolved.",
+    );
+    expect(screen.queryByTestId("btn-warn")).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/__tests__/moderator-flag-detail.test.tsx
+++ b/apps/web/src/__tests__/moderator-flag-detail.test.tsx
@@ -114,6 +114,7 @@ function WarnActionView({
   flag,
   warnPending = false,
   warnSuccess = false,
+  warnError,
   onWarn,
 }: {
   flag: {
@@ -122,6 +123,7 @@ function WarnActionView({
   };
   warnPending?: boolean;
   warnSuccess?: boolean;
+  warnError?: string;
   onWarn: () => void;
 }) {
   if (warnSuccess) {
@@ -136,15 +138,20 @@ function WarnActionView({
       : undefined;
 
   return (
-    <span title={disabledReason}>
-      <button
-        data-testid="btn-warn"
-        disabled={studentDisabled || warnPending}
-        onClick={onWarn}
-      >
-        {warnPending ? "Warning…" : "Warn"}
-      </button>
-    </span>
+    <div>
+      {warnError ? (
+        <p data-testid="warn-error">{warnError}</p>
+      ) : null}
+      <span title={disabledReason}>
+        <button
+          data-testid="btn-warn"
+          disabled={studentDisabled || warnPending}
+          onClick={onWarn}
+        >
+          {warnPending ? "Warning…" : "Warn"}
+        </button>
+      </span>
+    </div>
   );
 }
 
@@ -277,5 +284,20 @@ describe("#88 — Warn action on flag detail view", () => {
       "Warning issued. The flag has been resolved.",
     );
     expect(screen.queryByTestId("btn-warn")).not.toBeInTheDocument();
+  });
+});
+
+describe("#88 — Edge cases", () => {
+  const warnFlag = {
+    flagId: "flag-abc",
+    flaggedStudent: { id: "user-2", name: "Jane Doe", removed: false, suspended: false },
+  };
+
+  it("shows error message when warn action is no longer available (stale click)", () => {
+    render(<WarnActionView flag={warnFlag} warnError="Action no longer available. The flag may have already been resolved." onWarn={vi.fn()} />);
+
+    expect(screen.getByTestId("warn-error")).toHaveTextContent(
+      "Action no longer available",
+    );
   });
 });

--- a/apps/web/src/routes/moderator/flags.$flagId.tsx
+++ b/apps/web/src/routes/moderator/flags.$flagId.tsx
@@ -35,6 +35,10 @@ function FlagDetailScreen() {
     }),
   );
 
+  const warnError = warnMutation.isError
+    ? "Action no longer available. The flag may have already been resolved."
+    : undefined;
+
   if (isLoading) {
     return <p className="p-6 text-muted-foreground">Loading flag detail…</p>;
   }
@@ -129,6 +133,12 @@ function FlagDetailScreen() {
           </ul>
         )}
       </section>
+
+      {warnError ? (
+        <p className="rounded-md border border-destructive/40 bg-destructive/10 px-4 py-2 text-sm text-destructive" data-testid="warn-error">
+          {warnError}
+        </p>
+      ) : null}
 
       <section className="flex gap-3 pt-2">
         <span title={disabledReason}>

--- a/apps/web/src/routes/moderator/flags.$flagId.tsx
+++ b/apps/web/src/routes/moderator/flags.$flagId.tsx
@@ -1,7 +1,8 @@
 // #80 — Moderator flag detail view
+// #88 — Warn action with loading/success states
 // TODO: Tighten auth guard to Moderator role once role field is added to user schema
 
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, Link, redirect } from "@tanstack/react-router";
 
 import { authClient } from "@/lib/auth-client";
@@ -20,8 +21,18 @@ export const Route = createFileRoute("/moderator/flags/$flagId")({
 
 function FlagDetailScreen() {
   const { flagId } = Route.useParams();
+  const queryClient = useQueryClient();
   const { data: flag, isLoading } = useQuery(
     trpc.moderation.getFlagDetail.queryOptions({ flagId }),
+  );
+
+  const warnMutation = useMutation(
+    trpc.moderation.warnStudent.mutationOptions({
+      onSuccess: () => {
+        queryClient.invalidateQueries(trpc.moderation.getFlagDetail.queryOptions({ flagId }));
+        queryClient.invalidateQueries(trpc.moderation.listOpenFlags.queryOptions());
+      },
+    }),
   );
 
   if (isLoading) {
@@ -31,6 +42,29 @@ function FlagDetailScreen() {
   if (!flag) {
     return <p className="p-6 text-destructive">Flag not found.</p>;
   }
+
+  if (warnMutation.isSuccess) {
+    return (
+      <div className="p-6 space-y-4 max-w-2xl">
+        <Link to="/moderator/flags" className="text-sm text-muted-foreground hover:underline">
+          ← Back to queue
+        </Link>
+        <div
+          className="rounded-md border border-green-500/40 bg-green-500/10 px-4 py-3 text-sm text-green-700"
+          data-testid="warn-success"
+        >
+          Warning issued. The flag has been resolved.
+        </div>
+      </div>
+    );
+  }
+
+  const studentDisabled = flag.flaggedStudent.suspended || flag.flaggedStudent.removed;
+  const disabledReason = flag.flaggedStudent.removed
+    ? "Student has already been removed"
+    : flag.flaggedStudent.suspended
+      ? "Student is already suspended"
+      : undefined;
 
   return (
     <div className="p-6 space-y-6 max-w-2xl">
@@ -97,14 +131,18 @@ function FlagDetailScreen() {
       </section>
 
       <section className="flex gap-3 pt-2">
+        <span title={disabledReason}>
+          <button
+            data-testid="btn-warn"
+            disabled={studentDisabled || warnMutation.isPending}
+            onClick={() => warnMutation.mutate({ flagId })}
+            className="rounded-md border px-4 py-2 text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {warnMutation.isPending ? "Warning…" : "Warn"}
+          </button>
+        </span>
         <button
           disabled
-          className="rounded-md border px-4 py-2 text-sm font-medium opacity-50 cursor-not-allowed"
-        >
-          Warn
-        </button>
-        <button
-          disabled={flag.flaggedStudent.removed}
           className="rounded-md border px-4 py-2 text-sm font-medium opacity-50 cursor-not-allowed"
         >
           Suspend

--- a/packages/api/src/routers/moderation-utils.ts
+++ b/packages/api/src/routers/moderation-utils.ts
@@ -140,7 +140,8 @@ export interface PriorFlagRow {
 
 export interface FlagDetailEntry {
   flagId: string;
-  flaggedStudent: { id: string; name: string | null; removed: boolean };
+  // #88 — `suspended` added; always false until Feature #33 adds the DB column
+  flaggedStudent: { id: string; name: string | null; removed: boolean; suspended: boolean };
   reason: string;
   detail: string | null;
   submittedAt: string;
@@ -150,6 +151,7 @@ export interface FlagDetailEntry {
 /**
  * Builds the flag detail API response from DB rows.
  * `removed` is true when the flagged Student's user record is absent (null name + no match).
+ * `suspended` is always false until Feature #33 adds a DB-level suspended status.
  */
 export function buildFlagDetail(
   flag: FlagDetailRow,
@@ -161,6 +163,7 @@ export function buildFlagDetail(
       id: flag.targetId,
       name: flag.targetName,
       removed: flag.targetName === null,
+      suspended: false, // Feature #33 will set this from the DB
     },
     reason: flag.reason,
     detail: flag.detail,

--- a/packages/api/src/routers/moderation.ts
+++ b/packages/api/src/routers/moderation.ts
@@ -105,6 +105,27 @@ export const moderationRouter = router({
     }),
 
   /**
+   * #88 — Warn a flagged Student.
+   * Stub: validates the flag exists and is open, returns success.
+   * Recording the warning and emitting the domain event is deferred to Task #90.
+   */
+  warnStudent: protectedProcedure
+    .input(z.object({ flagId: z.string() }))
+    .mutation(async ({ input }) => {
+      const rows = await db
+        .select({ id: userFlag.id })
+        .from(userFlag)
+        .where(and(eq(userFlag.id, input.flagId), eq(userFlag.status, "open")))
+        .limit(1);
+
+      if (!rows[0]) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Flag not found or already resolved." });
+      }
+
+      return { success: true as const };
+    }),
+
+  /**
    * #65/#67 — Flag submission with validation.
    * Persistence (#72) is implemented in a subsequent task.
    */


### PR DESCRIPTION
## Summary

Gives the Moderator a functional "Warn" button on the flag detail view. Previously the button was always disabled (placeholder from Task #80). This task wires up the `moderation.warnStudent` tRPC mutation, adds proper loading and success states, disables the button with an explanatory tooltip when the Student is already suspended or removed, and shows an error message if the action is no longer available (stale click after flag already resolved).

Part of Feature #32 — Moderator can warn a flagged Student.

## Changes

- **Backend (`packages/api`):** `warnStudent` stub mutation added to `moderationRouter` — validates the flag exists and is open, returns `{ success: true }`. Full recording logic deferred to Task #90. `FlagDetailEntry.flaggedStudent` gains a `suspended: boolean` field (always `false` until Feature #33 adds the DB column).
- **Frontend (`apps/web`):** Flag detail component wired to `useMutation` for `warnStudent`. Button shows loading state, transitions to a resolved confirmation on success, and displays "Action no longer available" on error. Disabled with tooltip when Student is suspended or removed.
- **Tests:** 6 new test cases in `moderator-flag-detail.test.tsx` covering all 4 Gherkin scenarios + stale-click edge case.

## Test plan

- [ ] Moderator sees Warn button visible and enabled for an active Student
- [ ] Warn button is disabled with tooltip for a suspended Student
- [ ] Warn button is disabled with tooltip for a removed Student
- [ ] Warn button shows loading state while mutation is pending
- [ ] Detail view transitions to resolved confirmation on warn success
- [ ] Error message shown when warn action is no longer available (stale click)

## Related

Closes #88
