### PR TITLE
feat(native): display name, surname, and picture in profile tab

### DIFF
--- a/apps/native/__tests__/profile-tab-display.test.tsx
+++ b/apps/native/__tests__/profile-tab-display.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * Tests for task #281 — Display name, surname, and picture in the profile tab
+ *
+ * Scenario 1: Student with complete identity profile sees their details
+ * Scenario 2: Student without a profile picture sees a placeholder
+ * Scenario 3: Profile tab reflects updated values after editing
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react-native";
+import React from "react";
+
+const mockPush = jest.fn();
+const mockReplace = jest.fn();
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ push: mockPush, replace: mockReplace }),
+}));
+
+jest.mock("@/lib/auth-client", () => ({
+  authClient: {
+    useSession: () => ({ data: null }),
+    signOut: jest.fn(),
+  },
+}));
+
+const mockGetMyProfile = jest.fn();
+jest.mock("@/utils/trpc", () => ({
+  trpc: {
+    profile: {
+      getMyProfile: {
+        queryOptions: () => ({ queryKey: ["profile"], queryFn: mockGetMyProfile }),
+      },
+    },
+  },
+}));
+
+import ProfileScreen from "../app/(tabs)/profile";
+
+function renderScreen() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <ProfileScreen />
+    </QueryClientProvider>,
+  );
+}
+
+describe("#281 — Profile tab display", () => {
+  beforeEach(() => mockGetMyProfile.mockReset());
+
+  describe("Scenario 1: complete identity profile", () => {
+    it("shows full name and profile picture", async () => {
+      mockGetMyProfile.mockResolvedValue({
+        identity: { name: "Sander", surname: "Boer", image: "data:image/jpeg;base64,abc", email: "s.boer@student.tue.nl" },
+        profile: null,
+        languages: [],
+        interests: [],
+      });
+
+      renderScreen();
+
+      const fullName = await screen.findByText("Sander Boer");
+      expect(fullName).toBeTruthy();
+
+      const picture = await screen.findByLabelText("Profile picture");
+      expect(picture).toBeTruthy();
+    });
+  });
+
+  describe("Scenario 2: no profile picture → placeholder", () => {
+    it("shows placeholder avatar when image is null", async () => {
+      mockGetMyProfile.mockResolvedValue({
+        identity: { name: "Sander", surname: "Boer", image: null, email: "s.boer@student.tue.nl" },
+        profile: null,
+        languages: [],
+        interests: [],
+      });
+
+      renderScreen();
+
+      const placeholder = await screen.findByLabelText("Profile picture placeholder");
+      expect(placeholder).toBeTruthy();
+
+      const fullName = await screen.findByText("Sander Boer");
+      expect(fullName).toBeTruthy();
+    });
+  });
+
+  describe("Scenario 3: updated values reflected", () => {
+    it("displays latest name and surname from getMyProfile", async () => {
+      mockGetMyProfile.mockResolvedValue({
+        identity: { name: "Alex", surname: "Updated", image: null, email: "a.updated@student.tue.nl" },
+        profile: null,
+        languages: [],
+        interests: [],
+      });
+
+      renderScreen();
+
+      const fullName = await screen.findByText("Alex Updated");
+      expect(fullName).toBeTruthy();
+    });
+  });
+
+  describe("edge cases", () => {
+    it("shows only name when surname is null", async () => {
+      mockGetMyProfile.mockResolvedValue({
+        identity: { name: "Sander", surname: null, image: null, email: "s@student.tue.nl" },
+        profile: null,
+        languages: [],
+        interests: [],
+      });
+
+      renderScreen();
+
+      const nameText = await screen.findByText("Sander");
+      expect(nameText).toBeTruthy();
+    });
+  });
+});

--- a/apps/native/app/(tabs)/profile.tsx
+++ b/apps/native/app/(tabs)/profile.tsx
@@ -1,21 +1,54 @@
+import { useQuery } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
 import { Button } from "heroui-native";
