### PR TITLE
feat(native): add profile picture encoding utility

### DIFF
--- a/apps/native/__tests__/profile-picture.test.ts
+++ b/apps/native/__tests__/profile-picture.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for task #278 — Base64 image encoding and validation for profile picture
+ *
+ * Scenario 1: Student picks a valid image
+ * Scenario 2: Student picks an oversized image
+ * Scenario 3: Student picks a non-image file
+ * Scenario 4: Student cancels the image picker
+ */
+
+const mockLaunchImageLibraryAsync = jest.fn();
+
+jest.mock("expo-image-picker", () => ({
+  launchImageLibraryAsync: () => mockLaunchImageLibraryAsync(),
+}));
+
+import {
+  validateImageMimeType,
+  validateImageSize,
+  buildDataUri,
+  pickAndEncodeProfilePicture,
+} from "@/utils/profile-picture";
+
+const SMALL_BASE64 = "A".repeat(100); // ~75 bytes
+const LARGE_BASE64 = "A".repeat(700_000); // ~525 KB, exceeds 500 KB limit
+
+describe("validateImageMimeType", () => {
+  it("accepts image/jpeg", () => {
+    expect(validateImageMimeType("image/jpeg")).toBe(true);
+  });
+
+  it("accepts image/png", () => {
+    expect(validateImageMimeType("image/png")).toBe(true);
+  });
+
+  it("rejects application/pdf", () => {
+    expect(validateImageMimeType("application/pdf")).toBe(false);
+  });
+
+  it("rejects empty string", () => {
+    expect(validateImageMimeType("")).toBe(false);
+  });
+});
+
+describe("validateImageSize", () => {
+  it("accepts base64 string within 500 KB limit", () => {
+    expect(validateImageSize(SMALL_BASE64)).toBe(true);
+  });
+
+  it("rejects base64 string exceeding 500 KB limit", () => {
+    expect(validateImageSize(LARGE_BASE64)).toBe(false);
+  });
+});
+
+describe("buildDataUri", () => {
+  it("builds a valid data URI", () => {
+    const uri = buildDataUri("image/jpeg", "abc123");
+    expect(uri).toBe("data:image/jpeg;base64,abc123");
+  });
+});
+
+describe("pickAndEncodeProfilePicture", () => {
+  beforeEach(() => {
+    mockLaunchImageLibraryAsync.mockReset();
+  });
+
+  it("Scenario 1: returns data URI for valid image under size limit", async () => {
+    mockLaunchImageLibraryAsync.mockResolvedValue({
+      canceled: false,
+      assets: [{ base64: SMALL_BASE64, mimeType: "image/jpeg" }],
+    });
+
+    const result = await pickAndEncodeProfilePicture();
+
+    expect(result.imageDataUri).toBe(`data:image/jpeg;base64,${SMALL_BASE64}`);
+    expect(result.error).toBeNull();
+  });
+
+  it("Scenario 2: rejects oversized image with error", async () => {
+    mockLaunchImageLibraryAsync.mockResolvedValue({
+      canceled: false,
+      assets: [{ base64: LARGE_BASE64, mimeType: "image/jpeg" }],
+    });
+
+    const result = await pickAndEncodeProfilePicture();
+
+    expect(result.imageDataUri).toBeNull();
+    expect(result.error).toBe("Image is too large (max 500 KB)");
+  });
+
+  it("Scenario 3: rejects non-image file with error", async () => {
+    mockLaunchImageLibraryAsync.mockResolvedValue({
+      canceled: false,
+      assets: [{ base64: SMALL_BASE64, mimeType: "application/pdf" }],
+    });
+
+    const result = await pickAndEncodeProfilePicture();
+
+    expect(result.imageDataUri).toBeNull();
+    expect(result.error).toBe("Only image files are accepted");
+  });
+
+  it("Scenario 4: returns null with no error when picker is cancelled", async () => {
+    mockLaunchImageLibraryAsync.mockResolvedValue({
+      canceled: true,
+      assets: [],
+    });
+
+    const result = await pickAndEncodeProfilePicture();
+
+    expect(result.imageDataUri).toBeNull();
+    expect(result.error).toBeNull();
+  });
+});

--- a/apps/native/package.json
+++ b/apps/native/package.json
@@ -35,6 +35,7 @@
     "expo-constants": "~55.0.7",
     "expo-font": "~55.0.4",
     "expo-haptics": "~55.0.8",
+    "expo-image-picker": "^55.0.18",
     "expo-linking": "~55.0.7",
     "expo-network": "~55.0.8",
     "expo-notifications": "^55.0.18",

