### PR TITLE
feat(moderation): Feature #33 — Moderator can suspend a flagged Student

### DIFF
--- a/apps/server/src/__tests__/notifications-suspension.test.ts
+++ b/apps/server/src/__tests__/notifications-suspension.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for:
+ *   task #102 — Cancel active proposals on Student suspension + notify peers
+ *   task #104 — Notify suspended Student of the moderation decision
+ *   task #106 — Notify Student when suspension is lifted
+ */
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+interface CapturedFetchCall {
+  url: string;
+  messages: Array<{ to: string; title?: string; body?: string; data?: Record<string, unknown> }>;
+}
+
+const fetchCalls: CapturedFetchCall[] = [];
+(global as unknown as { fetch: unknown }).fetch = mock(async (url: string, options: RequestInit) => {
+  fetchCalls.push({ url, messages: JSON.parse(options.body as string) as CapturedFetchCall["messages"] });
+  return { json: async () => ({ data: [{ status: "ok", id: "t-1" }] }) };
+});
+
+// Track DB update calls for proposal cancellation
+const dbUpdateCalls: Array<{ table: string; status: string }> = [];
+
+mock.module("@sip-and-speak/db/schema/sip-and-speak", () => ({
+  userDeviceToken: "userDeviceToken",
+  userLanguage: "userLanguage",
+  conversationPresence: "conversationPresence",
+  meetup: "meetup",
+}));
+mock.module("@sip-and-speak/db/schema/auth", () => ({ user: "user" }));
+mock.module("drizzle-orm", () => ({
+  eq: (_col: unknown, val: unknown) => ({ _eq: val }),
+  and: (...args: unknown[]) => ({ _and: args }),
+  or: (...args: unknown[]) => ({ _or: args }),
+  inArray: (_col: unknown, vals: unknown) => ({ _inArray: vals }),
+}));
+
+// Rows returned by meetup select (active proposals)
+let mockMeetupRows: Array<{ id: string; proposerId: string; receiverId: string }> = [];
+// Rows returned by device token select
+let mockTokenRows: Array<{ token: string }> = [];
+let mockTokenRowsForSuspended: Array<{ token: string }> = [];
+
+mock.module("@sip-and-speak/db", () => ({
+  db: {
+    select: (cols?: unknown) => {
+      // Distinguish based on field shape — crude but effective for unit tests
+      const hasId = cols && typeof cols === "object" && "id" in (cols as object);
+      return {
+        from: (_table: unknown) => ({
+          where: () => {
+            if (hasId) {
+              // meetup select (has `id` field)
+              return Promise.resolve(mockMeetupRows);
+            }
+            // Alternate between "for peer tokens" and "for suspended student tokens"
+            // by returning mockTokenRows (peer) when mockMeetupRows is non-empty
+            return Promise.resolve(mockMeetupRows.length > 0 ? mockTokenRows : mockTokenRowsForSuspended);
+          },
+        }),
+      };
+    },
+    update: (_table: unknown) => ({
+      set: (_vals: unknown) => ({
+        where: () => {
+          dbUpdateCalls.push({ table: "meetup", status: "cancelled" });
+          return Promise.resolve();
+        },
+      }),
+    }),
+  },
+}));
+
+import { registerNotificationHandlers } from "../notifications";
+import { domainEvents } from "@sip-and-speak/api/domain-events";
+
+describe("handleStudentSuspended — proposal cancellation (#102)", () => {
+  beforeEach(() => {
+    fetchCalls.length = 0;
+    dbUpdateCalls.length = 0;
+    mockMeetupRows = [];
+    mockTokenRows = [];
+    mockTokenRowsForSuspended = [];
+    domainEvents.removeAllListeners();
+    registerNotificationHandlers();
+  });
+
+  it("cancels active proposals when a Student is suspended", async () => {
+    mockMeetupRows = [{ id: "m-1", proposerId: "student-1", receiverId: "student-2" }];
+    mockTokenRows = [{ token: "ExponentPushToken[peer]" }];
+    domainEvents.emit("StudentSuspended", { flagId: "flag-1", targetId: "student-1", moderatorId: "mod-1", suspendedAt: new Date() });
+    await new Promise((r) => setTimeout(r, 30));
+    expect(dbUpdateCalls.length).toBeGreaterThan(0);
+    expect(dbUpdateCalls[0]!.status).toBe("cancelled");
+  });
+
+  it("notifies affected peer when proposal is cancelled", async () => {
+    mockMeetupRows = [{ id: "m-1", proposerId: "student-1", receiverId: "student-2" }];
+    mockTokenRows = [{ token: "ExponentPushToken[peer]" }];
+    domainEvents.emit("StudentSuspended", { flagId: "flag-1", targetId: "student-1", moderatorId: "mod-1", suspendedAt: new Date() });
+    await new Promise((r) => setTimeout(r, 30));
+    const proposalCancelMsg = fetchCalls.find((c) => c.messages[0]?.title === "Meetup proposal cancelled");
+    expect(proposalCancelMsg).toBeDefined();
+    expect(proposalCancelMsg!.messages[0]!.body).toBe("Your meetup proposal has been cancelled.");
+  });
+
+  it("notification does not reveal moderation reason", async () => {
+    mockMeetupRows = [{ id: "m-1", proposerId: "student-1", receiverId: "student-2" }];
+    mockTokenRows = [{ token: "ExponentPushToken[peer]" }];
+    domainEvents.emit("StudentSuspended", { flagId: "flag-1", targetId: "student-1", moderatorId: "mod-1", suspendedAt: new Date() });
+    await new Promise((r) => setTimeout(r, 30));
+    const proposalCancelMsg = fetchCalls.find((c) => c.messages[0]?.title === "Meetup proposal cancelled");
+    expect(proposalCancelMsg!.messages[0]!.body).not.toContain("suspend");
+    expect(proposalCancelMsg!.messages[0]!.body).not.toContain("moderation");
+  });
+
+  it("does nothing when Student has no active proposals", async () => {
+    mockMeetupRows = [];
+    domainEvents.emit("StudentSuspended", { flagId: "flag-2", targetId: "student-1", moderatorId: "mod-1", suspendedAt: new Date() });
+    await new Promise((r) => setTimeout(r, 30));
+    expect(dbUpdateCalls.length).toBe(0);
+  });
+});
+
+describe("handleSuspensionLifted — notify Student (#106)", () => {
+  beforeEach(() => {
+    fetchCalls.length = 0;
+    mockMeetupRows = [];
+    mockTokenRows = [];
+    mockTokenRowsForSuspended = [];
+    domainEvents.removeAllListeners();
+    registerNotificationHandlers();
+  });
+
+  it("notifies Student when suspension is lifted", async () => {
+    mockTokenRowsForSuspended = [{ token: "ExponentPushToken[student]" }];
+    domainEvents.emit("SuspensionLifted", { targetId: "student-1", moderatorId: "mod-1", liftedAt: new Date() });
+    await new Promise((r) => setTimeout(r, 30));
+    const liftedMsg = fetchCalls.find((c) => c.messages[0]?.title === "Suspension lifted");
+    expect(liftedMsg).toBeDefined();
+  });
+
+  it("sends no notification when Student has no device token", async () => {
+    mockTokenRowsForSuspended = [];
+    domainEvents.emit("SuspensionLifted", { targetId: "student-2", moderatorId: "mod-1", liftedAt: new Date() });
+    await new Promise((r) => setTimeout(r, 30));
+    expect(fetchCalls.filter((c) => c.messages[0]?.title === "Suspension lifted").length).toBe(0);
+  });
+});