-import { Text, View } from "react-native";
+import { Image, Text, View } from "react-native";
 
 import { Container } from "@/components/container";
 import { authClient } from "@/lib/auth-client";
+import { trpc } from "@/utils/trpc";
+
+const AVATAR_SIZE = 80;
 
 export default function ProfileScreen() {
   const router = useRouter();
-  const { data: session } = authClient.useSession();
+  const profileQuery = useQuery(trpc.profile.getMyProfile.queryOptions());
+  const identity = profileQuery.data?.identity;
+
+  const fullName = [identity?.name, identity?.surname].filter(Boolean).join(" ");
 
   return (
     <Container isScrollable={false}>
       <View className="flex-1 p-6">
-        <Text className="text-foreground text-2xl font-bold mb-2">Profile</Text>
-        {session?.user?.name && (
-          <Text className="text-muted-foreground mb-6">{session.user.name}</Text>
-        )}
+        <Text className="text-foreground text-2xl font-bold mb-4">Profile</Text>
+
+        <View className="flex-row items-center gap-4 mb-6">
+          {identity?.image ? (
+            <Image
+              source={{ uri: identity.image }}
+              style={{ width: AVATAR_SIZE, height: AVATAR_SIZE, borderRadius: AVATAR_SIZE / 2 }}
+              accessibilityLabel="Profile picture"
+            />
+          ) : (
+            <View
+              style={{ width: AVATAR_SIZE, height: AVATAR_SIZE, borderRadius: AVATAR_SIZE / 2 }}
+              className="bg-default-200 items-center justify-center"
+              accessibilityLabel="Profile picture placeholder"
+            >
+              <Text className="text-default-500 text-2xl font-bold">
+                {identity?.name?.[0]?.toUpperCase() ?? "?"}
+              </Text>
+            </View>
+          )}
+
+          <View className="flex-1">
+            {fullName ? (
+              <Text className="text-foreground text-lg font-semibold">{fullName}</Text>
+            ) : (
+              <Text className="text-muted-foreground text-sm">No name set</Text>
+            )}
+          </View>
+        </View>
+
         <Button onPress={() => router.push("/edit-profile")}>
           <Button.Label>Edit Profile</Button.Label>
         </Button>

--- a/packages/api/src/routers/profile.ts
+++ b/packages/api/src/routers/profile.ts
@@ -142,24 +142,24 @@ export const profileRouter = router({
   getMyProfile: protectedProcedure.query(async ({ ctx }) => {
     const userId = ctx.session.user.id;
 
-    const profile = await db.query.languageProfile.findFirst({
-      where: eq(languageProfile.userId, userId),
-    });
-
-    const languages = await db
-      .select()
-      .from(userLanguage)
-      .where(eq(userLanguage.userId, userId));
-
-    const interests = await db
-      .select()
-      .from(userInterest)
-      .where(eq(userInterest.userId, userId));
+    const [profile, languages, interests, identity] = await Promise.all([
+      db.query.languageProfile.findFirst({
+        where: eq(languageProfile.userId, userId),
+      }),
+      db.select().from(userLanguage).where(eq(userLanguage.userId, userId)),
+      db.select().from(userInterest).where(eq(userInterest.userId, userId)),
+      db
+        .select({ name: user.name, surname: user.surname, image: user.image, email: user.email })
+        .from(user)
+        .where(eq(user.id, userId))
+        .limit(1),
+    ]);
 
     return {
       profile: profile ?? null,
       languages,
       interests,
+      identity: identity[0] ?? null,
     };
   }),
 


### PR DESCRIPTION
## Summary
- Extends `getMyProfile` to return identity fields (`name`, `surname`, `image`, `email`) in parallel with language/interest data
- Profile tab shows profile picture (or initial-letter placeholder avatar) and full name
- Falls back gracefully: no picture → placeholder with first initial; no surname → name only

## Test plan
- [x] Complete profile → picture + full name shown (Scenario 1)
- [x] No picture → placeholder avatar shown (Scenario 2)
- [x] Updated values reflected from query (Scenario 3)
- [x] Null surname handled gracefully

Closes #281