--- a/apps/native/utils/profile-picture.ts
+++ b/apps/native/utils/profile-picture.ts
@@ -1,0 +1,47 @@
+import * as ImagePicker from "expo-image-picker";
+
+const MAX_SIZE_BYTES = 500 * 1024;
+
+export function validateImageMimeType(mimeType: string): boolean {
+  return mimeType.startsWith("image/");
+}
+
+export function validateImageSize(base64: string): boolean {
+  // base64 encodes 3 bytes as 4 chars
+  const bytes = (base64.length * 3) / 4;
+  return bytes <= MAX_SIZE_BYTES;
+}
+
+export function buildDataUri(mimeType: string, base64: string): string {
+  return `data:${mimeType};base64,${base64}`;
+}
+
+export type PickResult =
+  | { imageDataUri: string; error: null }
+  | { imageDataUri: null; error: string }
+  | { imageDataUri: null; error: null };
+
+export async function pickAndEncodeProfilePicture(): Promise<PickResult> {
+  const result = await ImagePicker.launchImageLibraryAsync({
+    mediaTypes: "images",
+    base64: true,
+    quality: 0.8,
+  });
+
+  if (result.canceled) return { imageDataUri: null, error: null };
+
+  const asset = result.assets[0];
+  if (!asset?.base64) return { imageDataUri: null, error: "Could not encode image" };
+
+  const mimeType = asset.mimeType ?? "image/jpeg";
+
+  if (!validateImageMimeType(mimeType)) {
+    return { imageDataUri: null, error: "Only image files are accepted" };
+  }
+
+  if (!validateImageSize(asset.base64)) {
+    return { imageDataUri: null, error: "Image is too large (max 500 KB)" };
+  }
+
+  return { imageDataUri: buildDataUri(mimeType, asset.base64), error: null };
+}

--- a/bun.lock
+++ b/bun.lock
@@ -43,6 +43,7 @@
         "expo-constants": "~55.0.7",
         "expo-font": "~55.0.4",
         "expo-haptics": "~55.0.8",
+        "expo-image-picker": "^55.0.18",
         "expo-linking": "~55.0.7",
         "expo-network": "~55.0.8",
         "expo-notifications": "^55.0.18",
@@ -1691,6 +1692,10 @@
     "expo-haptics": ["expo-haptics@55.0.11", "", { "peerDependencies": { "expo": "*" } }, "sha512-cvayByobLtoS5Yt2JFqcBPH+1mnLHkz+Rr+H1EOCZDdTVo5T6aaAHMOZrbRBZBhxrUevAPxfz0bfyhVZj3XHzA=="],
 
     "expo-image": ["expo-image@55.0.8", "", { "dependencies": { "sf-symbols-typescript": "^2.2.0" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*", "react-native-web": "*" }, "optionalPeers": ["react-native-web"] }, "sha512-fNdvdYVcGn3g1x6o5AXHKzk4xX8U6rg2W9vFdE1pQO80kWCNReh003ypqSrGy4dD+zA8FtZjrNF3oMDGnPpIGQ=="],
+
+    "expo-image-loader": ["expo-image-loader@55.0.0", "", { "peerDependencies": { "expo": "*" } }, "sha512-NOjp56wDrfuA5aiNAybBIjqIn1IxKeGJ8CECWZncQ/GzjZfyTYAHTCyeApYkdKkMBLHINzI4BbTGSlbCa0fXXQ=="],
+
+    "expo-image-picker": ["expo-image-picker@55.0.18", "", { "dependencies": { "expo-image-loader": "~55.0.0" }, "peerDependencies": { "expo": "*" } }, "sha512-lGpPGRu+7mE8qN0ma2boRsCmfOGbdHZ2bXTpWVeWly0JCZdogGlTrYFnhTqgS8+lmiRb/UCOs7iTm2P5Rra6kw=="],
 
     "expo-keep-awake": ["expo-keep-awake@55.0.6", "", { "peerDependencies": { "expo": "*", "react": "*" } }, "sha512-acJjeHqkNxMVckEcJhGQeIksqqsarscSHJtT559bNgyiM4r14dViQ66su7bb6qDVeBt0K7z3glXI1dHVck1Zgg=="],
 


### PR DESCRIPTION
## Summary
- Installs `expo-image-picker`
- Adds `apps/native/utils/profile-picture.ts` with `pickAndEncodeProfilePicture()` utility
- Validates MIME type (must be `image/*`) and encoded size (≤ 500 KB)
- Returns base64 data URI or `null` on cancel; error string on rejection
- Pure validation functions exported separately for testability

## Test plan
- [x] Valid JPEG/PNG image returns data URI (Scenario 1)
- [x] Oversized image returns error message (Scenario 2)
- [x] Non-image file returns error message (Scenario 3)
- [x] Cancel returns null with no error (Scenario 4)
- [x] All 11 tests pass

Closes #278