### PR TITLE
feat(moderation): #94 — notify warned Student via push on StudentWarned

### DIFF
--- a/apps/server/src/__tests__/notifications-student-warned.test.ts
+++ b/apps/server/src/__tests__/notifications-student-warned.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Tests for task #94 — Push notification on StudentWarned
+ */
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+interface CapturedFetchCall {
+  url: string;
+  messages: Array<{ to: string; title?: string; body?: string; data?: Record<string, unknown> }>;
+}
+
+const fetchCalls: CapturedFetchCall[] = [];
+(global as unknown as { fetch: unknown }).fetch = mock(async (url: string, options: RequestInit) => {
+  fetchCalls.push({ url, messages: JSON.parse(options.body as string) as CapturedFetchCall["messages"] });
+  return { json: async () => ({ data: [{ status: "ok", id: "t-1" }] }) };
+});
+
+mock.module("@sip-and-speak/db/schema/sip-and-speak", () => ({ userDeviceToken: "userDeviceToken", userLanguage: "userLanguage", conversationPresence: "conversationPresence" }));
+mock.module("@sip-and-speak/db/schema/auth", () => ({ user: "user" }));
+mock.module("drizzle-orm", () => ({ eq: (_col: unknown, val: unknown) => ({ _val: val }), and: (...args: unknown[]) => ({ _args: args }) }));
+
+let mockTokenRows: Array<{ id: string; token: string }> = [];
+mock.module("@sip-and-speak/db", () => ({
+  db: {
+    select: () => ({ from: () => ({ where: () => Promise.resolve(mockTokenRows) }) }),
+  },
+}));
+
+import { registerNotificationHandlers } from "../notifications";
+import { domainEvents } from "@sip-and-speak/api/domain-events";
+
+describe("handleStudentWarned", () => {
+  beforeEach(() => { fetchCalls.length = 0; mockTokenRows = []; domainEvents.removeAllListeners(); registerNotificationHandlers(); });
+
+  it("sends push notification to warned Student's device", async () => {
+    mockTokenRows = [{ id: "t-1", token: "ExponentPushToken[warned]" }];
+    domainEvents.emit("StudentWarned", { flagId: "flag-1", targetId: "student-1", moderatorId: "mod-1", warnedAt: new Date() });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(fetchCalls.length).toBe(1);
+    expect(fetchCalls[0]!.messages[0]!.to).toBe("ExponentPushToken[warned]");
+    expect(fetchCalls[0]!.messages[0]!.title).toBe("Moderation notice");
+    expect(fetchCalls[0]!.messages[0]!.data?.type).toBe("student_warned");
+  });
+
+  it("sends no notification when Student has no registered token", async () => {
+    mockTokenRows = [];
+    domainEvents.emit("StudentWarned", { flagId: "flag-2", targetId: "student-2", moderatorId: "mod-1", warnedAt: new Date() });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(fetchCalls.length).toBe(0);
+  });
+
+  it("sends to all registered tokens when Student has multiple devices", async () => {
+    mockTokenRows = [
+      { id: "t-1", token: "ExponentPushToken[device1]" },
+      { id: "t-2", token: "ExponentPushToken[device2]" },
+    ];
+    domainEvents.emit("StudentWarned", { flagId: "flag-3", targetId: "student-3", moderatorId: "mod-1", warnedAt: new Date() });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(fetchCalls.length).toBe(1);
+    expect(fetchCalls[0]!.messages.length).toBe(2);
+  });
+});

--- a/apps/server/src/notifications.ts
+++ b/apps/server/src/notifications.ts
@@ -8,7 +8,7 @@ import { and, eq } from "drizzle-orm";
 import { db } from "@sip-and-speak/db";
 import { userDeviceToken, userLanguage, conversationPresence } from "@sip-and-speak/db/schema/sip-and-speak";
 import { user } from "@sip-and-speak/db/schema/auth";
-import { domainEvents, type MatchRequestSentEvent, type MatchRequestAcceptedEvent, type MatchRequestDeclinedEvent, type MeetupProposedEvent, type MeetupConfirmedEvent, type MeetupCounterProposedEvent, type MeetupDeclinedEvent, type MeetupCancelledEvent, type MeetupRescheduleProposedEvent, type MeetupRescheduledEvent, type MeetupRescheduleDeclinedEvent, type SipAndSpeakMomentCompletedEvent, type MeetupNotAttendedEvent, type MessagingOptInPromptedEvent, type MessagingNudgeNeededEvent, type ConversationOpenedEvent, type MessagingDeclineOutcomeEvent, type MessageSentEvent } from "@sip-and-speak/api/domain-events";
+import { domainEvents, type MatchRequestSentEvent, type MatchRequestAcceptedEvent, type MatchRequestDeclinedEvent, type MeetupProposedEvent, type MeetupConfirmedEvent, type MeetupCounterProposedEvent, type MeetupDeclinedEvent, type MeetupCancelledEvent, type MeetupRescheduleProposedEvent, type MeetupRescheduledEvent, type MeetupRescheduleDeclinedEvent, type SipAndSpeakMomentCompletedEvent, type MeetupNotAttendedEvent, type MessagingOptInPromptedEvent, type MessagingNudgeNeededEvent, type ConversationOpenedEvent, type MessagingDeclineOutcomeEvent, type MessageSentEvent, type StudentWarnedEvent } from "@sip-and-speak/api/domain-events";
 import { buildMatchRequestNotificationBody } from "@sip-and-speak/api/routers/matching-utils";
 
 const EXPO_PUSH_URL = "https://exp.host/--/api/v2/push/send";
@@ -390,6 +390,9 @@ export function registerNotificationHandlers(): void {
   });
   domainEvents.on("MessageSent", (event) => {
     void handleMessageSent(event);
+  });
+  domainEvents.on("StudentWarned", (event) => {
+    void handleStudentWarned(event);
   });
 }
 
@@ -785,5 +788,26 @@ async function handleMeetupCancelled(event: MeetupCancelledEvent): Promise<void>
     await sendExpoPushNotification(messages);
   } catch (err) {
     console.error("[push] Failed to send MeetupCancelled notification", { meetupId, err });
+  }
+}
+
+// #94 — Notify warned Student of the moderation decision
+async function handleStudentWarned(event: StudentWarnedEvent): Promise<void> {
+  const { flagId, targetId } = event;
+  const tokens = await db
+    .select({ id: userDeviceToken.id, token: userDeviceToken.token })
+    .from(userDeviceToken)
+    .where(eq(userDeviceToken.userId, targetId));
+  if (tokens.length === 0) return;
+  const messages: ExpoPushMessage[] = tokens.map(({ token }) => ({
+    to: token,
+    title: "Moderation notice",
+    body: "A formal warning has been recorded on your account. Please review the community guidelines.",
+    data: { flagId, type: "student_warned" },
+  }));
+  try {
+    await sendExpoPushNotification(messages);
+  } catch (err) {
+    console.error("[push] Failed to send StudentWarned notification", { flagId, err });
   }
 }


### PR DESCRIPTION
## Summary

- Registers `StudentWarned` domain event handler in `registerNotificationHandlers()`
- Adds `handleStudentWarned` — fetches warned Student's device tokens, sends Expo push notification with moderation notice
- Graceful no-op when Student has no registered tokens; delivery failure logged and does not propagate

Closes #94

## Test plan

- [x] `notifications-student-warned.test.ts` — 3 scenarios: token present, no token, multiple tokens
- [x] All tests pass (`bun test --cwd apps/server`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)