### PR TITLE
feat(moderation): #100/#103 — suspend Student state + flag history

### DIFF
--- a/packages/api/src/__tests__/moderation-flag-detail.test.ts
+++ b/packages/api/src/__tests__/moderation-flag-detail.test.ts
@@ -15,6 +15,7 @@ const baseFlag = {
   id: "flag-abc",
   targetId: "user-2",
   targetName: "Jane Doe",
+  targetStatus: "active" as string | null,
   reason: "Disruptive behaviour",
   detail: "Kept interrupting",
   createdAt: new Date("2026-04-10T09:15:00Z"),
@@ -25,7 +26,7 @@ describe("#80 — buildFlagDetail", () => {
     const result = buildFlagDetail(baseFlag, []);
 
     expect(result.flagId).toBe("flag-abc");
-    expect(result.flaggedStudent).toEqual({ id: "user-2", name: "Jane Doe", removed: false });
+    expect(result.flaggedStudent).toEqual({ id: "user-2", name: "Jane Doe", removed: false, suspended: false });
     expect(result.reason).toBe("Disruptive behaviour");
     expect(result.detail).toBe("Kept interrupting");
     expect(result.submittedAt).toBe("2026-04-10T09:15:00.000Z");
@@ -53,7 +54,7 @@ describe("#80 — buildFlagDetail", () => {
   });
 
   it("sets removed: true when flagged Student's name is null (user record absent)", () => {
-    const removedStudentFlag = { ...baseFlag, targetName: null };
+    const removedStudentFlag = { ...baseFlag, targetName: null, targetStatus: null };
 
     const result = buildFlagDetail(removedStudentFlag, []);
 

--- a/packages/api/src/__tests__/moderation-suspend.test.ts
+++ b/packages/api/src/__tests__/moderation-suspend.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for task #100/#103 — Transition Student to Suspended state + record in flag history
+ *
+ * Covers pure helpers — no DB interaction.
+ *
+ *   - buildSuspendFlagValues: status='resolved', outcome='suspended', moderatorId, resolvedAt
+ *   - buildStudentSuspendedEvent: correct payload shape
+ *   - checkStudentActive: blocks on suspended or removed students
+ *   - buildFlagDetail: suspended field reflects actual studentStatus
+ */
+import { describe, it, expect } from "bun:test";
+
+import {
+  buildSuspendFlagValues,
+  buildStudentSuspendedEvent,
+  checkStudentActive,
+  buildFlagDetail,
+} from "../routers/moderation-utils";
+
+describe("#103 — buildSuspendFlagValues", () => {
+  it("Suspension recorded in flag history: sets status=resolved, outcome=suspended", () => {
+    const resolvedAt = new Date("2026-04-14T12:00:00Z");
+    const result = buildSuspendFlagValues("mod-1", resolvedAt);
+
+    expect(result).toEqual({
+      status: "resolved",
+      outcome: "suspended",
+      moderatorId: "mod-1",
+      resolvedAt,
+    });
+  });
+
+  it("Flag transitions to resolved after suspend: status is always 'resolved'", () => {
+    const result = buildSuspendFlagValues("mod-1", new Date());
+    expect(result.status).toBe("resolved");
+    expect(result.outcome).toBe("suspended");
+  });
+});
+
+describe("#100 — buildStudentSuspendedEvent", () => {
+  it("StudentSuspended domain event emitted with correct payload", () => {
+    const suspendedAt = new Date("2026-04-14T12:00:00Z");
+    const result = buildStudentSuspendedEvent("flag-1", "student-1", "mod-1", suspendedAt);
+
+    expect(result).toEqual({
+      flagId: "flag-1",
+      targetId: "student-1",
+      moderatorId: "mod-1",
+      suspendedAt,
+    });
+  });
+});
+
+describe("#100 — checkStudentActive (suspend guard)", () => {
+  it("Suspended Student cannot be suspended again: returns false when suspended=true", () => {
+    expect(checkStudentActive(true, true)).toBe(false);
+  });
+
+  it("Removed Student cannot be suspended: returns false when exists=false", () => {
+    expect(checkStudentActive(false, false)).toBe(false);
+  });
+
+  it("Active Student can be suspended: returns true when exists=true and suspended=false", () => {
+    expect(checkStudentActive(true, false)).toBe(true);
+  });
+});
+
+describe("#100 — buildFlagDetail suspended field", () => {
+  const base = {
+    id: "flag-1",
+    targetId: "student-1",
+    targetName: "Jane Doe",
+    reason: "HARASSMENT",
+    detail: null,
+    createdAt: new Date("2026-01-01"),
+  };
+
+  it("Returns suspended=true when studentStatus is 'suspended'", () => {
+    const result = buildFlagDetail({ ...base, targetStatus: "suspended" }, []);
+    expect(result.flaggedStudent.suspended).toBe(true);
+  });
+
+  it("Returns suspended=false when studentStatus is 'active'", () => {
+    const result = buildFlagDetail({ ...base, targetStatus: "active" }, []);
+    expect(result.flaggedStudent.suspended).toBe(false);
+  });
+
+  it("Returns suspended=false when targetStatus is null (user removed)", () => {
+    const result = buildFlagDetail({ ...base, targetStatus: null }, []);
+    expect(result.flaggedStudent.suspended).toBe(false);
+  });
+
+  it("Returns removed=true and suspended=false when targetName is null", () => {
+    const result = buildFlagDetail({ ...base, targetName: null, targetStatus: null }, []);
+    expect(result.flaggedStudent.removed).toBe(true);
+    expect(result.flaggedStudent.suspended).toBe(false);
+  });
+});

--- a/packages/api/src/domain-events.ts
+++ b/packages/api/src/domain-events.ts
@@ -203,6 +203,21 @@ export interface StudentWarnedEvent {
   warnedAt: Date;
 }
 
+// #100
+export interface StudentSuspendedEvent {
+  flagId: string;
+  targetId: string;
+  moderatorId: string;
+  suspendedAt: Date;
+}
+
+// #105
+export interface SuspensionLiftedEvent {
+  targetId: string;
+  moderatorId: string;
+  liftedAt: Date;
+}
+
 type DomainEventMap = {
   LanguageProfileUpdated: [LanguageProfileUpdatedEvent];
   InterestProfileUpdated: [InterestProfileUpdatedEvent];
@@ -230,6 +245,8 @@ type DomainEventMap = {
   MessageSent: [MessageSentEvent];
   StudentFlagged: [StudentFlaggedEvent];
   StudentWarned: [StudentWarnedEvent];
+  StudentSuspended: [StudentSuspendedEvent];
+  SuspensionLifted: [SuspensionLiftedEvent];
 };
 
 class TypedEventEmitter extends EventEmitter {

--- a/packages/api/src/routers/chat.ts
+++ b/packages/api/src/routers/chat.ts
@@ -162,6 +162,16 @@ export const chatRouter = router({
     .mutation(async ({ ctx, input }) => {
       const userId = ctx.session.user.id;
 
+      // #100 — Guard: suspended Students cannot send messages
+      const [sender] = await db
+        .select({ studentStatus: user.studentStatus })
+        .from(user)
+        .where(eq(user.id, userId))
+        .limit(1);
+      if (sender?.studentStatus === "suspended") {
+        throw new TRPCError({ code: "FORBIDDEN", message: "Suspended Students cannot send messages." });
+      }
+
       // Verify user is part of this conversation
       const conv = await db
         .select()

--- a/packages/api/src/routers/matching.ts
+++ b/packages/api/src/routers/matching.ts
@@ -118,11 +118,11 @@ export const matchingRouter = router({
         .from(userInterest)
         .where(inArray(userInterest.userId, otherUserIds));
 
-      // Fetch user info (name, image) for candidates
+      // Fetch user info (name, image) for candidates — exclude suspended Students (#100)
       const allUsers = await db
         .select({ id: user.id, name: user.name, image: user.image })
         .from(user)
-        .where(inArray(user.id, otherUserIds));
+        .where(and(inArray(user.id, otherUserIds), ne(user.studentStatus, "suspended")));
 
       const userMap = new Map(allUsers.map((u) => [u.id, u]));
 

--- a/packages/api/src/routers/meetup.ts
+++ b/packages/api/src/routers/meetup.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { db } from "@sip-and-speak/db";
 import { meetup, venue, studentMatch, attendanceReport } from "@sip-and-speak/db/schema/sip-and-speak";
+import { user } from "@sip-and-speak/db/schema/auth";
 import { protectedProcedure, router } from "../index";
 import { domainEvents } from "../domain-events";
 import { isMeetupInThePast, isRescheduleNoOp } from "./meetup-utils";
@@ -62,6 +63,16 @@ export const meetupRouter = router({
 
       if (userId === input.partnerId) {
         throw new TRPCError({ code: "BAD_REQUEST", message: "You cannot propose a meetup with yourself" });
+      }
+
+      // #100 — Guard: suspended Students cannot create meetup proposals
+      const [proposer] = await db
+        .select({ studentStatus: user.studentStatus })
+        .from(user)
+        .where(eq(user.id, userId))
+        .limit(1);
+      if (proposer?.studentStatus === "suspended") {
+        throw new TRPCError({ code: "FORBIDDEN", message: "Suspended Students cannot create meetup proposals." });
       }
 
       // #68: Matched state check

--- a/packages/api/src/routers/moderation-persist.ts
+++ b/packages/api/src/routers/moderation-persist.ts
@@ -6,7 +6,8 @@ import { eq } from "drizzle-orm";
 
 import { db } from "@sip-and-speak/db";
 import { userFlag } from "@sip-and-speak/db/schema/sip-and-speak";
-import { buildFlagValues, buildWarnFlagValues } from "./moderation-utils";
+import { buildFlagValues, buildWarnFlagValues, buildSuspendFlagValues } from "./moderation-utils";
+import { user } from "@sip-and-speak/db/schema/auth";
 
 export interface PersistFlagInput {
   reporterId: string;
@@ -41,4 +42,38 @@ export async function persistWarnFlag(flagId: string, moderatorId: string) {
     .returning({ targetId: userFlag.targetId, warnedAt: userFlag.resolvedAt });
 
   return { targetId: updated!.targetId, warnedAt };
+}
+
+/**
+ * #100/#103 — Transitions a Student to suspended state and resolves the flag.
+ * Sets user.studentStatus = 'suspended' and resolves the flag with outcome 'suspended'.
+ */
+export async function persistSuspendStudent(flagId: string, targetId: string, moderatorId: string) {
+  const suspendedAt = new Date();
+  await db
+    .update(user)
+    .set({ studentStatus: "suspended" })
+    .where(eq(user.id, targetId));
+
+  const [updated] = await db
+    .update(userFlag)
+    .set(buildSuspendFlagValues(moderatorId, suspendedAt))
+    .where(eq(userFlag.id, flagId))
+    .returning({ targetId: userFlag.targetId, suspendedAt: userFlag.resolvedAt });
+
+  return { targetId: updated!.targetId, suspendedAt };
+}
+
+/**
+ * #105 — Lifts a Student's suspension.
+ * Sets user.studentStatus back to 'active'.
+ */
+export async function persistLiftSuspension(targetId: string) {
+  const liftedAt = new Date();
+  await db
+    .update(user)
+    .set({ studentStatus: "active" })
+    .where(eq(user.id, targetId));
+
+  return { liftedAt };
 }

--- a/packages/api/src/routers/moderation-utils.ts
+++ b/packages/api/src/routers/moderation-utils.ts
@@ -127,6 +127,7 @@ export interface FlagDetailRow {
   id: string;
   targetId: string;
   targetName: string | null;
+  targetStatus: string | null; // #100 — studentStatus from user table
   reason: string;
   detail: string | null;
   createdAt: Date;
@@ -141,7 +142,6 @@ export interface PriorFlagRow {
 
 export interface FlagDetailEntry {
   flagId: string;
-  // #88 — `suspended` added; always false until Feature #33 adds the DB column
   flaggedStudent: { id: string; name: string | null; removed: boolean; suspended: boolean };
   reason: string;
   detail: string | null;
@@ -151,8 +151,8 @@ export interface FlagDetailEntry {
 
 /**
  * Builds the flag detail API response from DB rows.
- * `removed` is true when the flagged Student's user record is absent (null name + no match).
- * `suspended` is always false until Feature #33 adds a DB-level suspended status.
+ * `removed` is true when the flagged Student's user record is absent.
+ * `suspended` is true when studentStatus is 'suspended'.
  */
 export function buildFlagDetail(
   flag: FlagDetailRow,
@@ -164,7 +164,7 @@ export function buildFlagDetail(
       id: flag.targetId,
       name: flag.targetName,
       removed: flag.targetName === null,
-      suspended: false, // Feature #33 will set this from the DB
+      suspended: flag.targetStatus === "suspended",
     },
     reason: flag.reason,
     detail: flag.detail,
@@ -244,10 +244,69 @@ export const STUDENT_INACTIVE_MESSAGE =
   "Action no longer available — Student is suspended or removed";
 
 /**
- * Returns true if the Student can receive a warn action.
+ * Returns true if the Student can receive a warn/suspend action.
  * `exists` — user record found in DB (false = removed).
- * `suspended` — suspended flag (always false until Feature #33 adds DB column).
+ * `suspended` — true when studentStatus is 'suspended'.
  */
 export function checkStudentActive(exists: boolean, suspended: boolean): boolean {
   return exists && !suspended;
+}
+
+// #100 — Pure helpers for the suspend flow
+
+export interface SuspendFlagValues {
+  status: "resolved";
+  outcome: "suspended";
+  moderatorId: string;
+  resolvedAt: Date;
+}
+
+/**
+ * Builds the DB update payload for resolving a flag with outcome 'suspended'.
+ */
+export function buildSuspendFlagValues(moderatorId: string, resolvedAt: Date): SuspendFlagValues {
+  return {
+    status: "resolved",
+    outcome: "suspended",
+    moderatorId,
+    resolvedAt,
+  };
+}
+
+export interface StudentSuspendedPayload {
+  flagId: string;
+  targetId: string;
+  moderatorId: string;
+  suspendedAt: Date;
+}
+
+/**
+ * Builds the StudentSuspended domain event payload.
+ */
+export function buildStudentSuspendedEvent(
+  flagId: string,
+  targetId: string,
+  moderatorId: string,
+  suspendedAt: Date,
+): StudentSuspendedPayload {
+  return { flagId, targetId, moderatorId, suspendedAt };
+}
+
+// #105 — Pure helpers for the lift suspension flow
+
+export interface SuspensionLiftedPayload {
+  targetId: string;
+  moderatorId: string;
+  liftedAt: Date;
+}
+
+/**
+ * Builds the SuspensionLifted domain event payload.
+ */
+export function buildSuspensionLiftedEvent(
+  targetId: string,
+  moderatorId: string,
+  liftedAt: Date,
+): SuspensionLiftedPayload {
+  return { targetId, moderatorId, liftedAt };
 }

--- a/packages/api/src/routers/moderation.ts
+++ b/packages/api/src/routers/moderation.ts
@@ -12,12 +12,14 @@ import {
   FLAG_VALIDATION_MESSAGES,
   buildStudentFlaggedEvent,
   buildStudentWarnedEvent,
+  buildStudentSuspendedEvent,
+  buildSuspensionLiftedEvent,
   buildFlagQueueEntry,
   buildFlagDetail,
   checkStudentActive,
   STUDENT_INACTIVE_MESSAGE,
 } from "./moderation-utils";
-import { persistFlag, persistWarnFlag } from "./moderation-persist";
+import { persistFlag, persistWarnFlag, persistSuspendStudent, persistLiftSuspension } from "./moderation-persist";
 import { domainEvents } from "../domain-events";
 
 export const flagReasonSchema = z.enum([
@@ -73,6 +75,7 @@ export const moderationRouter = router({
           id: userFlag.id,
           targetId: userFlag.targetId,
           targetName: user.name,
+          targetStatus: user.studentStatus,
           reason: userFlag.reason,
           detail: userFlag.detail,
           createdAt: userFlag.createdAt,
@@ -132,14 +135,14 @@ export const moderationRouter = router({
         throw new TRPCError({ code: "CONFLICT", message: "Flag already resolved." });
       }
 
-      // #92 — Guard: reject if Student is removed (suspended deferred to Feature #33)
+      // #92 — Guard: reject if Student is removed or suspended
       const studentRows = await db
-        .select({ id: user.id })
+        .select({ id: user.id, studentStatus: user.studentStatus })
         .from(user)
         .where(eq(user.id, flagRows[0].targetId))
         .limit(1);
 
-      if (!checkStudentActive(!!studentRows[0], false)) {
+      if (!checkStudentActive(!!studentRows[0], studentRows[0]?.studentStatus === "suspended")) {
         throw new TRPCError({ code: "BAD_REQUEST", message: STUDENT_INACTIVE_MESSAGE });
       }
 
@@ -148,6 +151,85 @@ export const moderationRouter = router({
       domainEvents.emit(
         "StudentWarned",
         buildStudentWarnedEvent(input.flagId, flagRows[0].targetId, moderatorId, warnedAt),
+      );
+
+      return { success: true as const };
+    }),
+
+  /**
+   * #100/#103 — Suspend a flagged Student.
+   * Sets studentStatus to 'suspended', resolves flag with outcome 'suspended',
+   * and emits the StudentSuspended domain event.
+   */
+  suspendStudent: protectedProcedure
+    .input(z.object({ flagId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const moderatorId = ctx.session.user.id;
+
+      const flagRows = await db
+        .select({ id: userFlag.id, status: userFlag.status, targetId: userFlag.targetId })
+        .from(userFlag)
+        .where(eq(userFlag.id, input.flagId))
+        .limit(1);
+
+      if (!flagRows[0]) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Flag not found." });
+      }
+      if (flagRows[0].status !== "open") {
+        throw new TRPCError({ code: "CONFLICT", message: "Flag already resolved." });
+      }
+
+      const studentRows = await db
+        .select({ id: user.id, studentStatus: user.studentStatus })
+        .from(user)
+        .where(eq(user.id, flagRows[0].targetId))
+        .limit(1);
+
+      if (!checkStudentActive(!!studentRows[0], studentRows[0]?.studentStatus === "suspended")) {
+        throw new TRPCError({ code: "BAD_REQUEST", message: STUDENT_INACTIVE_MESSAGE });
+      }
+
+      const { targetId, suspendedAt } = await persistSuspendStudent(
+        input.flagId,
+        flagRows[0].targetId,
+        moderatorId,
+      );
+
+      domainEvents.emit(
+        "StudentSuspended",
+        buildStudentSuspendedEvent(input.flagId, targetId, moderatorId, suspendedAt),
+      );
+
+      return { success: true as const };
+    }),
+
+  /**
+   * #105 — Lift a Student's suspension.
+   * Resets studentStatus to 'active' and emits SuspensionLifted event.
+   */
+  liftSuspension: protectedProcedure
+    .input(z.object({ targetId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const moderatorId = ctx.session.user.id;
+
+      const studentRows = await db
+        .select({ id: user.id, studentStatus: user.studentStatus })
+        .from(user)
+        .where(eq(user.id, input.targetId))
+        .limit(1);
+
+      if (!studentRows[0]) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Student not found." });
+      }
+      if (studentRows[0].studentStatus !== "suspended") {
+        throw new TRPCError({ code: "BAD_REQUEST", message: "Student is not suspended." });
+      }
+
+      const { liftedAt } = await persistLiftSuspension(input.targetId);
+
+      domainEvents.emit(
+        "SuspensionLifted",
+        buildSuspensionLiftedEvent(input.targetId, moderatorId, liftedAt),
       );
 
       return { success: true as const };

--- a/packages/db/src/migrations/0013_slim_marvel_zombies.sql
+++ b/packages/db/src/migrations/0013_slim_marvel_zombies.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "user" ADD COLUMN "student_status" text DEFAULT 'active' NOT NULL;

--- a/packages/db/src/migrations/meta/0013_snapshot.json
+++ b/packages/db/src/migrations/meta/0013_snapshot.json
@@ -1,0 +1,2093 @@
+{
+  "id": "8adb3870-d6d4-4af3-bc78-cff9abad5e86",
+  "prevId": "f49b6f45-a63f-4236-bfd5-68f89a307f39",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "student_status": {
+          "name": "student_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attendance_report": {
+      "name": "attendance_report",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "meetup_id": {
+          "name": "meetup_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attended": {
+          "name": "attended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reported_at": {
+          "name": "reported_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "attendance_report_meetupId_idx": {
+          "name": "attendance_report_meetupId_idx",
+          "columns": [
+            {
+              "expression": "meetup_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attendance_report_meetup_id_meetup_id_fk": {
+          "name": "attendance_report_meetup_id_meetup_id_fk",
+          "tableFrom": "attendance_report",
+          "tableTo": "meetup",
+          "columnsFrom": [
+            "meetup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attendance_report_student_id_user_id_fk": {
+          "name": "attendance_report_student_id_user_id_fk",
+          "tableFrom": "attendance_report",
+          "tableTo": "user",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "attendance_report_meetup_student_unique": {
+          "name": "attendance_report_meetup_student_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "meetup_id",
+            "student_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation": {
+      "name": "conversation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user1_id": {
+          "name": "user1_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user2_id": {
+          "name": "user2_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meetup_id": {
+          "name": "meetup_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_user1_idx": {
+          "name": "conversation_user1_idx",
+          "columns": [
+            {
+              "expression": "user1_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_user2_idx": {
+          "name": "conversation_user2_idx",
+          "columns": [
+            {
+              "expression": "user2_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_meetupId_idx": {
+          "name": "conversation_meetupId_idx",
+          "columns": [
+            {
+              "expression": "meetup_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_user1_id_user_id_fk": {
+          "name": "conversation_user1_id_user_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user1_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_user2_id_user_id_fk": {
+          "name": "conversation_user2_id_user_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user2_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_meetup_id_meetup_id_fk": {
+          "name": "conversation_meetup_id_meetup_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "meetup",
+          "columnsFrom": [
+            "meetup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_presence": {
+      "name": "conversation_presence",
+      "schema": "",
+      "columns": {
+        "student_id": {
+          "name": "student_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_until": {
+          "name": "active_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "conversation_presence_studentId_idx": {
+          "name": "conversation_presence_studentId_idx",
+          "columns": [
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_presence_student_id_user_id_fk": {
+          "name": "conversation_presence_student_id_user_id_fk",
+          "tableFrom": "conversation_presence",
+          "tableTo": "user",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_presence_conversation_id_conversation_id_fk": {
+          "name": "conversation_presence_conversation_id_conversation_id_fk",
+          "tableFrom": "conversation_presence",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversation_presence_student_conv_unique": {
+          "name": "conversation_presence_student_conv_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "student_id",
+            "conversation_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.language_profile": {
+      "name": "language_profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "university": {
+          "name": "university",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "age": {
+          "name": "age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_complete": {
+          "name": "onboarding_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "language_profile_user_id_user_id_fk": {
+          "name": "language_profile_user_id_user_id_fk",
+          "tableFrom": "language_profile",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "language_profile_user_id_unique": {
+          "name": "language_profile_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_request": {
+      "name": "match_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "requester_id": {
+          "name": "requester_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receiver_id": {
+          "name": "receiver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "match_request_requesterId_idx": {
+          "name": "match_request_requesterId_idx",
+          "columns": [
+            {
+              "expression": "requester_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "match_request_receiverId_idx": {
+          "name": "match_request_receiverId_idx",
+          "columns": [
+            {
+              "expression": "receiver_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "match_request_requester_id_user_id_fk": {
+          "name": "match_request_requester_id_user_id_fk",
+          "tableFrom": "match_request",
+          "tableTo": "user",
+          "columnsFrom": [
+            "requester_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "match_request_receiver_id_user_id_fk": {
+          "name": "match_request_receiver_id_user_id_fk",
+          "tableFrom": "match_request",
+          "tableTo": "user",
+          "columnsFrom": [
+            "receiver_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meetup": {
+      "name": "meetup",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "proposer_id": {
+          "name": "proposer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receiver_id": {
+          "name": "receiver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "venue_id": {
+          "name": "venue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "reschedule_proposer_id": {
+          "name": "reschedule_proposer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reschedule_venue_id": {
+          "name": "reschedule_venue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reschedule_date": {
+          "name": "reschedule_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reschedule_time": {
+          "name": "reschedule_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "meetup_proposerId_idx": {
+          "name": "meetup_proposerId_idx",
+          "columns": [
+            {
+              "expression": "proposer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meetup_receiverId_idx": {
+          "name": "meetup_receiverId_idx",
+          "columns": [
+            {
+              "expression": "receiver_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meetup_date_idx": {
+          "name": "meetup_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "meetup_proposer_id_user_id_fk": {
+          "name": "meetup_proposer_id_user_id_fk",
+          "tableFrom": "meetup",
+          "tableTo": "user",
+          "columnsFrom": [
+            "proposer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meetup_receiver_id_user_id_fk": {
+          "name": "meetup_receiver_id_user_id_fk",
+          "tableFrom": "meetup",
+          "tableTo": "user",
+          "columnsFrom": [
+            "receiver_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meetup_venue_id_venue_id_fk": {
+          "name": "meetup_venue_id_venue_id_fk",
+          "tableFrom": "meetup",
+          "tableTo": "venue",
+          "columnsFrom": [
+            "venue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meetup_reschedule_proposer_id_user_id_fk": {
+          "name": "meetup_reschedule_proposer_id_user_id_fk",
+          "tableFrom": "meetup",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reschedule_proposer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "meetup_reschedule_venue_id_venue_id_fk": {
+          "name": "meetup_reschedule_venue_id_venue_id_fk",
+          "tableFrom": "meetup",
+          "tableTo": "venue",
+          "columnsFrom": [
+            "reschedule_venue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message": {
+      "name": "message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_conversationId_idx": {
+          "name": "message_conversationId_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_createdAt_idx": {
+          "name": "message_createdAt_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_conversation_id_conversation_id_fk": {
+          "name": "message_conversation_id_conversation_id_fk",
+          "tableFrom": "message",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_sender_id_user_id_fk": {
+          "name": "message_sender_id_user_id_fk",
+          "tableFrom": "message",
+          "tableTo": "user",
+          "columnsFrom": [
+            "sender_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message_read_status": {
+      "name": "message_read_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_read_conversationId_userId_idx": {
+          "name": "message_read_conversationId_userId_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_read_status_conversation_id_conversation_id_fk": {
+          "name": "message_read_status_conversation_id_conversation_id_fk",
+          "tableFrom": "message_read_status",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_read_status_user_id_user_id_fk": {
+          "name": "message_read_status_user_id_user_id_fk",
+          "tableFrom": "message_read_status",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messaging_opt_in": {
+      "name": "messaging_opt_in",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "meetup_id": {
+          "name": "meetup_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "nudge_sent_at": {
+          "name": "nudge_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "messaging_opt_in_meetupId_idx": {
+          "name": "messaging_opt_in_meetupId_idx",
+          "columns": [
+            {
+              "expression": "meetup_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messaging_opt_in_meetup_id_meetup_id_fk": {
+          "name": "messaging_opt_in_meetup_id_meetup_id_fk",
+          "tableFrom": "messaging_opt_in",
+          "tableTo": "meetup",
+          "columnsFrom": [
+            "meetup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messaging_opt_in_student_id_user_id_fk": {
+          "name": "messaging_opt_in_student_id_user_id_fk",
+          "tableFrom": "messaging_opt_in",
+          "tableTo": "user",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "messaging_opt_in_meetup_student_unique": {
+          "name": "messaging_opt_in_meetup_student_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "meetup_id",
+            "student_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_comment": {
+      "name": "student_comment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "student_comment_targetId_idx": {
+          "name": "student_comment_targetId_idx",
+          "columns": [
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "student_comment_author_id_user_id_fk": {
+          "name": "student_comment_author_id_user_id_fk",
+          "tableFrom": "student_comment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "student_comment_target_id_user_id_fk": {
+          "name": "student_comment_target_id_user_id_fk",
+          "tableFrom": "student_comment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_match": {
+      "name": "student_match",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "student_a_id": {
+          "name": "student_a_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_b_id": {
+          "name": "student_b_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_request_id": {
+          "name": "match_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'matched'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "student_match_studentA_idx": {
+          "name": "student_match_studentA_idx",
+          "columns": [
+            {
+              "expression": "student_a_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "student_match_studentB_idx": {
+          "name": "student_match_studentB_idx",
+          "columns": [
+            {
+              "expression": "student_b_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "student_match_student_a_id_user_id_fk": {
+          "name": "student_match_student_a_id_user_id_fk",
+          "tableFrom": "student_match",
+          "tableTo": "user",
+          "columnsFrom": [
+            "student_a_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "student_match_student_b_id_user_id_fk": {
+          "name": "student_match_student_b_id_user_id_fk",
+          "tableFrom": "student_match",
+          "tableTo": "user",
+          "columnsFrom": [
+            "student_b_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "student_match_match_request_id_match_request_id_fk": {
+          "name": "student_match_match_request_id_match_request_id_fk",
+          "tableFrom": "student_match",
+          "tableTo": "match_request",
+          "columnsFrom": [
+            "match_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_device_token": {
+      "name": "user_device_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_device_token_userId_token_idx": {
+          "name": "user_device_token_userId_token_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_device_token_user_id_user_id_fk": {
+          "name": "user_device_token_user_id_user_id_fk",
+          "tableFrom": "user_device_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_flag": {
+      "name": "user_flag",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moderator_id": {
+          "name": "moderator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_flag_reporter_idx": {
+          "name": "user_flag_reporter_idx",
+          "columns": [
+            {
+              "expression": "reporter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_flag_target_idx": {
+          "name": "user_flag_target_idx",
+          "columns": [
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_flag_status_idx": {
+          "name": "user_flag_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_flag_reporter_id_user_id_fk": {
+          "name": "user_flag_reporter_id_user_id_fk",
+          "tableFrom": "user_flag",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_flag_target_id_user_id_fk": {
+          "name": "user_flag_target_id_user_id_fk",
+          "tableFrom": "user_flag",
+          "tableTo": "user",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_flag_moderator_id_user_id_fk": {
+          "name": "user_flag_moderator_id_user_id_fk",
+          "tableFrom": "user_flag",
+          "tableTo": "user",
+          "columnsFrom": [
+            "moderator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_interest": {
+      "name": "user_interest",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interest": {
+          "name": "interest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_interest_userId_idx": {
+          "name": "user_interest_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_interest_user_id_user_id_fk": {
+          "name": "user_interest_user_id_user_id_fk",
+          "tableFrom": "user_interest",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_language": {
+      "name": "user_language",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proficiency": {
+          "name": "proficiency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_language_userId_idx": {
+          "name": "user_language_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_language_user_id_user_id_fk": {
+          "name": "user_language_user_id_user_id_fk",
+          "tableFrom": "user_language",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.venue": {
+      "name": "venue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "venue_name_idx": {
+          "name": "venue_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1776157965717,
       "tag": "0012_striped_victor_mancha",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1776163744198,
+      "tag": "0013_slim_marvel_zombies",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/auth.ts
+++ b/packages/db/src/schema/auth.ts
@@ -21,6 +21,10 @@ export const user = pgTable("user", {
     .defaultNow()
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
+  // #100 — Trust & Moderation: student participation status
+  studentStatus: text("student_status", { enum: ["active", "suspended", "removed"] })
+    .notNull()
+    .default("active"),
 });
 
 export const session = pgTable(


### PR DESCRIPTION
## Summary

- Adds `studentStatus` column to `user` table (`active` | `suspended` | `removed`, default `active`)
- DB migration `0013_slim_marvel_zombies.sql`
- `StudentSuspended` and `SuspensionLifted` domain events added to `domain-events.ts`
- `suspendStudent` tRPC mutation: guards inactive student, sets status, resolves flag with outcome `suspended`, emits `StudentSuspended`
- `liftSuspension` tRPC mutation: resets status to `active`, emits `SuspensionLifted`
- Enforcement guards: `chat.sendMessage`, `meetup.propose`, `matching.discover` block/exclude suspended Students
- `buildFlagDetail` now returns actual `suspended` field from DB instead of hardcoded `false`
- `checkStudentActive` now checks actual suspended status for warn guard

Closes #100
Closes #103

## Test plan

- [x] `moderation-suspend.test.ts` — 10 scenarios covering flag values, event payload, guard, detail shape
- [x] `moderation-flag-detail.test.ts` — updated fixtures to include `targetStatus`
- [x] All pass (`bun test --cwd packages/api`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)