--- a/apps/server/src/notifications.ts
+++ b/apps/server/src/notifications.ts
@@ -4,11 +4,11 @@
  * Wires domain events to Expo Push API calls.
  * Fire-and-forget: errors are logged but never thrown to callers.
  */
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray, or } from "drizzle-orm";
 import { db } from "@sip-and-speak/db";
-import { userDeviceToken, userLanguage, conversationPresence } from "@sip-and-speak/db/schema/sip-and-speak";
+import { userDeviceToken, userLanguage, conversationPresence, meetup } from "@sip-and-speak/db/schema/sip-and-speak";
 import { user } from "@sip-and-speak/db/schema/auth";
-import { domainEvents, type MatchRequestSentEvent, type MatchRequestAcceptedEvent, type MatchRequestDeclinedEvent, type MeetupProposedEvent, type MeetupConfirmedEvent, type MeetupCounterProposedEvent, type MeetupDeclinedEvent, type MeetupCancelledEvent, type MeetupRescheduleProposedEvent, type MeetupRescheduledEvent, type MeetupRescheduleDeclinedEvent, type SipAndSpeakMomentCompletedEvent, type MeetupNotAttendedEvent, type MessagingOptInPromptedEvent, type MessagingNudgeNeededEvent, type ConversationOpenedEvent, type MessagingDeclineOutcomeEvent, type MessageSentEvent, type StudentWarnedEvent } from "@sip-and-speak/api/domain-events";
+import { domainEvents, type MatchRequestSentEvent, type MatchRequestAcceptedEvent, type MatchRequestDeclinedEvent, type MeetupProposedEvent, type MeetupConfirmedEvent, type MeetupCounterProposedEvent, type MeetupDeclinedEvent, type MeetupCancelledEvent, type MeetupRescheduleProposedEvent, type MeetupRescheduledEvent, type MeetupRescheduleDeclinedEvent, type SipAndSpeakMomentCompletedEvent, type MeetupNotAttendedEvent, type MessagingOptInPromptedEvent, type MessagingNudgeNeededEvent, type ConversationOpenedEvent, type MessagingDeclineOutcomeEvent, type MessageSentEvent, type StudentWarnedEvent, type StudentSuspendedEvent, type SuspensionLiftedEvent } from "@sip-and-speak/api/domain-events";
 import { buildMatchRequestNotificationBody } from "@sip-and-speak/api/routers/matching-utils";
 
 const EXPO_PUSH_URL = "https://exp.host/--/api/v2/push/send";
@@ -393,6 +393,13 @@ export function registerNotificationHandlers(): void {
   });
   domainEvents.on("StudentWarned", (event) => {
     void handleStudentWarned(event);
+  });
+  domainEvents.on("StudentSuspended", (event) => {
+    void handleStudentSuspended(event);        // #102 — cancel proposals + notify peers
+    void handleStudentSuspendedNotify(event);  // #104 — notify the suspended Student
+  });
+  domainEvents.on("SuspensionLifted", (event) => {
+    void handleSuspensionLifted(event);
   });
 }
 
@@ -809,5 +816,97 @@ async function handleStudentWarned(event: StudentWarnedEvent): Promise<void> {
     await sendExpoPushNotification(messages);
   } catch (err) {
     console.error("[push] Failed to send StudentWarned notification", { flagId, err });
+  }
+}
+
+// #102 — Cancel active meetup proposals when a Student is suspended; notify affected peers
+async function handleStudentSuspended(event: StudentSuspendedEvent): Promise<void> {
+  const { flagId, targetId } = event;
+
+  const activeProposals = await db
+    .select({ id: meetup.id, proposerId: meetup.proposerId, receiverId: meetup.receiverId })
+    .from(meetup)
+    .where(
+      and(
+        or(eq(meetup.proposerId, targetId), eq(meetup.receiverId, targetId)),
+        inArray(meetup.status, ["pending", "confirmed"]),
+      ),
+    );
+
+  if (activeProposals.length > 0) {
+    await db
+      .update(meetup)
+      .set({ status: "cancelled" })
+      .where(
+        and(
+          or(eq(meetup.proposerId, targetId), eq(meetup.receiverId, targetId)),
+          inArray(meetup.status, ["pending", "confirmed"]),
+        ),
+      );
+
+    const peerIds = [...new Set(
+      activeProposals.map((p) => p.proposerId === targetId ? p.receiverId : p.proposerId),
+    )];
+
+    const tokens = await db
+      .select({ token: userDeviceToken.token })
+      .from(userDeviceToken)
+      .where(inArray(userDeviceToken.userId, peerIds));
+
+    if (tokens.length > 0) {
+      const messages: ExpoPushMessage[] = tokens.map(({ token }) => ({
+        to: token,
+        title: "Meetup proposal cancelled",
+        body: "Your meetup proposal has been cancelled.",
+        data: { type: "proposal_cancelled" },
+      }));
+      try {
+        await sendExpoPushNotification(messages);
+      } catch (err) {
+        console.error("[push] Failed to send proposal cancellation notification", { flagId, err });
+      }
+    }
+  }
+}
+
+// #104 — Notify suspended Student of the moderation decision
+async function handleStudentSuspendedNotify(event: StudentSuspendedEvent): Promise<void> {
+  const { flagId, targetId } = event;
+  const tokens = await db
+    .select({ token: userDeviceToken.token })
+    .from(userDeviceToken)
+    .where(eq(userDeviceToken.userId, targetId));
+  if (tokens.length === 0) return;
+  const messages: ExpoPushMessage[] = tokens.map(({ token }) => ({
+    to: token,
+    title: "Account suspended",
+    body: "Your account has been temporarily suspended. You will not be able to participate until the suspension is lifted.",
+    data: { flagId, type: "student_suspended" },
+  }));
+  try {
+    await sendExpoPushNotification(messages);
+  } catch (err) {
+    console.error("[push] Failed to send StudentSuspended notification", { flagId, err });
+  }
+}
+
+// #106 — Notify Student when their suspension is lifted
+async function handleSuspensionLifted(event: SuspensionLiftedEvent): Promise<void> {
+  const { targetId } = event;
+  const tokens = await db
+    .select({ token: userDeviceToken.token })
+    .from(userDeviceToken)
+    .where(eq(userDeviceToken.userId, targetId));
+  if (tokens.length === 0) return;
+  const messages: ExpoPushMessage[] = tokens.map(({ token }) => ({
+    to: token,
+    title: "Suspension lifted",
+    body: "Your suspension has been lifted. You can now participate in Sip & Speak again.",
+    data: { type: "suspension_lifted" },
+  }));
+  try {
+    await sendExpoPushNotification(messages);
+  } catch (err) {
+    console.error("[push] Failed to send SuspensionLifted notification", { targetId, err });
   }
 }

--- a/apps/web/src/__tests__/moderator-flag-detail.test.tsx
+++ b/apps/web/src/__tests__/moderator-flag-detail.test.tsx
@@ -34,6 +34,9 @@ vi.mock("@/utils/trpc", () => ({
       suspendStudent: {
         mutationOptions: vi.fn((opts) => ({ mutationKey: ["suspendStudent"], ...opts })),
       },
+      liftSuspension: {
+        mutationOptions: vi.fn((opts) => ({ mutationKey: ["liftSuspension"], ...opts })),
+      },
     },
   },
 }));
