### PR TITLE
feat(moderation): #102/#104/#106 — cancel proposals + suspend/lift notifications

### DIFF
--- a/apps/server/src/__tests__/notifications-suspension.test.ts
+++ b/apps/server/src/__tests__/notifications-suspension.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for:
+ *   task #102 — Cancel active proposals on Student suspension + notify peers
+ *   task #104 — Notify suspended Student of the moderation decision
+ *   task #106 — Notify Student when suspension is lifted
+ */
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+interface CapturedFetchCall {
+  url: string;
+  messages: Array<{ to: string; title?: string; body?: string; data?: Record<string, unknown> }>;
+}
+
+const fetchCalls: CapturedFetchCall[] = [];
+(global as unknown as { fetch: unknown }).fetch = mock(async (url: string, options: RequestInit) => {
+  fetchCalls.push({ url, messages: JSON.parse(options.body as string) as CapturedFetchCall["messages"] });
+  return { json: async () => ({ data: [{ status: "ok", id: "t-1" }] }) };
+});
+
+// Track DB update calls for proposal cancellation
+const dbUpdateCalls: Array<{ table: string; status: string }> = [];
+
+mock.module("@sip-and-speak/db/schema/sip-and-speak", () => ({
+  userDeviceToken: "userDeviceToken",
+  userLanguage: "userLanguage",
+  conversationPresence: "conversationPresence",
+  meetup: "meetup",
+}));
+mock.module("@sip-and-speak/db/schema/auth", () => ({ user: "user" }));
+mock.module("drizzle-orm", () => ({
+  eq: (_col: unknown, val: unknown) => ({ _eq: val }),
+  and: (...args: unknown[]) => ({ _and: args }),
+  or: (...args: unknown[]) => ({ _or: args }),
+  inArray: (_col: unknown, vals: unknown) => ({ _inArray: vals }),
+}));
+
+// Rows returned by meetup select (active proposals)
+let mockMeetupRows: Array<{ id: string; proposerId: string; receiverId: string }> = [];
+// Rows returned by device token select
+let mockTokenRows: Array<{ token: string }> = [];
+let mockTokenRowsForSuspended: Array<{ token: string }> = [];
+
+mock.module("@sip-and-speak/db", () => ({
+  db: {
+    select: (cols?: unknown) => {
+      // Distinguish based on field shape — crude but effective for unit tests
+      const hasId = cols && typeof cols === "object" && "id" in (cols as object);
+      return {
+        from: (_table: unknown) => ({
+          where: () => {
+            if (hasId) {
+              // meetup select (has `id` field)
+              return Promise.resolve(mockMeetupRows);
+            }
+            // Alternate between "for peer tokens" and "for suspended student tokens"
+            // by returning mockTokenRows (peer) when mockMeetupRows is non-empty
+            return Promise.resolve(mockMeetupRows.length > 0 ? mockTokenRows : mockTokenRowsForSuspended);
+          },
+        }),
+      };
+    },
+    update: (_table: unknown) => ({
+      set: (_vals: unknown) => ({
+        where: () => {
+          dbUpdateCalls.push({ table: "meetup", status: "cancelled" });
+          return Promise.resolve();
+        },
+      }),
+    }),
+  },
+}));
+
+import { registerNotificationHandlers } from "../notifications";
+import { domainEvents } from "@sip-and-speak/api/domain-events";
+
+describe("handleStudentSuspended — proposal cancellation (#102)", () => {
+  beforeEach(() => {
+    fetchCalls.length = 0;
+    dbUpdateCalls.length = 0;
+    mockMeetupRows = [];
+    mockTokenRows = [];
+    mockTokenRowsForSuspended = [];
+    domainEvents.removeAllListeners();
+    registerNotificationHandlers();
+  });
+
+  it("cancels active proposals when a Student is suspended", async () => {
+    mockMeetupRows = [{ id: "m-1", proposerId: "student-1", receiverId: "student-2" }];
+    mockTokenRows = [{ token: "ExponentPushToken[peer]" }];
+    domainEvents.emit("StudentSuspended", { flagId: "flag-1", targetId: "student-1", moderatorId: "mod-1", suspendedAt: new Date() });
+    await new Promise((r) => setTimeout(r, 30));
+    expect(dbUpdateCalls.length).toBeGreaterThan(0);
+    expect(dbUpdateCalls[0]!.status).toBe("cancelled");
+  });
+
+  it("notifies affected peer when proposal is cancelled", async () => {
+    mockMeetupRows = [{ id: "m-1", proposerId: "student-1", receiverId: "student-2" }];
+    mockTokenRows = [{ token: "ExponentPushToken[peer]" }];
+    domainEvents.emit("StudentSuspended", { flagId: "flag-1", targetId: "student-1", moderatorId: "mod-1", suspendedAt: new Date() });
+    await new Promise((r) => setTimeout(r, 30));
+    const proposalCancelMsg = fetchCalls.find((c) => c.messages[0]?.title === "Meetup proposal cancelled");
+    expect(proposalCancelMsg).toBeDefined();
+    expect(proposalCancelMsg!.messages[0]!.body).toBe("Your meetup proposal has been cancelled.");
+  });
+
+  it("notification does not reveal moderation reason", async () => {
+    mockMeetupRows = [{ id: "m-1", proposerId: "student-1", receiverId: "student-2" }];
+    mockTokenRows = [{ token: "ExponentPushToken[peer]" }];
+    domainEvents.emit("StudentSuspended", { flagId: "flag-1", targetId: "student-1", moderatorId: "mod-1", suspendedAt: new Date() });
+    await new Promise((r) => setTimeout(r, 30));
+    const proposalCancelMsg = fetchCalls.find((c) => c.messages[0]?.title === "Meetup proposal cancelled");
+    expect(proposalCancelMsg!.messages[0]!.body).not.toContain("suspend");
+    expect(proposalCancelMsg!.messages[0]!.body).not.toContain("moderation");
+  });
+
+  it("does nothing when Student has no active proposals", async () => {
+    mockMeetupRows = [];
+    domainEvents.emit("StudentSuspended", { flagId: "flag-2", targetId: "student-1", moderatorId: "mod-1", suspendedAt: new Date() });
+    await new Promise((r) => setTimeout(r, 30));
+    expect(dbUpdateCalls.length).toBe(0);
+  });
+});
+
+describe("handleSuspensionLifted — notify Student (#106)", () => {
+  beforeEach(() => {
+    fetchCalls.length = 0;
+    mockMeetupRows = [];
+    mockTokenRows = [];
+    mockTokenRowsForSuspended = [];
+    domainEvents.removeAllListeners();
+    registerNotificationHandlers();
+  });
+
+  it("notifies Student when suspension is lifted", async () => {
+    mockTokenRowsForSuspended = [{ token: "ExponentPushToken[student]" }];
+    domainEvents.emit("SuspensionLifted", { targetId: "student-1", moderatorId: "mod-1", liftedAt: new Date() });
+    await new Promise((r) => setTimeout(r, 30));
+    const liftedMsg = fetchCalls.find((c) => c.messages[0]?.title === "Suspension lifted");
+    expect(liftedMsg).toBeDefined();
+  });
+
+  it("sends no notification when Student has no device token", async () => {
+    mockTokenRowsForSuspended = [];
+    domainEvents.emit("SuspensionLifted", { targetId: "student-2", moderatorId: "mod-1", liftedAt: new Date() });
+    await new Promise((r) => setTimeout(r, 30));
+    expect(fetchCalls.filter((c) => c.messages[0]?.title === "Suspension lifted").length).toBe(0);
+  });
+});

