### PR TITLE
feat(moderation): #111 — close open conversations on Student removal

### DIFF
--- a/apps/server/src/__tests__/notifications-removal-conversations.test.ts
+++ b/apps/server/src/__tests__/notifications-removal-conversations.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests for task #111 — Close open conversations involving a removed Student
+ */
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+(global as unknown as { fetch: unknown }).fetch = mock(async () => ({
+  json: async () => ({ data: [{ status: "ok", id: "t-1" }] }),
+}));
+
+const dbUpdateCalls: Array<{ table: string; status: string }> = [];
+let mockConversationRows: Array<{ id: string }> = [];
+
+mock.module("@sip-and-speak/db/schema/sip-and-speak", () => ({
+  userDeviceToken: "userDeviceToken",
+  userLanguage: "userLanguage",
+  conversationPresence: "conversationPresence",
+  meetup: "meetup",
+  blockedEmail: "blockedEmail",
+  conversation: "conversation",
+}));
+mock.module("@sip-and-speak/db/schema/auth", () => ({ user: "user" }));
+mock.module("drizzle-orm", () => ({
+  eq: (_col: unknown, val: unknown) => ({ _eq: val }),
+  and: (...args: unknown[]) => ({ _and: args }),
+  or: (...args: unknown[]) => ({ _or: args }),
+  inArray: (_col: unknown, vals: unknown) => ({ _inArray: vals }),
+}));
+
+mock.module("@sip-and-speak/db", () => ({
+  db: {
+    select: (_cols?: unknown) => ({
+      from: (_table: unknown) => ({
+        where: () => Promise.resolve(mockConversationRows),
+        limit: () => Promise.resolve([]),
+      }),
+    }),
+    update: (table: unknown) => ({
+      set: (vals: Record<string, unknown>) => ({
+        where: () => {
+          dbUpdateCalls.push({ table: table as string, status: vals["status"] as string });
+          return Promise.resolve();
+        },
+      }),
+    }),
+    insert: (_table: unknown) => ({
+      values: (_vals: unknown) => ({
+        onConflictDoNothing: () => Promise.resolve(),
+      }),
+    }),
+  },
+}));
+
+import { registerNotificationHandlers } from "../notifications";
+import { domainEvents } from "@sip-and-speak/api/domain-events";
+
+describe("handleStudentRemovedCloseConversations (#111)", () => {
+  beforeEach(() => {
+    dbUpdateCalls.length = 0;
+    mockConversationRows = [];
+    domainEvents.removeAllListeners();
+    registerNotificationHandlers();
+  });
+
+  it("closes open conversations when a Student is removed", async () => {
+    mockConversationRows = [{ id: "conv-1" }];
+    domainEvents.emit("StudentRemoved", { flagId: "flag-1", targetId: "student-1", moderatorId: "mod-1", removedAt: new Date() });
+    await new Promise((r) => setTimeout(r, 30));
+    const conversationUpdate = dbUpdateCalls.find((c) => c.table === "conversation" && c.status === "closed");
+    expect(conversationUpdate).toBeDefined();
+  });
+
+  it("does not update conversations when no open conversations exist", async () => {
+    mockConversationRows = [];
+    domainEvents.emit("StudentRemoved", { flagId: "flag-2", targetId: "student-1", moderatorId: "mod-1", removedAt: new Date() });
+    await new Promise((r) => setTimeout(r, 30));
+    const conversationUpdate = dbUpdateCalls.find((c) => c.table === "conversation");
+    expect(conversationUpdate).toBeUndefined();
+  });
+
+  it("already-closed conversations are not re-updated (idempotent via query filter)", async () => {
+    // The handler only queries status="open" conversations — none returned = no update
+    mockConversationRows = [];
+    domainEvents.emit("StudentRemoved", { flagId: "flag-3", targetId: "student-2", moderatorId: "mod-1", removedAt: new Date() });
+    await new Promise((r) => setTimeout(r, 30));
+    const conversationUpdate = dbUpdateCalls.find((c) => c.table === "conversation");
+    expect(conversationUpdate).toBeUndefined();
+  });
+});

--- a/apps/server/src/notifications.ts
+++ b/apps/server/src/notifications.ts
@@ -6,7 +6,7 @@
  */
 import { and, eq, inArray, or } from "drizzle-orm";
 import { db } from "@sip-and-speak/db";
-import { userDeviceToken, userLanguage, conversationPresence, meetup } from "@sip-and-speak/db/schema/sip-and-speak";
+import { userDeviceToken, userLanguage, conversationPresence, meetup, conversation } from "@sip-and-speak/db/schema/sip-and-speak";
 import { user } from "@sip-and-speak/db/schema/auth";
 import { domainEvents, type MatchRequestSentEvent, type MatchRequestAcceptedEvent, type MatchRequestDeclinedEvent, type MeetupProposedEvent, type MeetupConfirmedEvent, type MeetupCounterProposedEvent, type MeetupDeclinedEvent, type MeetupCancelledEvent, type MeetupRescheduleProposedEvent, type MeetupRescheduledEvent, type MeetupRescheduleDeclinedEvent, type SipAndSpeakMomentCompletedEvent, type MeetupNotAttendedEvent, type MessagingOptInPromptedEvent, type MessagingNudgeNeededEvent, type ConversationOpenedEvent, type MessagingDeclineOutcomeEvent, type MessageSentEvent, type StudentWarnedEvent, type StudentSuspendedEvent, type SuspensionLiftedEvent, type StudentRemovedEvent } from "@sip-and-speak/api/domain-events";
 import { buildMatchRequestNotificationBody } from "@sip-and-speak/api/routers/matching-utils";