@@ -396,6 +399,62 @@ describe("#98 — Suspend action on flag detail view", () => {
     render(<SuspendActionView flag={suspendFlag} suspendError="Action no longer available. The flag may have already been resolved." onSuspend={vi.fn()} />);
 
     expect(screen.getByTestId("suspend-error")).toHaveTextContent("Action no longer available");
+  });
+});
+
+// #105 — Lift suspension inline component
+function LiftSuspensionView({
+  flag,
+  liftPending = false,
+  liftSuccess = false,
+  onLift,
+}: {
+  flag: { flagId: string; flaggedStudent: { id: string; suspended: boolean } };
+  liftPending?: boolean;
+  liftSuccess?: boolean;
+  onLift: () => void;
+}) {
+  if (!flag.flaggedStudent.suspended) return null;
+  return (
+    <div>
+      {liftSuccess ? (
+        <p data-testid="lift-suspension-success">Suspension lifted. Student is now active again.</p>
+      ) : (
+        <button data-testid="btn-lift-suspension" disabled={liftPending || liftSuccess} onClick={onLift}>
+          {liftPending ? "Lifting…" : "Lift Suspension"}
+        </button>
+      )}
+    </div>
+  );
+}
+
+describe("#105 — Lift suspension action", () => {
+  const suspendedFlag = {
+    flagId: "flag-abc",
+    flaggedStudent: { id: "user-2", suspended: true },
+  };
+
+  it("Lift Suspension button visible for suspended Student", () => {
+    render(<LiftSuspensionView flag={suspendedFlag} onLift={vi.fn()} />);
+    expect(screen.getByTestId("btn-lift-suspension")).toBeInTheDocument();
+    expect(screen.getByTestId("btn-lift-suspension")).not.toBeDisabled();
+  });
+
+  it("Lift Suspension button not shown for active Student", () => {
+    const activeFlag = { ...suspendedFlag, flaggedStudent: { ...suspendedFlag.flaggedStudent, suspended: false } };
+    render(<LiftSuspensionView flag={activeFlag} onLift={vi.fn()} />);
+    expect(screen.queryByTestId("btn-lift-suspension")).not.toBeInTheDocument();
+  });
+
+  it("shows loading state while lift is pending", () => {
+    render(<LiftSuspensionView flag={suspendedFlag} liftPending={true} onLift={vi.fn()} />);
+    expect(screen.getByTestId("btn-lift-suspension")).toBeDisabled();
+    expect(screen.getByTestId("btn-lift-suspension")).toHaveTextContent("Lifting…");
+  });
+
+  it("shows success confirmation after lift", () => {
+    render(<LiftSuspensionView flag={suspendedFlag} liftSuccess={true} onLift={vi.fn()} />);
+    expect(screen.getByTestId("lift-suspension-success")).toHaveTextContent("Suspension lifted");
   });
 });
 

--- a/apps/web/src/__tests__/moderator-flag-detail.test.tsx
+++ b/apps/web/src/__tests__/moderator-flag-detail.test.tsx
@@ -31,6 +31,9 @@ vi.mock("@/utils/trpc", () => ({
       getFlagDetail: {
         queryOptions: vi.fn((input) => ({ queryKey: ["getFlagDetail", input] })),
       },
+      suspendStudent: {
+        mutationOptions: vi.fn((opts) => ({ mutationKey: ["suspendStudent"], ...opts })),
+      },
     },
   },
 }));
@@ -284,6 +287,115 @@ describe("#88 — Warn action on flag detail view", () => {
       "Warning issued. The flag has been resolved.",
     );
     expect(screen.queryByTestId("btn-warn")).not.toBeInTheDocument();
+  });
+});
+
+// #98 — Suspend action inline component
+function SuspendActionView({
+  flag,
+  suspendPending = false,
+  suspendSuccess = false,
+  suspendError,
+  onSuspend,
+}: {
+  flag: {
+    flagId: string;
+    flaggedStudent: { id: string; name: string | null; removed: boolean; suspended: boolean };
+  };
+  suspendPending?: boolean;
+  suspendSuccess?: boolean;
+  suspendError?: string;
+  onSuspend: () => void;
+}) {
+  if (suspendSuccess) {
+    return <p data-testid="suspend-success">Student suspended. The flag has been resolved.</p>;
+  }
+
+  const studentDisabled = flag.flaggedStudent.suspended || flag.flaggedStudent.removed;
+  const disabledReason = flag.flaggedStudent.removed
+    ? "Student has already been removed"
+    : flag.flaggedStudent.suspended
+      ? "Student is already suspended"
+      : undefined;
+
+  return (
+    <div>
+      {suspendError ? (
+        <p data-testid="suspend-error">{suspendError}</p>
+      ) : null}
+      <span title={disabledReason}>
+        <button
+          data-testid="btn-suspend"
+          disabled={studentDisabled || suspendPending}
+          onClick={onSuspend}
+        >
+          {suspendPending ? "Suspending…" : "Suspend"}
+        </button>
+      </span>
+    </div>
+  );
+}
+
+describe("#98 — Suspend action on flag detail view", () => {
+  const suspendFlag = {
+    flagId: "flag-abc",
+    flaggedStudent: { id: "user-2", name: "Jane Doe", removed: false, suspended: false },
+  };
+
+  it("Suspend button is visible and enabled for an active Student", () => {
+    render(<SuspendActionView flag={suspendFlag} onSuspend={vi.fn()} />);
+
+    const btn = screen.getByTestId("btn-suspend");
+    expect(btn).toBeInTheDocument();
+    expect(btn).not.toBeDisabled();
+    expect(btn).toHaveTextContent("Suspend");
+  });
+
+  it("Suspend button is disabled with tooltip for an already-suspended Student", () => {
+    const suspendedFlag = {
+      ...suspendFlag,
+      flaggedStudent: { ...suspendFlag.flaggedStudent, suspended: true },
+    };
+
+    render(<SuspendActionView flag={suspendedFlag} onSuspend={vi.fn()} />);
+
+    expect(screen.getByTestId("btn-suspend")).toBeDisabled();
+    expect(screen.getByTitle("Student is already suspended")).toBeInTheDocument();
+  });
+
+  it("Suspend button is disabled with tooltip for a removed Student", () => {
+    const removedFlag = {
+      ...suspendFlag,
+      flaggedStudent: { ...suspendFlag.flaggedStudent, removed: true },
+    };
+
+    render(<SuspendActionView flag={removedFlag} onSuspend={vi.fn()} />);
+
+    expect(screen.getByTestId("btn-suspend")).toBeDisabled();
+    expect(screen.getByTitle("Student has already been removed")).toBeInTheDocument();
+  });
+
+  it("shows loading state while suspend is pending", () => {
+    render(<SuspendActionView flag={suspendFlag} suspendPending={true} onSuspend={vi.fn()} />);
+
+    const btn = screen.getByTestId("btn-suspend");
+    expect(btn).toBeDisabled();
+    expect(btn).toHaveTextContent("Suspending…");
+  });
+
+  it("shows resolved confirmation on suspend success", () => {
+    render(<SuspendActionView flag={suspendFlag} suspendSuccess={true} onSuspend={vi.fn()} />);
+
+    expect(screen.getByTestId("suspend-success")).toHaveTextContent(
+      "Student suspended. The flag has been resolved.",
+    );
+    expect(screen.queryByTestId("btn-suspend")).not.toBeInTheDocument();
+  });
+
+  it("shows error message when suspend action is no longer available", () => {
+    render(<SuspendActionView flag={suspendFlag} suspendError="Action no longer available. The flag may have already been resolved." onSuspend={vi.fn()} />);
+
+    expect(screen.getByTestId("suspend-error")).toHaveTextContent("Action no longer available");
   });
 });
 