--- a/apps/server/src/notifications.ts
+++ b/apps/server/src/notifications.ts
@@ -4,11 +4,11 @@
  * Wires domain events to Expo Push API calls.
  * Fire-and-forget: errors are logged but never thrown to callers.
  */
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray, or } from "drizzle-orm";
 import { db } from "@sip-and-speak/db";
-import { userDeviceToken, userLanguage, conversationPresence } from "@sip-and-speak/db/schema/sip-and-speak";
+import { userDeviceToken, userLanguage, conversationPresence, meetup } from "@sip-and-speak/db/schema/sip-and-speak";
 import { user } from "@sip-and-speak/db/schema/auth";
-import { domainEvents, type MatchRequestSentEvent, type MatchRequestAcceptedEvent, type MatchRequestDeclinedEvent, type MeetupProposedEvent, type MeetupConfirmedEvent, type MeetupCounterProposedEvent, type MeetupDeclinedEvent, type MeetupCancelledEvent, type MeetupRescheduleProposedEvent, type MeetupRescheduledEvent, type MeetupRescheduleDeclinedEvent, type SipAndSpeakMomentCompletedEvent, type MeetupNotAttendedEvent, type MessagingOptInPromptedEvent, type MessagingNudgeNeededEvent, type ConversationOpenedEvent, type MessagingDeclineOutcomeEvent, type MessageSentEvent, type StudentWarnedEvent } from "@sip-and-speak/api/domain-events";
+import { domainEvents, type MatchRequestSentEvent, type MatchRequestAcceptedEvent, type MatchRequestDeclinedEvent, type MeetupProposedEvent, type MeetupConfirmedEvent, type MeetupCounterProposedEvent, type MeetupDeclinedEvent, type MeetupCancelledEvent, type MeetupRescheduleProposedEvent, type MeetupRescheduledEvent, type MeetupRescheduleDeclinedEvent, type SipAndSpeakMomentCompletedEvent, type MeetupNotAttendedEvent, type MessagingOptInPromptedEvent, type MessagingNudgeNeededEvent, type ConversationOpenedEvent, type MessagingDeclineOutcomeEvent, type MessageSentEvent, type StudentWarnedEvent, type StudentSuspendedEvent, type SuspensionLiftedEvent } from "@sip-and-speak/api/domain-events";
 import { buildMatchRequestNotificationBody } from "@sip-and-speak/api/routers/matching-utils";
 
 const EXPO_PUSH_URL = "https://exp.host/--/api/v2/push/send";
