### PR TITLE
feat(moderation): #108 — deactivate removed Student account + block login

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -176,6 +176,7 @@
         "@sip-and-speak/env": "workspace:*",
         "better-auth": "catalog:",
         "dotenv": "catalog:",
+        "drizzle-orm": "^0.45.1",
         "zod": "catalog:",
       },
       "devDependencies": {

--- a/packages/api/src/__tests__/moderation-remove.test.ts
+++ b/packages/api/src/__tests__/moderation-remove.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for task #108 — Deactivate removed Student's account (block login)
+ *
+ * Covers pure helpers — no DB interaction.
+ *
+ *   - buildRemoveFlagValues: status='resolved', outcome='removed', moderatorId, resolvedAt
+ *   - buildStudentRemovedEvent: correct payload shape
+ *   - buildFlagDetail: removed field reflects studentStatus='removed'
+ *   - checkStudentRemoved: idempotency guard
+ */
+import { describe, it, expect } from "bun:test";
+
+import {
+  buildRemoveFlagValues,
+  buildStudentRemovedEvent,
+  buildFlagDetail,
+  checkStudentRemoved,
+} from "../routers/moderation-utils";
+
+describe("#108 — buildRemoveFlagValues", () => {
+  it("sets status=resolved, outcome=removed", () => {
+    const resolvedAt = new Date("2026-04-14T12:00:00Z");
+    const result = buildRemoveFlagValues("mod-1", resolvedAt);
+
+    expect(result).toEqual({
+      status: "resolved",
+      outcome: "removed",
+      moderatorId: "mod-1",
+      resolvedAt,
+    });
+  });
+
+  it("flag transitions to resolved after remove: status is always 'resolved'", () => {
+    const result = buildRemoveFlagValues("mod-1", new Date());
+    expect(result.status).toBe("resolved");
+    expect(result.outcome).toBe("removed");
+  });
+});
+
+describe("#108 — buildStudentRemovedEvent", () => {
+  it("StudentRemoved domain event emitted with correct payload", () => {
+    const removedAt = new Date("2026-04-14T12:00:00Z");
+    const result = buildStudentRemovedEvent("flag-1", "student-1", "mod-1", removedAt);
+
+    expect(result).toEqual({
+      flagId: "flag-1",
+      targetId: "student-1",
+      moderatorId: "mod-1",
+      removedAt,
+    });
+  });
+});
+
+describe("#108 — checkStudentRemoved (idempotency guard)", () => {
+  it("Already-removed Student: returns true (is already removed)", () => {
+    expect(checkStudentRemoved("removed")).toBe(true);
+  });
+
+  it("Active Student can be removed: returns false (not yet removed)", () => {
+    expect(checkStudentRemoved("active")).toBe(false);
+  });
+
+  it("Suspended Student can be removed: returns false (not yet removed)", () => {
+    expect(checkStudentRemoved("suspended")).toBe(false);
+  });
+});
+
+describe("#108 — buildFlagDetail removed field (via studentStatus)", () => {
+  const base = {
+    id: "flag-1",
+    targetId: "student-1",
+    targetName: "Jane Doe",
+    reason: "HARASSMENT",
+    detail: null,
+    createdAt: new Date("2026-01-01"),
+  };
+
+  it("Returns removed=true when studentStatus is 'removed'", () => {
+    const result = buildFlagDetail({ ...base, targetStatus: "removed" }, []);
+    expect(result.flaggedStudent.removed).toBe(true);
+  });
+
+  it("Returns removed=false when studentStatus is 'active'", () => {
+    const result = buildFlagDetail({ ...base, targetStatus: "active" }, []);
+    expect(result.flaggedStudent.removed).toBe(false);
+  });
+
+  it("Returns removed=false when studentStatus is 'suspended'", () => {
+    const result = buildFlagDetail({ ...base, targetStatus: "suspended" }, []);
+    expect(result.flaggedStudent.removed).toBe(false);
+  });
+
+  it("Returns removed=true when targetName is null (legacy removed proxy still works)", () => {
+    const result = buildFlagDetail({ ...base, targetName: null, targetStatus: null }, []);
+    expect(result.flaggedStudent.removed).toBe(true);
+  });
+});

--- a/packages/api/src/domain-events.ts
+++ b/packages/api/src/domain-events.ts
@@ -218,6 +218,14 @@ export interface SuspensionLiftedEvent {
   liftedAt: Date;
 }
 
+// #108
+export interface StudentRemovedEvent {
+  flagId: string;
+  targetId: string;
+  moderatorId: string;
+  removedAt: Date;
+}
+
 type DomainEventMap = {
   LanguageProfileUpdated: [LanguageProfileUpdatedEvent];
   InterestProfileUpdated: [InterestProfileUpdatedEvent];
@@ -247,6 +255,7 @@ type DomainEventMap = {
   StudentWarned: [StudentWarnedEvent];
   StudentSuspended: [StudentSuspendedEvent];
   SuspensionLifted: [SuspensionLiftedEvent];
+  StudentRemoved: [StudentRemovedEvent];
 };
 
 class TypedEventEmitter extends EventEmitter {

--- a/packages/api/src/routers/moderation-persist.ts
+++ b/packages/api/src/routers/moderation-persist.ts
@@ -6,7 +6,7 @@ import { eq } from "drizzle-orm";
 
 import { db } from "@sip-and-speak/db";
 import { userFlag } from "@sip-and-speak/db/schema/sip-and-speak";
-import { buildFlagValues, buildWarnFlagValues, buildSuspendFlagValues } from "./moderation-utils";
+import { buildFlagValues, buildWarnFlagValues, buildSuspendFlagValues, buildRemoveFlagValues } from "./moderation-utils";
 import { user } from "@sip-and-speak/db/schema/auth";
 
 export interface PersistFlagInput {
@@ -62,6 +62,26 @@ export async function persistSuspendStudent(flagId: string, targetId: string, mo
     .returning({ targetId: userFlag.targetId, suspendedAt: userFlag.resolvedAt });
 
   return { targetId: updated!.targetId, suspendedAt };
+}
+
+/**
+ * #108 — Permanently removes a Student.
+ * Sets user.studentStatus = 'removed' and resolves the flag with outcome 'removed'.
+ */
+export async function persistRemoveStudent(flagId: string, targetId: string, moderatorId: string) {
+  const removedAt = new Date();
+  await db
+    .update(user)
+    .set({ studentStatus: "removed" })
+    .where(eq(user.id, targetId));
+
+  const [updated] = await db
+    .update(userFlag)
+    .set(buildRemoveFlagValues(moderatorId, removedAt))
+    .where(eq(userFlag.id, flagId))
+    .returning({ targetId: userFlag.targetId });
+
+  return { targetId: updated!.targetId, removedAt };
 }
 
 /**

--- a/packages/api/src/routers/moderation-utils.ts
+++ b/packages/api/src/routers/moderation-utils.ts
@@ -151,7 +151,7 @@ export interface FlagDetailEntry {
 
 /**
  * Builds the flag detail API response from DB rows.
- * `removed` is true when the flagged Student's user record is absent.
+ * `removed` is true when studentStatus is 'removed' OR targetName is null (legacy proxy).
  * `suspended` is true when studentStatus is 'suspended'.
  */
 export function buildFlagDetail(
@@ -163,7 +163,7 @@ export function buildFlagDetail(
     flaggedStudent: {
       id: flag.targetId,
       name: flag.targetName,
-      removed: flag.targetName === null,
+      removed: flag.targetStatus === "removed" || flag.targetName === null,
       suspended: flag.targetStatus === "suspended",
     },
     reason: flag.reason,
@@ -290,6 +290,53 @@ export function buildStudentSuspendedEvent(
   suspendedAt: Date,
 ): StudentSuspendedPayload {
   return { flagId, targetId, moderatorId, suspendedAt };
+}
+
+// #108 — Pure helpers for the permanent remove flow
+
+export interface RemoveFlagValues {
+  status: "resolved";
+  outcome: "removed";
+  moderatorId: string;
+  resolvedAt: Date;
+}
+
+/**
+ * Builds the DB update payload for resolving a flag with outcome 'removed'.
+ */
+export function buildRemoveFlagValues(moderatorId: string, resolvedAt: Date): RemoveFlagValues {
+  return {
+    status: "resolved",
+    outcome: "removed",
+    moderatorId,
+    resolvedAt,
+  };
+}
+
+export interface StudentRemovedPayload {
+  flagId: string;
+  targetId: string;
+  moderatorId: string;
+  removedAt: Date;
+}
+
+/**
+ * Builds the StudentRemoved domain event payload.
+ */
+export function buildStudentRemovedEvent(
+  flagId: string,
+  targetId: string,
+  moderatorId: string,
+  removedAt: Date,
+): StudentRemovedPayload {
+  return { flagId, targetId, moderatorId, removedAt };
+}
+
+/**
+ * Returns true if the Student is already removed (idempotency guard).
+ */
+export function checkStudentRemoved(studentStatus: string | null | undefined): boolean {
+  return studentStatus === "removed";
 }
 
 // #105 — Pure helpers for the lift suspension flow

--- a/packages/api/src/routers/moderation.ts
+++ b/packages/api/src/routers/moderation.ts
@@ -13,13 +13,15 @@ import {
   buildStudentFlaggedEvent,
   buildStudentWarnedEvent,
   buildStudentSuspendedEvent,
+  buildStudentRemovedEvent,
   buildSuspensionLiftedEvent,
   buildFlagQueueEntry,
   buildFlagDetail,
   checkStudentActive,
+  checkStudentRemoved,
   STUDENT_INACTIVE_MESSAGE,
 } from "./moderation-utils";
-import { persistFlag, persistWarnFlag, persistSuspendStudent, persistLiftSuspension } from "./moderation-persist";
+import { persistFlag, persistWarnFlag, persistSuspendStudent, persistRemoveStudent, persistLiftSuspension } from "./moderation-persist";
 import { domainEvents } from "../domain-events";
 
 export const flagReasonSchema = z.enum([
@@ -236,12 +238,15 @@ export const moderationRouter = router({
     }),
 
   /**
-   * #107 (stub) — Permanent remove action.
-   * Accepts flagId, validates flag is open. Full removal logic in Task #108.
+   * #107/#108 — Permanently remove a flagged Student.
+   * Sets studentStatus to 'removed', resolves flag with outcome 'removed',
+   * and emits the StudentRemoved domain event.
    */
   removeStudent: protectedProcedure
     .input(z.object({ flagId: z.string() }))
-    .mutation(async ({ input }) => {
+    .mutation(async ({ ctx, input }) => {
+      const moderatorId = ctx.session.user.id;
+
       const flagRows = await db
         .select({ id: userFlag.id, status: userFlag.status, targetId: userFlag.targetId })
         .from(userFlag)
@@ -254,6 +259,28 @@ export const moderationRouter = router({
       if (flagRows[0].status !== "open") {
         throw new TRPCError({ code: "CONFLICT", message: "Flag already resolved." });
       }
+
+      const studentRows = await db
+        .select({ id: user.id, studentStatus: user.studentStatus })
+        .from(user)
+        .where(eq(user.id, flagRows[0].targetId))
+        .limit(1);
+
+      if (checkStudentRemoved(studentRows[0]?.studentStatus)) {
+        // Idempotent — already removed, return success without side effects
+        return { success: true as const };
+      }
+
+      const { targetId, removedAt } = await persistRemoveStudent(
+        input.flagId,
+        flagRows[0].targetId,
+        moderatorId,
+      );
+
+      domainEvents.emit(
+        "StudentRemoved",
+        buildStudentRemovedEvent(input.flagId, targetId, moderatorId, removedAt),
+      );
 
       return { success: true as const };
     }),

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -20,6 +20,7 @@
     "@sip-and-speak/env": "workspace:*",
     "better-auth": "catalog:",
     "dotenv": "catalog:",
+    "drizzle-orm": "^0.45.1",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -6,6 +6,7 @@ import { env } from "@sip-and-speak/env/server";
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { emailOTP } from "better-auth/plugins";
+import { eq } from "drizzle-orm";
 
 import { polarClient } from "./lib/payments";
 
@@ -19,6 +20,22 @@ export function createAuth() {
       schema: schema,
     }),
     databaseHooks: {
+      session: {
+        create: {
+          before: async (sessionData) => {
+            // #108 — Block login for permanently removed Students
+            const [userRow] = await db
+              .select({ studentStatus: schema.user.studentStatus })
+              .from(schema.user)
+              .where(eq(schema.user.id, sessionData.userId))
+              .limit(1);
+
+            if (userRow?.studentStatus === "removed") {
+              throw new Error("Your account is no longer active.");
+            }
+          },
+        },
+      },
       user: {
         create: {
           after: async (user) => {


### PR DESCRIPTION
## Summary

- `removeStudent` mutation now sets `studentStatus = 'removed'`, resolves flag with `outcome = 'removed'`, and emits `StudentRemoved` domain event
- Better-Auth `databaseHooks.session.create.before` rejects login for removed accounts (generic message, no moderation reason disclosed)
- Remove action is idempotent — already-removed Students return success without re-emitting the event
- Pure helpers: `buildRemoveFlagValues`, `buildStudentRemovedEvent`, `checkStudentRemoved`
- `buildFlagDetail` now uses `targetStatus === 'removed'` (+ legacy `targetName === null` fallback)

## Test plan

- [ ] 10 new Bun unit tests in `packages/api/src/__tests__/moderation-remove.test.ts`
- [ ] All existing moderation tests still pass
- [ ] Web tests still pass (31 scenarios)

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)