--- a/apps/web/src/routes/moderator/flags.$flagId.tsx
+++ b/apps/web/src/routes/moderator/flags.$flagId.tsx
@@ -45,6 +45,14 @@ function FlagDetailScreen() {
     }),
   );
 
+  const liftSuspensionMutation = useMutation(
+    trpc.moderation.liftSuspension.mutationOptions({
+      onSuccess: () => {
+        queryClient.invalidateQueries(trpc.moderation.getFlagDetail.queryOptions({ flagId }));
+      },
+    }),
+  );
+
   const warnError = warnMutation.isError
     ? "Action no longer available. The flag may have already been resolved."
     : undefined;
@@ -176,6 +184,12 @@ function FlagDetailScreen() {
         </p>
       ) : null}
 
+      {liftSuspensionMutation.isSuccess ? (
+        <div className="rounded-md border border-green-500/40 bg-green-500/10 px-4 py-3 text-sm text-green-700" data-testid="lift-suspension-success">
+          Suspension lifted. Student is now active again.
+        </div>
+      ) : null}
+
       <section className="flex gap-3 pt-2">
         <span title={disabledReason}>
           <button
@@ -203,6 +217,16 @@ function FlagDetailScreen() {
         >
           Remove
         </button>
+        {flag.flaggedStudent.suspended ? (
+          <button
+            data-testid="btn-lift-suspension"
+            disabled={liftSuspensionMutation.isPending || liftSuspensionMutation.isSuccess}
+            onClick={() => liftSuspensionMutation.mutate({ targetId: flag.flaggedStudent.id })}
+            className="rounded-md border px-4 py-2 text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {liftSuspensionMutation.isPending ? "Lifting…" : "Lift Suspension"}
+          </button>
+        ) : null}
       </section>
     </div>
   );

--- a/apps/web/src/routes/moderator/flags.$flagId.tsx
+++ b/apps/web/src/routes/moderator/flags.$flagId.tsx
@@ -1,5 +1,6 @@
 // #80 — Moderator flag detail view
 // #88 — Warn action with loading/success states
+// #98 — Suspend action with loading/success states
 // TODO: Tighten auth guard to Moderator role once role field is added to user schema
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -35,7 +36,20 @@ function FlagDetailScreen() {
     }),
   );
 
+  const suspendMutation = useMutation(
+    trpc.moderation.suspendStudent.mutationOptions({
+      onSuccess: () => {
+        queryClient.invalidateQueries(trpc.moderation.getFlagDetail.queryOptions({ flagId }));
+        queryClient.invalidateQueries(trpc.moderation.listOpenFlags.queryOptions());
+      },
+    }),
+  );
+
   const warnError = warnMutation.isError
+    ? "Action no longer available. The flag may have already been resolved."
+    : undefined;
+
+  const suspendError = suspendMutation.isError
     ? "Action no longer available. The flag may have already been resolved."
     : undefined;
 
@@ -58,6 +72,22 @@ function FlagDetailScreen() {
           data-testid="warn-success"
         >
           Warning issued. The flag has been resolved.
+        </div>
+      </div>
+    );
+  }
+
+  if (suspendMutation.isSuccess) {
+    return (
+      <div className="p-6 space-y-4 max-w-2xl">
+        <Link to="/moderator/flags" className="text-sm text-muted-foreground hover:underline">
+          ← Back to queue
+        </Link>
+        <div
+          className="rounded-md border border-yellow-500/40 bg-yellow-500/10 px-4 py-3 text-sm text-yellow-700"
+          data-testid="suspend-success"
+        >
+          Student suspended. The flag has been resolved.
         </div>
       </div>
     );
@@ -140,6 +170,12 @@ function FlagDetailScreen() {
         </p>
       ) : null}
 
+      {suspendError ? (
+        <p className="rounded-md border border-destructive/40 bg-destructive/10 px-4 py-2 text-sm text-destructive" data-testid="suspend-error">
+          {suspendError}
+        </p>
+      ) : null}
+
       <section className="flex gap-3 pt-2">
         <span title={disabledReason}>
           <button
