### PR TITLE
feat(native): add Personal Info section to profile editing screen

### DIFF
--- a/apps/native/__tests__/edit-profile-identity.test.tsx
+++ b/apps/native/__tests__/edit-profile-identity.test.tsx
@@ -1,0 +1,202 @@
+/**
+ * Tests for task #279 — Add name, surname, and picture to profile screen
+ *
+ * Scenario 1: Name and surname auto-save on blur
+ * Scenario 2: Picture auto-saves and previews on selection
+ * Scenario 3: Pre-filled values for existing profile
+ * Scenario 4: Dialog on missing name/surname
+ * Scenario 5: Proceeds to review with both fields filled
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react-native";
+import React from "react";
+import { Alert } from "react-native";
+
+const mockPush = jest.fn();
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+const mockSetIdentityProfile = jest.fn();
+const mockGetMyProfile = jest.fn();
+jest.mock("@/utils/trpc", () => ({
+  trpc: {
+    profile: {
+      getMyProfile: { queryOptions: () => ({ queryKey: ["profile"], queryFn: mockGetMyProfile }) },
+      setIdentityProfile: { mutationOptions: () => ({ mutationFn: mockSetIdentityProfile }) },
+      upsertLanguage: { mutationOptions: () => ({ mutationFn: jest.fn() }) },
+      removeLanguage: { mutationOptions: () => ({ mutationFn: jest.fn() }) },
+      toggleInterest: { mutationOptions: () => ({ mutationFn: jest.fn() }) },
+    },
+  },
+  queryClient: { invalidateQueries: jest.fn() },
+}));
+
+const mockPickAndEncode = jest.fn();
+jest.mock("@/utils/profile-picture", () => ({
+  pickAndEncodeProfilePicture: () => mockPickAndEncode(),
+}));
+
+import EditProfileScreen from "../app/edit-profile";
+
+const EMPTY_PROFILE = {
+  identity: { name: "", surname: null, image: null, email: "s.janssen@student.tue.nl" },
+  profile: null,
+  languages: [],
+  interests: [],
+};
+
+function renderScreen() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <EditProfileScreen />
+    </QueryClientProvider>,
+  );
+}
+
+describe("#279 — Profile screen identity section", () => {
+  beforeEach(() => {
+    mockGetMyProfile.mockReset();
+    mockSetIdentityProfile.mockReset();
+    mockPickAndEncode.mockReset();
+    mockPush.mockReset();
+    mockSetIdentityProfile.mockResolvedValue({ success: true });
+  });
+
+  describe("Scenario 3: pre-filled values for existing profile", () => {
+    it("pre-fills name and surname from existing profile data", async () => {
+      mockGetMyProfile.mockResolvedValue({
+        identity: { name: "Sander", surname: "Boer", image: null, email: "s.boer@student.tue.nl" },
+        profile: null,
+        languages: [],
+        interests: [],
+      });
+
+      renderScreen();
+
+      const nameInput = await screen.findByTestId("name-input");
+      const surnameInput = await screen.findByTestId("surname-input");
+      expect(nameInput.props.value).toBe("Sander");
+      expect(surnameInput.props.value).toBe("Boer");
+    });
+
+    it("pre-fills from email when name is empty", async () => {
+      mockGetMyProfile.mockResolvedValue(EMPTY_PROFILE);
+
+      renderScreen();
+
+      const nameInput = await screen.findByTestId("name-input");
+      const surnameInput = await screen.findByTestId("surname-input");
+      expect(nameInput.props.value).toBe("S");
+      expect(surnameInput.props.value).toBe("Janssen");
+    });
+  });
+
+  describe("Scenario 1: auto-save on blur", () => {
+    it("calls setIdentityProfile when both name and surname are filled on blur", async () => {
+      mockGetMyProfile.mockResolvedValue({
+        identity: { name: "Sander", surname: "Boer", image: null, email: "s.boer@student.tue.nl" },
+        profile: null,
+        languages: [],
+        interests: [],
+      });
+
+      renderScreen();
+
+      const nameInput = await screen.findByTestId("name-input");
+      fireEvent.changeText(nameInput, "Alex");
+      fireEvent(nameInput, "blur");
+
+      await waitFor(() => {
+        expect(mockSetIdentityProfile).toHaveBeenCalledWith(
+          expect.objectContaining({ name: "Alex", surname: "Boer" }),
+          expect.anything(),
+        );
+      });
+    });
+
+    it("does not save when name is empty on blur", async () => {
+      mockGetMyProfile.mockResolvedValue(EMPTY_PROFILE);
+
+      renderScreen();
+
+      const nameInput = await screen.findByTestId("name-input");
+      fireEvent.changeText(nameInput, "");
+      fireEvent(nameInput, "blur");
+
+      await waitFor(() => {
+        expect(mockSetIdentityProfile).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("Scenario 4: dialog on missing name/surname", () => {
+    it("shows alert when Review is pressed with empty name", async () => {
+      mockGetMyProfile.mockResolvedValue(EMPTY_PROFILE);
+      const alertSpy = jest.spyOn(Alert, "alert");
+
+      renderScreen();
+
+      const surnameInput = await screen.findByTestId("surname-input");
+      fireEvent.changeText(surnameInput, "Boer");
+
+      const nameInput = await screen.findByTestId("name-input");
+      fireEvent.changeText(nameInput, "");
+
+      const reviewButton = screen.getByTestId("review-submit-button");
+      fireEvent.press(reviewButton);
+
+      expect(alertSpy).toHaveBeenCalledWith(
+        "Required fields missing",
+        expect.stringContaining("Name"),
+        expect.any(Array),
+      );
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Scenario 5: proceeds to review with both fields filled", () => {
+    it("navigates to review-profile when both fields are present", async () => {
+      mockGetMyProfile.mockResolvedValue({
+        identity: { name: "Sander", surname: "Boer", image: null, email: "s.boer@student.tue.nl" },
+        profile: null,
+        languages: [],
+        interests: [],
+      });
+
+      renderScreen();
+
+      await screen.findByTestId("name-input");
+
+      const reviewButton = screen.getByTestId("review-submit-button");
+      fireEvent.press(reviewButton);
+
+      expect(mockPush).toHaveBeenCalledWith("/review-profile");
+    });
+  });
+
+  describe("Scenario 2: picture auto-saves and previews on selection", () => {
+    it("calls setIdentityProfile with imageUrl when picture is selected", async () => {
+      mockGetMyProfile.mockResolvedValue({
+        identity: { name: "Sander", surname: "Boer", image: null, email: "s.boer@student.tue.nl" },
+        profile: null,
+        languages: [],
+        interests: [],
+      });
+      mockPickAndEncode.mockResolvedValue({ imageDataUri: "data:image/jpeg;base64,abc", error: null });
+
+      renderScreen();
+
+      const pickButton = await screen.findByTestId("pick-picture-button");
+      fireEvent.press(pickButton);
+
+      await waitFor(() => {
+        expect(mockSetIdentityProfile).toHaveBeenCalledWith(
+          expect.objectContaining({ imageUrl: "data:image/jpeg;base64,abc" }),
+          expect.anything(),
+        );
+      });
+    });
+  });
+});

--- a/apps/native/__tests__/email-name-extract.test.ts
+++ b/apps/native/__tests__/email-name-extract.test.ts
@@ -1,0 +1,23 @@
+/**
+ * Tests for email-based name pre-fill utility
+ */
+import { extractNameFromEmail } from "@/utils/email-name-extract";
+import { describe, it, expect } from "@jest/globals";
+
+describe("extractNameFromEmail", () => {
+  it("extracts capitalized name and surname from firstname.lastname format", () => {
+    expect(extractNameFromEmail("sander.boer@student.tue.nl")).toEqual({ name: "Sander", surname: "Boer" });
+  });
+
+  it("extracts initial and surname from initial.lastname format", () => {
+    expect(extractNameFromEmail("s.janssen@student.tue.nl")).toEqual({ name: "S", surname: "Janssen" });
+  });
+
+  it("returns empty name and capitalized local part for no-dot email", () => {
+    expect(extractNameFromEmail("sander@tue.nl")).toEqual({ name: "", surname: "Sander" });
+  });
+
+  it("handles empty string", () => {
+    expect(extractNameFromEmail("")).toEqual({ name: "", surname: "" });
+  });
+});

