### PR TITLE
feat(moderation): #105 — lift suspension action for Moderator

### DIFF
--- a/apps/web/src/__tests__/moderator-flag-detail.test.tsx
+++ b/apps/web/src/__tests__/moderator-flag-detail.test.tsx
@@ -34,6 +34,9 @@ vi.mock("@/utils/trpc", () => ({
       suspendStudent: {
         mutationOptions: vi.fn((opts) => ({ mutationKey: ["suspendStudent"], ...opts })),
       },
+      liftSuspension: {
+        mutationOptions: vi.fn((opts) => ({ mutationKey: ["liftSuspension"], ...opts })),
+      },
     },
   },
 }));
@@ -396,6 +399,62 @@ describe("#98 — Suspend action on flag detail view", () => {
     render(<SuspendActionView flag={suspendFlag} suspendError="Action no longer available. The flag may have already been resolved." onSuspend={vi.fn()} />);
 
     expect(screen.getByTestId("suspend-error")).toHaveTextContent("Action no longer available");
+  });
+});
+
+// #105 — Lift suspension inline component
+function LiftSuspensionView({
+  flag,
+  liftPending = false,
+  liftSuccess = false,
+  onLift,
+}: {
+  flag: { flagId: string; flaggedStudent: { id: string; suspended: boolean } };
+  liftPending?: boolean;
+  liftSuccess?: boolean;
+  onLift: () => void;
+}) {
+  if (!flag.flaggedStudent.suspended) return null;
+  return (
+    <div>
+      {liftSuccess ? (
+        <p data-testid="lift-suspension-success">Suspension lifted. Student is now active again.</p>
+      ) : (
+        <button data-testid="btn-lift-suspension" disabled={liftPending || liftSuccess} onClick={onLift}>
+          {liftPending ? "Lifting…" : "Lift Suspension"}
+        </button>
+      )}
+    </div>
+  );
+}
+
+describe("#105 — Lift suspension action", () => {
+  const suspendedFlag = {
+    flagId: "flag-abc",
+    flaggedStudent: { id: "user-2", suspended: true },
+  };
+
+  it("Lift Suspension button visible for suspended Student", () => {
+    render(<LiftSuspensionView flag={suspendedFlag} onLift={vi.fn()} />);
+    expect(screen.getByTestId("btn-lift-suspension")).toBeInTheDocument();
+    expect(screen.getByTestId("btn-lift-suspension")).not.toBeDisabled();
+  });
+
+  it("Lift Suspension button not shown for active Student", () => {
+    const activeFlag = { ...suspendedFlag, flaggedStudent: { ...suspendedFlag.flaggedStudent, suspended: false } };
+    render(<LiftSuspensionView flag={activeFlag} onLift={vi.fn()} />);
+    expect(screen.queryByTestId("btn-lift-suspension")).not.toBeInTheDocument();
+  });
+
+  it("shows loading state while lift is pending", () => {
+    render(<LiftSuspensionView flag={suspendedFlag} liftPending={true} onLift={vi.fn()} />);
+    expect(screen.getByTestId("btn-lift-suspension")).toBeDisabled();
+    expect(screen.getByTestId("btn-lift-suspension")).toHaveTextContent("Lifting…");
+  });
+
+  it("shows success confirmation after lift", () => {
+    render(<LiftSuspensionView flag={suspendedFlag} liftSuccess={true} onLift={vi.fn()} />);
+    expect(screen.getByTestId("lift-suspension-success")).toHaveTextContent("Suspension lifted");
   });
 });
 

--- a/apps/web/src/routes/moderator/flags.$flagId.tsx
+++ b/apps/web/src/routes/moderator/flags.$flagId.tsx
@@ -45,6 +45,14 @@ function FlagDetailScreen() {
     }),
   );
 
+  const liftSuspensionMutation = useMutation(
+    trpc.moderation.liftSuspension.mutationOptions({
+      onSuccess: () => {
+        queryClient.invalidateQueries(trpc.moderation.getFlagDetail.queryOptions({ flagId }));
+      },
+    }),
+  );
+
   const warnError = warnMutation.isError
     ? "Action no longer available. The flag may have already been resolved."
     : undefined;
@@ -176,6 +184,12 @@ function FlagDetailScreen() {
         </p>
       ) : null}
 
+      {liftSuspensionMutation.isSuccess ? (
+        <div className="rounded-md border border-green-500/40 bg-green-500/10 px-4 py-3 text-sm text-green-700" data-testid="lift-suspension-success">
+          Suspension lifted. Student is now active again.
+        </div>
+      ) : null}
+
       <section className="flex gap-3 pt-2">
         <span title={disabledReason}>
           <button
@@ -203,6 +217,16 @@ function FlagDetailScreen() {
         >
           Remove
         </button>
+        {flag.flaggedStudent.suspended ? (
+          <button
+            data-testid="btn-lift-suspension"
+            disabled={liftSuspensionMutation.isPending || liftSuspensionMutation.isSuccess}
+            onClick={() => liftSuspensionMutation.mutate({ targetId: flag.flaggedStudent.id })}
+            className="rounded-md border px-4 py-2 text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {liftSuspensionMutation.isPending ? "Lifting…" : "Lift Suspension"}
+          </button>
+        ) : null}
       </section>
     </div>
   );


### PR DESCRIPTION
## Summary

- Wires `liftSuspension` tRPC mutation on flag detail view
- "Lift Suspension" button shown only when `flaggedStudent.suspended === true`
- Loading state while pending; success banner on completion

Closes #105

## Test plan
- [x] 4 new scenarios in `moderator-flag-detail.test.tsx` (21 total pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)