@@ -151,12 +187,16 @@ function FlagDetailScreen() {
             {warnMutation.isPending ? "Warning…" : "Warn"}
           </button>
         </span>
-        <button
-          disabled
-          className="rounded-md border px-4 py-2 text-sm font-medium opacity-50 cursor-not-allowed"
-        >
-          Suspend
-        </button>
+        <span title={disabledReason}>
+          <button
+            data-testid="btn-suspend"
+            disabled={studentDisabled || suspendMutation.isPending}
+            onClick={() => suspendMutation.mutate({ flagId })}
+            className="rounded-md border px-4 py-2 text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {suspendMutation.isPending ? "Suspending…" : "Suspend"}
+          </button>
+        </span>
         <button
           disabled={flag.flaggedStudent.removed}
           className="rounded-md border px-4 py-2 text-sm font-medium opacity-50 cursor-not-allowed"

--- a/packages/api/src/__tests__/moderation-flag-detail.test.ts
+++ b/packages/api/src/__tests__/moderation-flag-detail.test.ts
@@ -15,6 +15,7 @@ const baseFlag = {
   id: "flag-abc",
   targetId: "user-2",
   targetName: "Jane Doe",
+  targetStatus: "active" as string | null,
   reason: "Disruptive behaviour",
   detail: "Kept interrupting",
   createdAt: new Date("2026-04-10T09:15:00Z"),
@@ -25,7 +26,7 @@ describe("#80 — buildFlagDetail", () => {
     const result = buildFlagDetail(baseFlag, []);
 
     expect(result.flagId).toBe("flag-abc");
-    expect(result.flaggedStudent).toEqual({ id: "user-2", name: "Jane Doe", removed: false });
+    expect(result.flaggedStudent).toEqual({ id: "user-2", name: "Jane Doe", removed: false, suspended: false });
     expect(result.reason).toBe("Disruptive behaviour");
     expect(result.detail).toBe("Kept interrupting");
     expect(result.submittedAt).toBe("2026-04-10T09:15:00.000Z");
@@ -53,7 +54,7 @@ describe("#80 — buildFlagDetail", () => {
   });
 
   it("sets removed: true when flagged Student's name is null (user record absent)", () => {
-    const removedStudentFlag = { ...baseFlag, targetName: null };
+    const removedStudentFlag = { ...baseFlag, targetName: null, targetStatus: null };
 
     const result = buildFlagDetail(removedStudentFlag, []);
 

--- a/packages/api/src/__tests__/moderation-suspend.test.ts
+++ b/packages/api/src/__tests__/moderation-suspend.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for task #100/#103 — Transition Student to Suspended state + record in flag history
+ *
+ * Covers pure helpers — no DB interaction.
+ *
+ *   - buildSuspendFlagValues: status='resolved', outcome='suspended', moderatorId, resolvedAt
+ *   - buildStudentSuspendedEvent: correct payload shape
+ *   - checkStudentActive: blocks on suspended or removed students
+ *   - buildFlagDetail: suspended field reflects actual studentStatus
+ */
+import { describe, it, expect } from "bun:test";
+
+import {
+  buildSuspendFlagValues,
+  buildStudentSuspendedEvent,
+  checkStudentActive,
+  buildFlagDetail,
+} from "../routers/moderation-utils";
+
+describe("#103 — buildSuspendFlagValues", () => {
+  it("Suspension recorded in flag history: sets status=resolved, outcome=suspended", () => {
+    const resolvedAt = new Date("2026-04-14T12:00:00Z");
+    const result = buildSuspendFlagValues("mod-1", resolvedAt);
+
+    expect(result).toEqual({
+      status: "resolved",
+      outcome: "suspended",
+      moderatorId: "mod-1",
+      resolvedAt,
+    });
+  });
+
+  it("Flag transitions to resolved after suspend: status is always 'resolved'", () => {
+    const result = buildSuspendFlagValues("mod-1", new Date());
+    expect(result.status).toBe("resolved");
+    expect(result.outcome).toBe("suspended");
+  });
+});
+
+describe("#100 — buildStudentSuspendedEvent", () => {
+  it("StudentSuspended domain event emitted with correct payload", () => {
+    const suspendedAt = new Date("2026-04-14T12:00:00Z");
+    const result = buildStudentSuspendedEvent("flag-1", "student-1", "mod-1", suspendedAt);
+
+    expect(result).toEqual({
+      flagId: "flag-1",
+      targetId: "student-1",
+      moderatorId: "mod-1",
+      suspendedAt,
+    });
+  });
+});
+
+describe("#100 — checkStudentActive (suspend guard)", () => {
+  it("Suspended Student cannot be suspended again: returns false when suspended=true", () => {
+    expect(checkStudentActive(true, true)).toBe(false);
+  });
+
+  it("Removed Student cannot be suspended: returns false when exists=false", () => {
+    expect(checkStudentActive(false, false)).toBe(false);
+  });
+
+  it("Active Student can be suspended: returns true when exists=true and suspended=false", () => {
+    expect(checkStudentActive(true, false)).toBe(true);
+  });
+});
+
+describe("#100 — buildFlagDetail suspended field", () => {
+  const base = {
+    id: "flag-1",
+    targetId: "student-1",
+    targetName: "Jane Doe",
+    reason: "HARASSMENT",
+    detail: null,
+    createdAt: new Date("2026-01-01"),
+  };
+
+  it("Returns suspended=true when studentStatus is 'suspended'", () => {
+    const result = buildFlagDetail({ ...base, targetStatus: "suspended" }, []);
+    expect(result.flaggedStudent.suspended).toBe(true);
+  });
+
+  it("Returns suspended=false when studentStatus is 'active'", () => {
+    const result = buildFlagDetail({ ...base, targetStatus: "active" }, []);
+    expect(result.flaggedStudent.suspended).toBe(false);
+  });
+
+  it("Returns suspended=false when targetStatus is null (user removed)", () => {
+    const result = buildFlagDetail({ ...base, targetStatus: null }, []);
+    expect(result.flaggedStudent.suspended).toBe(false);
+  });
+
+  it("Returns removed=true and suspended=false when targetName is null", () => {
+    const result = buildFlagDetail({ ...base, targetName: null, targetStatus: null }, []);
+    expect(result.flaggedStudent.removed).toBe(true);
+    expect(result.flaggedStudent.suspended).toBe(false);
+  });
+});

--- a/packages/api/src/domain-events.ts
+++ b/packages/api/src/domain-events.ts
@@ -203,6 +203,21 @@ export interface StudentWarnedEvent {
   warnedAt: Date;
 }
 
+// #100
+export interface StudentSuspendedEvent {
+  flagId: string;
+  targetId: string;
+  moderatorId: string;
+  suspendedAt: Date;
+}
+
+// #105
+export interface SuspensionLiftedEvent {
+  targetId: string;
+  moderatorId: string;
+  liftedAt: Date;
+}
+
 type DomainEventMap = {
   LanguageProfileUpdated: [LanguageProfileUpdatedEvent];
   InterestProfileUpdated: [InterestProfileUpdatedEvent];
@@ -230,6 +245,8 @@ type DomainEventMap = {
   MessageSent: [MessageSentEvent];
   StudentFlagged: [StudentFlaggedEvent];
   StudentWarned: [StudentWarnedEvent];
+  StudentSuspended: [StudentSuspendedEvent];
+  SuspensionLifted: [SuspensionLiftedEvent];
 };
 
 class TypedEventEmitter extends EventEmitter {

--- a/packages/api/src/routers/chat.ts
+++ b/packages/api/src/routers/chat.ts
@@ -162,6 +162,16 @@ export const chatRouter = router({
     .mutation(async ({ ctx, input }) => {
       const userId = ctx.session.user.id;
 
+      // #100 — Guard: suspended Students cannot send messages
+      const [sender] = await db
+        .select({ studentStatus: user.studentStatus })
+        .from(user)
+        .where(eq(user.id, userId))
+        .limit(1);
+      if (sender?.studentStatus === "suspended") {
+        throw new TRPCError({ code: "FORBIDDEN", message: "Suspended Students cannot send messages." });
+      }
+
       // Verify user is part of this conversation
       const conv = await db
         .select()

--- a/packages/api/src/routers/matching.ts
+++ b/packages/api/src/routers/matching.ts
@@ -118,11 +118,11 @@ export const matchingRouter = router({
         .from(userInterest)
         .where(inArray(userInterest.userId, otherUserIds));
 
-      // Fetch user info (name, image) for candidates
+      // Fetch user info (name, image) for candidates — exclude suspended Students (#100)
       const allUsers = await db
         .select({ id: user.id, name: user.name, image: user.image })
         .from(user)
-        .where(inArray(user.id, otherUserIds));
+        .where(and(inArray(user.id, otherUserIds), ne(user.studentStatus, "suspended")));
 
       const userMap = new Map(allUsers.map((u) => [u.id, u]));
 

--- a/packages/api/src/routers/meetup.ts
+++ b/packages/api/src/routers/meetup.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { db } from "@sip-and-speak/db";
 import { meetup, venue, studentMatch, attendanceReport } from "@sip-and-speak/db/schema/sip-and-speak";
+import { user } from "@sip-and-speak/db/schema/auth";
 import { protectedProcedure, router } from "../index";
 import { domainEvents } from "../domain-events";
 import { isMeetupInThePast, isRescheduleNoOp } from "./meetup-utils";
@@ -62,6 +63,16 @@ export const meetupRouter = router({
 
       if (userId === input.partnerId) {
         throw new TRPCError({ code: "BAD_REQUEST", message: "You cannot propose a meetup with yourself" });
+      }
+
+      // #100 — Guard: suspended Students cannot create meetup proposals
+      const [proposer] = await db
+        .select({ studentStatus: user.studentStatus })
+        .from(user)
+        .where(eq(user.id, userId))
+        .limit(1);
+      if (proposer?.studentStatus === "suspended") {
+        throw new TRPCError({ code: "FORBIDDEN", message: "Suspended Students cannot create meetup proposals." });
       }
 
       // #68: Matched state check

--- a/packages/api/src/routers/moderation-persist.ts
+++ b/packages/api/src/routers/moderation-persist.ts
@@ -6,7 +6,8 @@ import { eq } from "drizzle-orm";
 
 import { db } from "@sip-and-speak/db";
 import { userFlag } from "@sip-and-speak/db/schema/sip-and-speak";
-import { buildFlagValues, buildWarnFlagValues } from "./moderation-utils";
+import { buildFlagValues, buildWarnFlagValues, buildSuspendFlagValues } from "./moderation-utils";
+import { user } from "@sip-and-speak/db/schema/auth";
 
 export interface PersistFlagInput {
   reporterId: string;
@@ -41,4 +42,38 @@ export async function persistWarnFlag(flagId: string, moderatorId: string) {
     .returning({ targetId: userFlag.targetId, warnedAt: userFlag.resolvedAt });
 
   return { targetId: updated!.targetId, warnedAt };
+}
+
+/**
+ * #100/#103 — Transitions a Student to suspended state and resolves the flag.
+ * Sets user.studentStatus = 'suspended' and resolves the flag with outcome 'suspended'.
+ */
+export async function persistSuspendStudent(flagId: string, targetId: string, moderatorId: string) {
+  const suspendedAt = new Date();
+  await db
+    .update(user)
+    .set({ studentStatus: "suspended" })
+    .where(eq(user.id, targetId));
+
+  const [updated] = await db
+    .update(userFlag)
+    .set(buildSuspendFlagValues(moderatorId, suspendedAt))
+    .where(eq(userFlag.id, flagId))
+    .returning({ targetId: userFlag.targetId, suspendedAt: userFlag.resolvedAt });
+
+  return { targetId: updated!.targetId, suspendedAt };
+}
+
+/**
+ * #105 — Lifts a Student's suspension.
+ * Sets user.studentStatus back to 'active'.
+ */
+export async function persistLiftSuspension(targetId: string) {
+  const liftedAt = new Date();
+  await db
+    .update(user)
+    .set({ studentStatus: "active" })
+    .where(eq(user.id, targetId));
+
+  return { liftedAt };
 }

--- a/packages/api/src/routers/moderation-utils.ts
+++ b/packages/api/src/routers/moderation-utils.ts
@@ -127,6 +127,7 @@ export interface FlagDetailRow {
   id: string;
   targetId: string;
   targetName: string | null;
+  targetStatus: string | null; // #100 — studentStatus from user table
   reason: string;
   detail: string | null;
   createdAt: Date;
@@ -141,7 +142,6 @@ export interface PriorFlagRow {
 
 export interface FlagDetailEntry {
   flagId: string;
-  // #88 — `suspended` added; always false until Feature #33 adds the DB column
   flaggedStudent: { id: string; name: string | null; removed: boolean; suspended: boolean };
   reason: string;
   detail: string | null;
@@ -151,8 +151,8 @@ export interface FlagDetailEntry {
 
 /**
  * Builds the flag detail API response from DB rows.
- * `removed` is true when the flagged Student's user record is absent (null name + no match).
- * `suspended` is always false until Feature #33 adds a DB-level suspended status.
+ * `removed` is true when the flagged Student's user record is absent.
+ * `suspended` is true when studentStatus is 'suspended'.
  */
 export function buildFlagDetail(
   flag: FlagDetailRow,
@@ -164,7 +164,7 @@ export function buildFlagDetail(
       id: flag.targetId,
       name: flag.targetName,
       removed: flag.targetName === null,
-      suspended: false, // Feature #33 will set this from the DB
+      suspended: flag.targetStatus === "suspended",
     },
     reason: flag.reason,
     detail: flag.detail,
@@ -244,10 +244,69 @@ export const STUDENT_INACTIVE_MESSAGE =
   "Action no longer available — Student is suspended or removed";
 
 /**
- * Returns true if the Student can receive a warn action.
+ * Returns true if the Student can receive a warn/suspend action.
  * `exists` — user record found in DB (false = removed).
- * `suspended` — suspended flag (always false until Feature #33 adds DB column).
+ * `suspended` — true when studentStatus is 'suspended'.
  */
 export function checkStudentActive(exists: boolean, suspended: boolean): boolean {
   return exists && !suspended;
+}
+
+// #100 — Pure helpers for the suspend flow
+
+export interface SuspendFlagValues {
+  status: "resolved";
+  outcome: "suspended";
+  moderatorId: string;
+  resolvedAt: Date;
+}
+
+/**
+ * Builds the DB update payload for resolving a flag with outcome 'suspended'.
+ */
+export function buildSuspendFlagValues(moderatorId: string, resolvedAt: Date): SuspendFlagValues {
+  return {
+    status: "resolved",
+    outcome: "suspended",
+    moderatorId,
+    resolvedAt,
+  };
+}
+
+export interface StudentSuspendedPayload {
+  flagId: string;
+  targetId: string;
+  moderatorId: string;
+  suspendedAt: Date;
+}
+
+/**
+ * Builds the StudentSuspended domain event payload.
+ */
+export function buildStudentSuspendedEvent(
+  flagId: string,
+  targetId: string,
+  moderatorId: string,
+  suspendedAt: Date,
+): StudentSuspendedPayload {
+  return { flagId, targetId, moderatorId, suspendedAt };
+}
+
+// #105 — Pure helpers for the lift suspension flow
+
+export interface SuspensionLiftedPayload {
+  targetId: string;
+  moderatorId: string;
+  liftedAt: Date;
+}
+
+/**
+ * Builds the SuspensionLifted domain event payload.
+ */
+export function buildSuspensionLiftedEvent(
+  targetId: string,
+  moderatorId: string,
+  liftedAt: Date,
+): SuspensionLiftedPayload {
+  return { targetId, moderatorId, liftedAt };
 }

--- a/packages/api/src/routers/moderation.ts
+++ b/packages/api/src/routers/moderation.ts
@@ -12,12 +12,14 @@ import {
   FLAG_VALIDATION_MESSAGES,
   buildStudentFlaggedEvent,
   buildStudentWarnedEvent,
+  buildStudentSuspendedEvent,
+  buildSuspensionLiftedEvent,
   buildFlagQueueEntry,
   buildFlagDetail,
   checkStudentActive,
   STUDENT_INACTIVE_MESSAGE,
 } from "./moderation-utils";
-import { persistFlag, persistWarnFlag } from "./moderation-persist";
+import { persistFlag, persistWarnFlag, persistSuspendStudent, persistLiftSuspension } from "./moderation-persist";
 import { domainEvents } from "../domain-events";
 
 export const flagReasonSchema = z.enum([
@@ -73,6 +75,7 @@ export const moderationRouter = router({
           id: userFlag.id,
           targetId: userFlag.targetId,
           targetName: user.name,
+          targetStatus: user.studentStatus,
           reason: userFlag.reason,
           detail: userFlag.detail,
           createdAt: userFlag.createdAt,
@@ -132,14 +135,14 @@ export const moderationRouter = router({
         throw new TRPCError({ code: "CONFLICT", message: "Flag already resolved." });
       }
 
-      // #92 — Guard: reject if Student is removed (suspended deferred to Feature #33)
+      // #92 — Guard: reject if Student is removed or suspended
       const studentRows = await db
-        .select({ id: user.id })
+        .select({ id: user.id, studentStatus: user.studentStatus })
         .from(user)
         .where(eq(user.id, flagRows[0].targetId))
         .limit(1);
 
-      if (!checkStudentActive(!!studentRows[0], false)) {
+      if (!checkStudentActive(!!studentRows[0], studentRows[0]?.studentStatus === "suspended")) {
         throw new TRPCError({ code: "BAD_REQUEST", message: STUDENT_INACTIVE_MESSAGE });
       }
 
@@ -148,6 +151,85 @@ export const moderationRouter = router({
       domainEvents.emit(
         "StudentWarned",
         buildStudentWarnedEvent(input.flagId, flagRows[0].targetId, moderatorId, warnedAt),
+      );
+
+      return { success: true as const };
+    }),
+
+  /**
+   * #100/#103 — Suspend a flagged Student.
+   * Sets studentStatus to 'suspended', resolves flag with outcome 'suspended',
+   * and emits the StudentSuspended domain event.
+   */
+  suspendStudent: protectedProcedure
+    .input(z.object({ flagId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const moderatorId = ctx.session.user.id;
+
+      const flagRows = await db
+        .select({ id: userFlag.id, status: userFlag.status, targetId: userFlag.targetId })
+        .from(userFlag)
+        .where(eq(userFlag.id, input.flagId))
+        .limit(1);
+
+      if (!flagRows[0]) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Flag not found." });
+      }
+      if (flagRows[0].status !== "open") {
+        throw new TRPCError({ code: "CONFLICT", message: "Flag already resolved." });
+      }
+
+      const studentRows = await db
+        .select({ id: user.id, studentStatus: user.studentStatus })
+        .from(user)
+        .where(eq(user.id, flagRows[0].targetId))
+        .limit(1);
+
+      if (!checkStudentActive(!!studentRows[0], studentRows[0]?.studentStatus === "suspended")) {
+        throw new TRPCError({ code: "BAD_REQUEST", message: STUDENT_INACTIVE_MESSAGE });
+      }
+
+      const { targetId, suspendedAt } = await persistSuspendStudent(
+        input.flagId,
+        flagRows[0].targetId,
+        moderatorId,
+      );
+
+      domainEvents.emit(
+        "StudentSuspended",
+        buildStudentSuspendedEvent(input.flagId, targetId, moderatorId, suspendedAt),
+      );
+
+      return { success: true as const };
+    }),
+
+  /**
+   * #105 — Lift a Student's suspension.
+   * Resets studentStatus to 'active' and emits SuspensionLifted event.
+   */
+  liftSuspension: protectedProcedure
+    .input(z.object({ targetId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const moderatorId = ctx.session.user.id;
+
+      const studentRows = await db
+        .select({ id: user.id, studentStatus: user.studentStatus })
+        .from(user)
+        .where(eq(user.id, input.targetId))
+        .limit(1);
+
+      if (!studentRows[0]) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Student not found." });
+      }
+      if (studentRows[0].studentStatus !== "suspended") {
+        throw new TRPCError({ code: "BAD_REQUEST", message: "Student is not suspended." });
+      }
+
+      const { liftedAt } = await persistLiftSuspension(input.targetId);
+
+      domainEvents.emit(
+        "SuspensionLifted",
+        buildSuspensionLiftedEvent(input.targetId, moderatorId, liftedAt),
       );
 
       return { success: true as const };

--- a/packages/db/src/migrations/0013_slim_marvel_zombies.sql
+++ b/packages/db/src/migrations/0013_slim_marvel_zombies.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "user" ADD COLUMN "student_status" text DEFAULT 'active' NOT NULL;

--- a/packages/db/src/migrations/meta/0013_snapshot.json
+++ b/packages/db/src/migrations/meta/0013_snapshot.json
@@ -1,0 +1,2093 @@
+{
+  "id": "8adb3870-d6d4-4af3-bc78-cff9abad5e86",
+  "prevId": "f49b6f45-a63f-4236-bfd5-68f89a307f39",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "student_status": {
+          "name": "student_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attendance_report": {
+      "name": "attendance_report",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "meetup_id": {
+          "name": "meetup_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attended": {
+          "name": "attended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reported_at": {
+          "name": "reported_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "attendance_report_meetupId_idx": {
+          "name": "attendance_report_meetupId_idx",
+          "columns": [
+            {
+              "expression": "meetup_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attendance_report_meetup_id_meetup_id_fk": {
+          "name": "attendance_report_meetup_id_meetup_id_fk",
+          "tableFrom": "attendance_report",
+          "tableTo": "meetup",
+          "columnsFrom": [
+            "meetup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attendance_report_student_id_user_id_fk": {
+          "name": "attendance_report_student_id_user_id_fk",
+          "tableFrom": "attendance_report",
+          "tableTo": "user",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "attendance_report_meetup_student_unique": {
+          "name": "attendance_report_meetup_student_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "meetup_id",
+            "student_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation": {
+      "name": "conversation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user1_id": {
+          "name": "user1_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user2_id": {
+          "name": "user2_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meetup_id": {
+          "name": "meetup_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_user1_idx": {
+          "name": "conversation_user1_idx",
+          "columns": [
+            {
+              "expression": "user1_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_user2_idx": {
+          "name": "conversation_user2_idx",
+          "columns": [
+            {
+              "expression": "user2_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_meetupId_idx": {
+          "name": "conversation_meetupId_idx",
+          "columns": [
+            {
+              "expression": "meetup_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_user1_id_user_id_fk": {
+          "name": "conversation_user1_id_user_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user1_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_user2_id_user_id_fk": {
+          "name": "conversation_user2_id_user_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user2_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_meetup_id_meetup_id_fk": {
+          "name": "conversation_meetup_id_meetup_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "meetup",
+          "columnsFrom": [
+            "meetup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_presence": {
+      "name": "conversation_presence",
+      "schema": "",
+      "columns": {
+        "student_id": {
+          "name": "student_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_until": {
+          "name": "active_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "conversation_presence_studentId_idx": {
+          "name": "conversation_presence_studentId_idx",
+          "columns": [
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_presence_student_id_user_id_fk": {
+          "name": "conversation_presence_student_id_user_id_fk",
+          "tableFrom": "conversation_presence",
+          "tableTo": "user",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_presence_conversation_id_conversation_id_fk": {
+          "name": "conversation_presence_conversation_id_conversation_id_fk",
+          "tableFrom": "conversation_presence",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversation_presence_student_conv_unique": {
+          "name": "conversation_presence_student_conv_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "student_id",
+            "conversation_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.language_profile": {
+      "name": "language_profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "university": {
+          "name": "university",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "age": {
+          "name": "age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_complete": {
+          "name": "onboarding_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "language_profile_user_id_user_id_fk": {
+          "name": "language_profile_user_id_user_id_fk",
+          "tableFrom": "language_profile",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "language_profile_user_id_unique": {
+          "name": "language_profile_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_request": {
+      "name": "match_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "requester_id": {
+          "name": "requester_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receiver_id": {
+          "name": "receiver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "match_request_requesterId_idx": {
+          "name": "match_request_requesterId_idx",
+          "columns": [
+            {
+              "expression": "requester_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "match_request_receiverId_idx": {
+          "name": "match_request_receiverId_idx",
+          "columns": [
+            {
+              "expression": "receiver_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "match_request_requester_id_user_id_fk": {
+          "name": "match_request_requester_id_user_id_fk",
+          "tableFrom": "match_request",
+          "tableTo": "user",
+          "columnsFrom": [
+            "requester_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "match_request_receiver_id_user_id_fk": {
+          "name": "match_request_receiver_id_user_id_fk",
+          "tableFrom": "match_request",
+          "tableTo": "user",
+          "columnsFrom": [
+            "receiver_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meetup": {
+      "name": "meetup",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "proposer_id": {
+          "name": "proposer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receiver_id": {
+          "name": "receiver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "venue_id": {
+          "name": "venue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "reschedule_proposer_id": {
+          "name": "reschedule_proposer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reschedule_venue_id": {
+          "name": "reschedule_venue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reschedule_date": {
+          "name": "reschedule_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reschedule_time": {
+          "name": "reschedule_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "meetup_proposerId_idx": {
+          "name": "meetup_proposerId_idx",
+          "columns": [
+            {
+              "expression": "proposer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meetup_receiverId_idx": {
+          "name": "meetup_receiverId_idx",
+          "columns": [
+            {
+              "expression": "receiver_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meetup_date_idx": {
+          "name": "meetup_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "meetup_proposer_id_user_id_fk": {
+          "name": "meetup_proposer_id_user_id_fk",
+          "tableFrom": "meetup",
+          "tableTo": "user",
+          "columnsFrom": [
+            "proposer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meetup_receiver_id_user_id_fk": {
+          "name": "meetup_receiver_id_user_id_fk",
+          "tableFrom": "meetup",
+          "tableTo": "user",
+          "columnsFrom": [
+            "receiver_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meetup_venue_id_venue_id_fk": {
+          "name": "meetup_venue_id_venue_id_fk",
+          "tableFrom": "meetup",
+          "tableTo": "venue",
+          "columnsFrom": [
+            "venue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meetup_reschedule_proposer_id_user_id_fk": {
+          "name": "meetup_reschedule_proposer_id_user_id_fk",
+          "tableFrom": "meetup",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reschedule_proposer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "meetup_reschedule_venue_id_venue_id_fk": {
+          "name": "meetup_reschedule_venue_id_venue_id_fk",
+          "tableFrom": "meetup",
+          "tableTo": "venue",
+          "columnsFrom": [
+            "reschedule_venue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message": {
+      "name": "message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_conversationId_idx": {
+          "name": "message_conversationId_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_createdAt_idx": {
+          "name": "message_createdAt_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_conversation_id_conversation_id_fk": {
+          "name": "message_conversation_id_conversation_id_fk",
+          "tableFrom": "message",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_sender_id_user_id_fk": {
+          "name": "message_sender_id_user_id_fk",
+          "tableFrom": "message",
+          "tableTo": "user",
+          "columnsFrom": [
+            "sender_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message_read_status": {
+      "name": "message_read_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_read_conversationId_userId_idx": {
+          "name": "message_read_conversationId_userId_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_read_status_conversation_id_conversation_id_fk": {
+          "name": "message_read_status_conversation_id_conversation_id_fk",
+          "tableFrom": "message_read_status",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_read_status_user_id_user_id_fk": {
+          "name": "message_read_status_user_id_user_id_fk",
+          "tableFrom": "message_read_status",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messaging_opt_in": {
+      "name": "messaging_opt_in",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "meetup_id": {
+          "name": "meetup_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "nudge_sent_at": {
+          "name": "nudge_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "messaging_opt_in_meetupId_idx": {
+          "name": "messaging_opt_in_meetupId_idx",
+          "columns": [
+            {
+              "expression": "meetup_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messaging_opt_in_meetup_id_meetup_id_fk": {
+          "name": "messaging_opt_in_meetup_id_meetup_id_fk",
+          "tableFrom": "messaging_opt_in",
+          "tableTo": "meetup",
+          "columnsFrom": [
+            "meetup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messaging_opt_in_student_id_user_id_fk": {
+          "name": "messaging_opt_in_student_id_user_id_fk",
+          "tableFrom": "messaging_opt_in",
+          "tableTo": "user",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "messaging_opt_in_meetup_student_unique": {
+          "name": "messaging_opt_in_meetup_student_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "meetup_id",
+            "student_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_comment": {
+      "name": "student_comment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "student_comment_targetId_idx": {
+          "name": "student_comment_targetId_idx",
+          "columns": [
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "student_comment_author_id_user_id_fk": {
+          "name": "student_comment_author_id_user_id_fk",
+          "tableFrom": "student_comment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "student_comment_target_id_user_id_fk": {
+          "name": "student_comment_target_id_user_id_fk",
+          "tableFrom": "student_comment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_match": {
+      "name": "student_match",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "student_a_id": {
+          "name": "student_a_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_b_id": {
+          "name": "student_b_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_request_id": {
+          "name": "match_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'matched'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "student_match_studentA_idx": {
+          "name": "student_match_studentA_idx",
+          "columns": [
+            {
+              "expression": "student_a_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "student_match_studentB_idx": {
+          "name": "student_match_studentB_idx",
+          "columns": [
+            {
+              "expression": "student_b_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "student_match_student_a_id_user_id_fk": {
+          "name": "student_match_student_a_id_user_id_fk",
+          "tableFrom": "student_match",
+          "tableTo": "user",
+          "columnsFrom": [
+            "student_a_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "student_match_student_b_id_user_id_fk": {
+          "name": "student_match_student_b_id_user_id_fk",
+          "tableFrom": "student_match",
+          "tableTo": "user",
+          "columnsFrom": [
+            "student_b_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "student_match_match_request_id_match_request_id_fk": {
+          "name": "student_match_match_request_id_match_request_id_fk",
+          "tableFrom": "student_match",
+          "tableTo": "match_request",
+          "columnsFrom": [
+            "match_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_device_token": {
+      "name": "user_device_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_device_token_userId_token_idx": {
+          "name": "user_device_token_userId_token_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_device_token_user_id_user_id_fk": {
+          "name": "user_device_token_user_id_user_id_fk",
+          "tableFrom": "user_device_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_flag": {
+      "name": "user_flag",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moderator_id": {
+          "name": "moderator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_flag_reporter_idx": {
+          "name": "user_flag_reporter_idx",
+          "columns": [
+            {
+              "expression": "reporter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_flag_target_idx": {
+          "name": "user_flag_target_idx",
+          "columns": [
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_flag_status_idx": {
+          "name": "user_flag_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_flag_reporter_id_user_id_fk": {
+          "name": "user_flag_reporter_id_user_id_fk",
+          "tableFrom": "user_flag",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_flag_target_id_user_id_fk": {
+          "name": "user_flag_target_id_user_id_fk",
+          "tableFrom": "user_flag",
+          "tableTo": "user",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_flag_moderator_id_user_id_fk": {
+          "name": "user_flag_moderator_id_user_id_fk",
+          "tableFrom": "user_flag",
+          "tableTo": "user",
+          "columnsFrom": [
+            "moderator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_interest": {
+      "name": "user_interest",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interest": {
+          "name": "interest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_interest_userId_idx": {
+          "name": "user_interest_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_interest_user_id_user_id_fk": {
+          "name": "user_interest_user_id_user_id_fk",
+          "tableFrom": "user_interest",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_language": {
+      "name": "user_language",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proficiency": {
+          "name": "proficiency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_language_userId_idx": {
+          "name": "user_language_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_language_user_id_user_id_fk": {
+          "name": "user_language_user_id_user_id_fk",
+          "tableFrom": "user_language",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.venue": {
+      "name": "venue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "venue_name_idx": {
+          "name": "venue_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1776157965717,
       "tag": "0012_striped_victor_mancha",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1776163744198,
+      "tag": "0013_slim_marvel_zombies",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/auth.ts
+++ b/packages/db/src/schema/auth.ts
@@ -21,6 +21,10 @@ export const user = pgTable("user", {
     .defaultNow()
     .$onUpdate(() => /* @__PURE__ */ new Date())
     .notNull(),
+  // #100 — Trust & Moderation: student participation status
+  studentStatus: text("student_status", { enum: ["active", "suspended", "removed"] })
+    .notNull()
+    .default("active"),
 });
 
 export const session = pgTable(


### PR DESCRIPTION
## Summary

- Moderator can suspend a flagged Student from the flag detail view
- Suspended Students blocked from sending messages, creating proposals, appearing as match candidates
- Active meetup proposals cancelled automatically on suspension
- Flag resolved with outcome `suspended`; suspension recorded in Student history
- Moderator can lift suspension, returning Student to active status
- Suspended Student and affected peers notified via push

Closes #33
Closes #98
Closes #100
Closes #102
Closes #103
Closes #104
Closes #105
Closes #106

## Tasks

- #100/#103 — Suspend state + flag history (PR #262)
- #98 — Suspend action UI (PR #263)
- #102/#104/#106 — Cancel proposals + push notifications (PR #264)
- #105 — Lift suspension UI (PR #265)

🤖 Generated with [Claude Code](https://claude.com/claude-code)