@@ -403,6 +403,7 @@ export function registerNotificationHandlers(): void {
   });
   domainEvents.on("StudentRemoved", (event) => {
     void handleStudentRemovedCancelProposals(event); // #110 — cancel proposals + notify peers
+    void handleStudentRemovedCloseConversations(event); // #111 — close open conversations
   });
 }
 
@@ -941,6 +942,35 @@ async function handleStudentRemovedCancelProposals(event: StudentRemovedEvent): 
       console.error("[push] Failed to send removal proposal cancellation notification", { targetId, err });
     }
   }
+}
+
+// #111 — Close all open conversations involving a permanently removed Student
+async function handleStudentRemovedCloseConversations(event: StudentRemovedEvent): Promise<void> {
+  const { targetId } = event;
+
+  const openConversations = await db
+    .select({ id: conversation.id })
+    .from(conversation)
+    .where(
+      and(
+        or(eq(conversation.user1Id, targetId), eq(conversation.user2Id, targetId)),
+        eq(conversation.status, "open"),
+      ),
+    );
+
+  if (openConversations.length === 0) return;
+
+  await db
+    .update(conversation)
+    .set({ status: "closed" })
+    .where(
+      and(
+        or(eq(conversation.user1Id, targetId), eq(conversation.user2Id, targetId)),
+        eq(conversation.status, "open"),
+      ),
+    );
+
+  console.info("[moderation] Closed conversations on removal", { targetId, count: openConversations.length });
 }
 
 // #106 — Notify Student when their suspension is lifted

--- a/packages/api/src/routers/chat.ts
+++ b/packages/api/src/routers/chat.ts
@@ -8,7 +8,7 @@ import {
   messageReadStatus,
 } from "@sip-and-speak/db/schema/sip-and-speak";
 import { user } from "@sip-and-speak/db/schema/auth";
-import { checkReadAccess, computeIsUnread, computeMarkReadAt } from "./messaging-utils";
+import { checkConversationAccess, checkReadAccess, computeIsUnread, computeMarkReadAt } from "./messaging-utils";
 import { protectedProcedure, router } from "../index";
 
 export const chatRouter = router({
@@ -187,8 +187,10 @@ export const chatRouter = router({
         )
         .limit(1);
 
-      if (conv.length === 0) {
-        throw new Error("Conversation not found");
+      // #111 — Guard: reject sends on non-open conversations (suspended or closed)
+      const access = checkConversationAccess(conv[0], userId);
+      if (!access.allowed) {
+        throw new TRPCError({ code: "FORBIDDEN", message: access.error });
       }
 
       const [newMessage] = await db

--- a/packages/api/src/routers/messaging-utils.ts
+++ b/packages/api/src/routers/messaging-utils.ts
@@ -59,7 +59,7 @@ export function computeMarkReadAt(existingLastReadAt: Date | null, now: Date): D
  * Returns `{ allowed: true }` or `{ allowed: false, error }`.
  */
 export function checkConversationAccess(
-  conv: { user1Id: string; user2Id: string; status: "open" | "suspended" } | undefined,
+  conv: { user1Id: string; user2Id: string; status: "open" | "suspended" | "closed" } | undefined,
   senderId: string,
 ): { allowed: true } | { allowed: false; error: "CONVERSATION_NOT_FOUND" | "NOT_A_PARTICIPANT" | "CONVERSATION_NOT_OPEN" } {
   if (!conv) return { allowed: false, error: "CONVERSATION_NOT_FOUND" };
@@ -103,7 +103,7 @@ export function computeIsUnread(
  * avoid leaking whether the conversation exists.
  */
 export function checkReadAccess(
-  conv: { user1Id: string; user2Id: string; status: "open" | "suspended" } | undefined,
+  conv: { user1Id: string; user2Id: string; status: "open" | "suspended" | "closed" } | undefined,
   readerId: string,
 ): { allowed: true } | { allowed: false; error: "NOT_A_PARTICIPANT" } {
   if (!conv) return { allowed: false, error: "NOT_A_PARTICIPANT" };

--- a/packages/db/src/schema/sip-and-speak.ts
+++ b/packages/db/src/schema/sip-and-speak.ts
@@ -153,7 +153,8 @@ export const conversation = pgTable(
     // #141 — FK to meetup; unique per meetup (at most one conversation per meetup pair)
     meetupId: text("meetup_id").references(() => meetup.id, { onDelete: "set null" }),
     // #146 — Trust & Moderation can suspend a conversation; only "open" conversations accept messages
-    status: text("status", { enum: ["open", "suspended"] }).notNull().default("open"),
+    // #111 — Permanently removed Students cause conversations to be "closed" (read-only, history preserved)
+    status: text("status", { enum: ["open", "suspended", "closed"] }).notNull().default("open"),
     createdAt: timestamp("created_at").defaultNow().notNull(),
   },
   (table) => [


### PR DESCRIPTION
## Summary

- Adds `"closed"` to `conversation.status` enum (no migration — text column with no DB constraint)
- Registers `handleStudentRemovedCloseConversations` handler on `StudentRemoved` event: bulk-closes all `open` conversations involving the removed Student
- Updates `checkConversationAccess` and `checkReadAccess` type signatures to include `"closed"`
- Adds `checkConversationAccess` guard to `sendMessage` — closed conversations reject further sends with `FORBIDDEN`
- History preserved (rows remain, status = `"closed"`, reads still work)

## Test plan

- [x] `notifications-removal-conversations.test.ts` — 3 scenarios (close open, no-op when none, idempotent)
- [x] `messaging-access-control.test.ts` — existing 5 tests still pass
- [x] All tests pass

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)