@@ -393,6 +393,13 @@ export function registerNotificationHandlers(): void {
   });
   domainEvents.on("StudentWarned", (event) => {
     void handleStudentWarned(event);
+  });
+  domainEvents.on("StudentSuspended", (event) => {
+    void handleStudentSuspended(event);        // #102 — cancel proposals + notify peers
+    void handleStudentSuspendedNotify(event);  // #104 — notify the suspended Student
+  });
+  domainEvents.on("SuspensionLifted", (event) => {
+    void handleSuspensionLifted(event);
   });
 }
 
@@ -809,5 +816,97 @@ async function handleStudentWarned(event: StudentWarnedEvent): Promise<void> {
     await sendExpoPushNotification(messages);
   } catch (err) {
     console.error("[push] Failed to send StudentWarned notification", { flagId, err });
+  }
+}
+
+// #102 — Cancel active meetup proposals when a Student is suspended; notify affected peers
+async function handleStudentSuspended(event: StudentSuspendedEvent): Promise<void> {
+  const { flagId, targetId } = event;
+
+  const activeProposals = await db
+    .select({ id: meetup.id, proposerId: meetup.proposerId, receiverId: meetup.receiverId })
+    .from(meetup)
+    .where(
+      and(
+        or(eq(meetup.proposerId, targetId), eq(meetup.receiverId, targetId)),
+        inArray(meetup.status, ["pending", "confirmed"]),
+      ),
+    );
+
+  if (activeProposals.length > 0) {
+    await db
+      .update(meetup)
+      .set({ status: "cancelled" })
+      .where(
+        and(
+          or(eq(meetup.proposerId, targetId), eq(meetup.receiverId, targetId)),
+          inArray(meetup.status, ["pending", "confirmed"]),
+        ),
+      );
+
+    const peerIds = [...new Set(
+      activeProposals.map((p) => p.proposerId === targetId ? p.receiverId : p.proposerId),
+    )];
+
+    const tokens = await db
+      .select({ token: userDeviceToken.token })
+      .from(userDeviceToken)
+      .where(inArray(userDeviceToken.userId, peerIds));
+
+    if (tokens.length > 0) {
+      const messages: ExpoPushMessage[] = tokens.map(({ token }) => ({
+        to: token,
+        title: "Meetup proposal cancelled",
+        body: "Your meetup proposal has been cancelled.",
+        data: { type: "proposal_cancelled" },
+      }));
+      try {
+        await sendExpoPushNotification(messages);
+      } catch (err) {
+        console.error("[push] Failed to send proposal cancellation notification", { flagId, err });
+      }
+    }
+  }
+}
+
+// #104 — Notify suspended Student of the moderation decision
+async function handleStudentSuspendedNotify(event: StudentSuspendedEvent): Promise<void> {
+  const { flagId, targetId } = event;
+  const tokens = await db
+    .select({ token: userDeviceToken.token })
+    .from(userDeviceToken)
+    .where(eq(userDeviceToken.userId, targetId));
+  if (tokens.length === 0) return;
+  const messages: ExpoPushMessage[] = tokens.map(({ token }) => ({
+    to: token,
+    title: "Account suspended",
+    body: "Your account has been temporarily suspended. You will not be able to participate until the suspension is lifted.",
+    data: { flagId, type: "student_suspended" },
+  }));
+  try {
+    await sendExpoPushNotification(messages);
+  } catch (err) {
+    console.error("[push] Failed to send StudentSuspended notification", { flagId, err });
+  }
+}
+
+// #106 — Notify Student when their suspension is lifted
+async function handleSuspensionLifted(event: SuspensionLiftedEvent): Promise<void> {
+  const { targetId } = event;
+  const tokens = await db
+    .select({ token: userDeviceToken.token })
+    .from(userDeviceToken)
+    .where(eq(userDeviceToken.userId, targetId));
+  if (tokens.length === 0) return;
+  const messages: ExpoPushMessage[] = tokens.map(({ token }) => ({
+    to: token,
+    title: "Suspension lifted",
+    body: "Your suspension has been lifted. You can now participate in Sip & Speak again.",
+    data: { type: "suspension_lifted" },
+  }));
+  try {
+    await sendExpoPushNotification(messages);
+  } catch (err) {
+    console.error("[push] Failed to send SuspensionLifted notification", { targetId, err });
   }
 }


### PR DESCRIPTION
## Summary

- `handleStudentSuspended` (#102): cancels all `pending`/`confirmed` meetup proposals for the suspended Student; sends generic cancellation push to affected peers (no moderation reason exposed)
- `handleStudentSuspendedNotify` (#104): sends push to suspended Student's devices
- `handleSuspensionLifted` (#106): sends push to Student when suspension is lifted
- Both `StudentSuspended` and `SuspensionLifted` handlers registered in `registerNotificationHandlers`

Closes #102
Closes #104
Closes #106

## Test plan

- [x] `notifications-suspension.test.ts` — 6 scenarios covering cancellation, peer notification, no-moderation-leak, no-proposals, lift notification, no-token
- [x] All pass (`bun test --cwd apps/server`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)