--- a/apps/native/app/edit-profile.tsx
+++ b/apps/native/app/edit-profile.tsx
@@ -1,11 +1,13 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
 import { Button, Card, Spinner, useToast } from "heroui-native";
-import { useState } from "react";
-import { Pressable, ScrollView, Text, View } from "react-native";
+import { useEffect, useState } from "react";
+import { Alert, Image, Pressable, ScrollView, Text, TextInput, View } from "react-native";
 
 import { Container } from "@/components/container";
 import { queryClient, trpc } from "@/utils/trpc";
+import { extractNameFromEmail } from "@/utils/email-name-extract";
+import { pickAndEncodeProfilePicture } from "@/utils/profile-picture";
 
 const LANGUAGES = [
   "English",
@@ -63,8 +65,76 @@ export default function EditProfileScreen() {
   const router = useRouter();
   const { toast } = useToast();
   const [addingType, setAddingType] = useState<LanguageType | null>(null);
+  const [nameInput, setNameInput] = useState("");
+  const [surnameInput, setSurnameInput] = useState("");
+  const [imageUri, setImageUri] = useState<string | undefined>(undefined);
+  const [identityInitialized, setIdentityInitialized] = useState(false);
 
   const profileQuery = useQuery(trpc.profile.getMyProfile.queryOptions());
+
+  const setIdentityMutation = useMutation({
+    ...trpc.profile.setIdentityProfile.mutationOptions(),
+    onSuccess: () => queryClient.invalidateQueries(),
+    onError: (e) => {
+      toast.show({ variant: "danger", label: (e as { message?: string }).message ?? "Failed to save profile." });
+    },
+  });
+
+  useEffect(() => {
+    if (identityInitialized || !profileQuery.data) return;
+    const identity = profileQuery.data.identity;
+    const email = identity?.email ?? "";
+
+    if (identity?.name || identity?.surname) {
+      setNameInput(identity.name ?? "");
+      setSurnameInput(identity.surname ?? "");
+    } else {
+      const { name, surname } = extractNameFromEmail(email);
+      setNameInput(name);
+      setSurnameInput(surname);
+    }
+
+    setImageUri(identity?.image ?? undefined);
+    setIdentityInitialized(true);
+  }, [profileQuery.data, identityInitialized]);
+
+  function handleIdentityBlur() {
+    const name = nameInput.trim();
+    const surname = surnameInput.trim();
+    if (!name || !surname) return;
+    setIdentityMutation.mutate({ name, surname, imageUrl: imageUri });
+  }
+
+  async function handlePickPicture() {
+    const result = await pickAndEncodeProfilePicture();
+    if (result.error) {
+      toast.show({ variant: "danger", label: result.error });
+      return;
+    }
+    if (result.imageDataUri) {
+      setImageUri(result.imageDataUri);
+      const name = nameInput.trim();
+      const surname = surnameInput.trim();
+      if (name && surname) {
+        setIdentityMutation.mutate({ name, surname, imageUrl: result.imageDataUri });
+      }
+    }
+  }
+
+  function handleReviewPress() {
+    const missing: string[] = [];
+    if (!nameInput.trim()) missing.push("Name");
+    if (!surnameInput.trim()) missing.push("Surname");
+    if (missing.length > 0) {
+      Alert.alert(
+        "Required fields missing",
+        `Please fill in: ${missing.join(", ")}`,
+        [{ text: "OK" }],
+      );
+      return;
+    }
+    router.push("/review-profile");
+  }
 
   const upsertMutation = useMutation({
     ...trpc.profile.upsertLanguage.mutationOptions(),
@@ -142,6 +212,58 @@ export default function EditProfileScreen() {
         keyboardShouldPersistTaps="handled"
       >
         <View className="flex-1 p-6 gap-8">
+
+          {/* Personal Info */}
+          <View>
+            <Text className="text-foreground text-xl font-bold mb-3">Personal Info</Text>
+
+            <View className="gap-3">
+              <View>
+                <Text className="text-foreground text-sm font-medium mb-1">Name</Text>
+                <TextInput
+                  testID="name-input"
+                  value={nameInput}
+                  onChangeText={setNameInput}
+                  onBlur={handleIdentityBlur}
+                  placeholder="First name"
+                  placeholderTextColor="#9ca3af"
+                  autoCapitalize="words"
+                  className="border border-border rounded-lg px-3 py-2 text-foreground bg-background"
+                />
+              </View>
+
+              <View>
+                <Text className="text-foreground text-sm font-medium mb-1">Surname</Text>
+                <TextInput
+                  testID="surname-input"
+                  value={surnameInput}
+                  onChangeText={setSurnameInput}
+                  onBlur={handleIdentityBlur}
+                  placeholder="Last name"
+                  placeholderTextColor="#9ca3af"
+                  autoCapitalize="words"
+                  className="border border-border rounded-lg px-3 py-2 text-foreground bg-background"
+                />
+              </View>
+
+              <View>
+                <Text className="text-foreground text-sm font-medium mb-2">Profile Picture</Text>
+                <Pressable onPress={handlePickPicture} testID="pick-picture-button">
+                  {imageUri ? (
+                    <Image
+                      source={{ uri: imageUri }}
+                      style={{ width: 80, height: 80, borderRadius: 40 }}
+                      accessibilityLabel="Profile picture preview"
+                    />
+                  ) : (
+                    <View className="w-20 h-20 rounded-full bg-default-200 items-center justify-center border border-dashed border-border">
+                      <Text className="text-muted-foreground text-xs text-center">Tap to add{"\n"}photo</Text>
+                    </View>
+                  )}
+                </Pressable>
+              </View>
+            </View>
+          </View>
 
           {/* Spoken Languages */}
           <View>
@@ -349,7 +471,7 @@ export default function EditProfileScreen() {
           )}
 
           <View className="mt-4 pt-4 border-t border-border">
-            <Button onPress={() => router.push("/review-profile")}>
+            <Button onPress={handleReviewPress} testID="review-submit-button">
               <Button.Label>Review & Submit Profile</Button.Label>
             </Button>
           </View>

--- a/apps/native/utils/email-name-extract.ts
+++ b/apps/native/utils/email-name-extract.ts
@@ -1,0 +1,14 @@
+function capitalize(s: string): string {
+  return s.length === 0 ? s : s[0].toUpperCase() + s.slice(1).toLowerCase();
+}
+
+export function extractNameFromEmail(email: string): { name: string; surname: string } {
+  const local = email.split("@")[0] ?? "";
+  const parts = local.split(".");
+
+  if (parts.length >= 2) {
+    return { name: capitalize(parts[0]), surname: capitalize(parts[1]) };
+  }
+
+  return { name: "", surname: capitalize(parts[0] ?? "") };
+}


### PR DESCRIPTION
## Summary
- Adds Personal Info section (name, surname, picture) at the top of `edit-profile.tsx`
- Auto-saves name/surname on blur via `setIdentityProfile`; auto-saves picture on selection
- **Email-based pre-fill**: when fields are empty, extracts name/surname from email (`s.janssen@student.tue.nl` → name: "S", surname: "Janssen") using `utils/email-name-extract.ts`
- Dialog blocks navigation to review if name or surname is missing

## Test plan
- [x] Pre-fills from existing profile data (Scenario 3)
- [x] Pre-fills from email when name is empty
- [x] Auto-saves on blur with valid name + surname (Scenario 1)
- [x] Does not save when name is empty on blur
- [x] Alert shown when Review pressed with missing name (Scenario 4)
- [x] Navigates when both fields filled (Scenario 5)
- [x] Picture auto-saves with imageUrl (Scenario 2)
- [x] Email extraction utility: 4 unit tests

Closes #279