### PR TITLE
feat(moderation): #110 — cancel active proposals on removal and notify affected Students

### DIFF
--- a/apps/server/src/__tests__/notifications-removal-proposals.test.ts
+++ b/apps/server/src/__tests__/notifications-removal-proposals.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Tests for task #110 — Cancel active meetup proposals on removal and notify affected Students
+ */
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+interface CapturedFetchCall {
+  url: string;
+  messages: Array<{ to: string; title?: string; body?: string; data?: Record<string, unknown> }>;
+}
+
+const fetchCalls: CapturedFetchCall[] = [];
+(global as unknown as { fetch: unknown }).fetch = mock(async (url: string, options: RequestInit) => {
+  fetchCalls.push({ url, messages: JSON.parse(options.body as string) as CapturedFetchCall["messages"] });
+  return { json: async () => ({ data: [{ status: "ok", id: "t-1" }] }) };
+});
+
+const dbUpdateCalls: Array<{ table: string; status: string }> = [];
+
+mock.module("@sip-and-speak/db/schema/sip-and-speak", () => ({
+  userDeviceToken: "userDeviceToken",
+  userLanguage: "userLanguage",
+  conversationPresence: "conversationPresence",
+  meetup: "meetup",
+  blockedEmail: "blockedEmail",
+}));
+mock.module("@sip-and-speak/db/schema/auth", () => ({ user: "user" }));
+mock.module("drizzle-orm", () => ({
+  eq: (_col: unknown, val: unknown) => ({ _eq: val }),
+  and: (...args: unknown[]) => ({ _and: args }),
+  or: (...args: unknown[]) => ({ _or: args }),
+  inArray: (_col: unknown, vals: unknown) => ({ _inArray: vals }),
+}));
+
+let mockMeetupRows: Array<{ id: string; proposerId: string; receiverId: string }> = [];
+let mockTokenRows: Array<{ token: string }> = [];
+
+mock.module("@sip-and-speak/db", () => ({
+  db: {
+    select: (cols?: unknown) => {
+      const hasId = cols && typeof cols === "object" && "id" in (cols as object);
+      return {
+        from: (_table: unknown) => ({
+          where: () => {
+            if (hasId) return Promise.resolve(mockMeetupRows);
+            return Promise.resolve(mockTokenRows);
+          },
+          limit: () => Promise.resolve([]),
+        }),
+      };
+    },
+    update: (_table: unknown) => ({
+      set: (_vals: unknown) => ({
+        where: () => {
+          dbUpdateCalls.push({ table: "meetup", status: "cancelled" });
+          return Promise.resolve();
+        },
+      }),
+    }),
+    insert: (_table: unknown) => ({
+      values: (_vals: unknown) => ({
+        onConflictDoNothing: () => Promise.resolve(),
+      }),
+    }),
+  },
+}));
+
+import { registerNotificationHandlers } from "../notifications";
+import { domainEvents } from "@sip-and-speak/api/domain-events";
+
+describe("handleStudentRemovedCancelProposals (#110)", () => {
+  beforeEach(() => {
+    fetchCalls.length = 0;
+    dbUpdateCalls.length = 0;
+    mockMeetupRows = [];
+    mockTokenRows = [];
+    domainEvents.removeAllListeners();
+    registerNotificationHandlers();
+  });
+
+  it("cancels active proposals when a Student is removed", async () => {
+    mockMeetupRows = [{ id: "m-1", proposerId: "student-1", receiverId: "student-2" }];
+    mockTokenRows = [{ token: "ExponentPushToken[peer]" }];
+    domainEvents.emit("StudentRemoved", { flagId: "flag-1", targetId: "student-1", moderatorId: "mod-1", removedAt: new Date() });
+    await new Promise((r) => setTimeout(r, 30));
+    expect(dbUpdateCalls.length).toBeGreaterThan(0);
+    expect(dbUpdateCalls[0]!.status).toBe("cancelled");
+  });
+
+  it("notifies affected peer generically (no mention of removal)", async () => {
+    mockMeetupRows = [{ id: "m-1", proposerId: "student-1", receiverId: "student-2" }];
+    mockTokenRows = [{ token: "ExponentPushToken[peer]" }];
+    domainEvents.emit("StudentRemoved", { flagId: "flag-1", targetId: "student-1", moderatorId: "mod-1", removedAt: new Date() });
+    await new Promise((r) => setTimeout(r, 30));
+    const msg = fetchCalls.find((c) => c.messages[0]?.title === "Meetup proposal cancelled");
+    expect(msg).toBeDefined();
+    expect(msg!.messages[0]!.body).toBe("Your meetup proposal has been cancelled.");
+    expect(msg!.messages[0]!.body).not.toContain("remov");
+  });
+
+  it("completed proposals not affected (no active proposals → no update)", async () => {
+    mockMeetupRows = [];
+    domainEvents.emit("StudentRemoved", { flagId: "flag-2", targetId: "student-1", moderatorId: "mod-1", removedAt: new Date() });
+    await new Promise((r) => setTimeout(r, 30));
+    expect(dbUpdateCalls.length).toBe(0);
+  });
+});

--- a/apps/server/src/notifications.ts
+++ b/apps/server/src/notifications.ts
@@ -8,7 +8,7 @@ import { and, eq, inArray, or } from "drizzle-orm";
 import { db } from "@sip-and-speak/db";
 import { userDeviceToken, userLanguage, conversationPresence, meetup } from "@sip-and-speak/db/schema/sip-and-speak";
 import { user } from "@sip-and-speak/db/schema/auth";
-import { domainEvents, type MatchRequestSentEvent, type MatchRequestAcceptedEvent, type MatchRequestDeclinedEvent, type MeetupProposedEvent, type MeetupConfirmedEvent, type MeetupCounterProposedEvent, type MeetupDeclinedEvent, type MeetupCancelledEvent, type MeetupRescheduleProposedEvent, type MeetupRescheduledEvent, type MeetupRescheduleDeclinedEvent, type SipAndSpeakMomentCompletedEvent, type MeetupNotAttendedEvent, type MessagingOptInPromptedEvent, type MessagingNudgeNeededEvent, type ConversationOpenedEvent, type MessagingDeclineOutcomeEvent, type MessageSentEvent, type StudentWarnedEvent, type StudentSuspendedEvent, type SuspensionLiftedEvent } from "@sip-and-speak/api/domain-events";
+import { domainEvents, type MatchRequestSentEvent, type MatchRequestAcceptedEvent, type MatchRequestDeclinedEvent, type MeetupProposedEvent, type MeetupConfirmedEvent, type MeetupCounterProposedEvent, type MeetupDeclinedEvent, type MeetupCancelledEvent, type MeetupRescheduleProposedEvent, type MeetupRescheduledEvent, type MeetupRescheduleDeclinedEvent, type SipAndSpeakMomentCompletedEvent, type MeetupNotAttendedEvent, type MessagingOptInPromptedEvent, type MessagingNudgeNeededEvent, type ConversationOpenedEvent, type MessagingDeclineOutcomeEvent, type MessageSentEvent, type StudentWarnedEvent, type StudentSuspendedEvent, type SuspensionLiftedEvent, type StudentRemovedEvent } from "@sip-and-speak/api/domain-events";
 import { buildMatchRequestNotificationBody } from "@sip-and-speak/api/routers/matching-utils";
 
 const EXPO_PUSH_URL = "https://exp.host/--/api/v2/push/send";
@@ -400,6 +400,9 @@ export function registerNotificationHandlers(): void {
   });
   domainEvents.on("SuspensionLifted", (event) => {
     void handleSuspensionLifted(event);
+  });
+  domainEvents.on("StudentRemoved", (event) => {
+    void handleStudentRemovedCancelProposals(event); // #110 — cancel proposals + notify peers
   });
 }
 
@@ -887,6 +890,56 @@ async function handleStudentSuspendedNotify(event: StudentSuspendedEvent): Promi
     await sendExpoPushNotification(messages);
   } catch (err) {
     console.error("[push] Failed to send StudentSuspended notification", { flagId, err });
+  }
+}
+
+// #110 — Cancel active meetup proposals when a Student is permanently removed
+async function handleStudentRemovedCancelProposals(event: StudentRemovedEvent): Promise<void> {
+  const { targetId } = event;
+
+  const activeProposals = await db
+    .select({ id: meetup.id, proposerId: meetup.proposerId, receiverId: meetup.receiverId })
+    .from(meetup)
+    .where(
+      and(
+        or(eq(meetup.proposerId, targetId), eq(meetup.receiverId, targetId)),
+        inArray(meetup.status, ["pending", "confirmed"]),
+      ),
+    );
+
+  if (activeProposals.length === 0) return;
+
+  await db
+    .update(meetup)
+    .set({ status: "cancelled" })
+    .where(
+      and(
+        or(eq(meetup.proposerId, targetId), eq(meetup.receiverId, targetId)),
+        inArray(meetup.status, ["pending", "confirmed"]),
+      ),
+    );
+
+  const peerIds = [...new Set(
+    activeProposals.map((p) => p.proposerId === targetId ? p.receiverId : p.proposerId),
+  )];
+
+  const tokens = await db
+    .select({ token: userDeviceToken.token })
+    .from(userDeviceToken)
+    .where(inArray(userDeviceToken.userId, peerIds));
+
+  if (tokens.length > 0) {
+    const messages: ExpoPushMessage[] = tokens.map(({ token }) => ({
+      to: token,
+      title: "Meetup proposal cancelled",
+      body: "Your meetup proposal has been cancelled.",
+      data: { type: "proposal_cancelled" },
+    }));
+    try {
+      await sendExpoPushNotification(messages);
+    } catch (err) {
+      console.error("[push] Failed to send removal proposal cancellation notification", { targetId, err });
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- Subscribes to `StudentRemoved` event and cancels all active (`pending`/`confirmed`) meetup proposals involving the removed Student
- Notifies affected peer Students with a generic "Your meetup proposal has been cancelled." push notification (no mention of moderation)
- Idempotent: no-ops when no active proposals exist

## Test plan

- [x] `notifications-removal-proposals.test.ts` — 3 Gherkin scenarios covered (cancel active, notify peer generically, completed unaffected)
- [x] All 3 tests pass

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)