### PR TITLE
feat: Student can complete and update their Profile (#275)

### DIFF
--- a/apps/native/__tests__/edit-profile-identity.test.tsx
+++ b/apps/native/__tests__/edit-profile-identity.test.tsx
@@ -1,0 +1,202 @@
+/**
+ * Tests for task #279 — Add name, surname, and picture to profile screen
+ *
+ * Scenario 1: Name and surname auto-save on blur
+ * Scenario 2: Picture auto-saves and previews on selection
+ * Scenario 3: Pre-filled values for existing profile
+ * Scenario 4: Dialog on missing name/surname
+ * Scenario 5: Proceeds to review with both fields filled
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react-native";
+import React from "react";
+import { Alert } from "react-native";
+
+const mockPush = jest.fn();
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+const mockSetIdentityProfile = jest.fn();
+const mockGetMyProfile = jest.fn();
+jest.mock("@/utils/trpc", () => ({
+  trpc: {
+    profile: {
+      getMyProfile: { queryOptions: () => ({ queryKey: ["profile"], queryFn: mockGetMyProfile }) },
+      setIdentityProfile: { mutationOptions: () => ({ mutationFn: mockSetIdentityProfile }) },
+      upsertLanguage: { mutationOptions: () => ({ mutationFn: jest.fn() }) },
+      removeLanguage: { mutationOptions: () => ({ mutationFn: jest.fn() }) },
+      toggleInterest: { mutationOptions: () => ({ mutationFn: jest.fn() }) },
+    },
+  },
+  queryClient: { invalidateQueries: jest.fn() },
+}));
+
+const mockPickAndEncode = jest.fn();
+jest.mock("@/utils/profile-picture", () => ({
+  pickAndEncodeProfilePicture: () => mockPickAndEncode(),
+}));
+
+import EditProfileScreen from "../app/edit-profile";
+
+const EMPTY_PROFILE = {
+  identity: { name: "", surname: null, image: null, email: "s.janssen@student.tue.nl" },
+  profile: null,
+  languages: [],
+  interests: [],
+};
+
+function renderScreen() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <EditProfileScreen />
+    </QueryClientProvider>,
+  );
+}
+
+describe("#279 — Profile screen identity section", () => {
+  beforeEach(() => {
+    mockGetMyProfile.mockReset();
+    mockSetIdentityProfile.mockReset();
+    mockPickAndEncode.mockReset();
+    mockPush.mockReset();
+    mockSetIdentityProfile.mockResolvedValue({ success: true });
+  });
+
+  describe("Scenario 3: pre-filled values for existing profile", () => {
+    it("pre-fills name and surname from existing profile data", async () => {
+      mockGetMyProfile.mockResolvedValue({
+        identity: { name: "Sander", surname: "Boer", image: null, email: "s.boer@student.tue.nl" },
+        profile: null,
+        languages: [],
+        interests: [],
+      });
+
+      renderScreen();
+
+      const nameInput = await screen.findByTestId("name-input");
+      const surnameInput = await screen.findByTestId("surname-input");
+      expect(nameInput.props.value).toBe("Sander");
+      expect(surnameInput.props.value).toBe("Boer");
+    });
+
+    it("pre-fills from email when name is empty", async () => {
+      mockGetMyProfile.mockResolvedValue(EMPTY_PROFILE);
+
+      renderScreen();
+
+      const nameInput = await screen.findByTestId("name-input");
+      const surnameInput = await screen.findByTestId("surname-input");
+      expect(nameInput.props.value).toBe("S");
+      expect(surnameInput.props.value).toBe("Janssen");
+    });
+  });
+
+  describe("Scenario 1: auto-save on blur", () => {
+    it("calls setIdentityProfile when both name and surname are filled on blur", async () => {
+      mockGetMyProfile.mockResolvedValue({
+        identity: { name: "Sander", surname: "Boer", image: null, email: "s.boer@student.tue.nl" },
+        profile: null,
+        languages: [],
+        interests: [],
+      });
+
+      renderScreen();
+
+      const nameInput = await screen.findByTestId("name-input");
+      fireEvent.changeText(nameInput, "Alex");
+      fireEvent(nameInput, "blur");
+
+      await waitFor(() => {
+        expect(mockSetIdentityProfile).toHaveBeenCalledWith(
+          expect.objectContaining({ name: "Alex", surname: "Boer" }),
+          expect.anything(),
+        );
+      });
+    });
+
+    it("does not save when name is empty on blur", async () => {
+      mockGetMyProfile.mockResolvedValue(EMPTY_PROFILE);
+
+      renderScreen();
+
+      const nameInput = await screen.findByTestId("name-input");
+      fireEvent.changeText(nameInput, "");
+      fireEvent(nameInput, "blur");
+
+      await waitFor(() => {
+        expect(mockSetIdentityProfile).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("Scenario 4: dialog on missing name/surname", () => {
+    it("shows alert when Review is pressed with empty name", async () => {
+      mockGetMyProfile.mockResolvedValue(EMPTY_PROFILE);
+      const alertSpy = jest.spyOn(Alert, "alert");
+
+      renderScreen();
+
+      const surnameInput = await screen.findByTestId("surname-input");
+      fireEvent.changeText(surnameInput, "Boer");
+
+      const nameInput = await screen.findByTestId("name-input");
+      fireEvent.changeText(nameInput, "");
+
+      const reviewButton = screen.getByTestId("review-submit-button");
+      fireEvent.press(reviewButton);
+
+      expect(alertSpy).toHaveBeenCalledWith(
+        "Required fields missing",
+        expect.stringContaining("Name"),
+        expect.any(Array),
+      );
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Scenario 5: proceeds to review with both fields filled", () => {
+    it("navigates to review-profile when both fields are present", async () => {
+      mockGetMyProfile.mockResolvedValue({
+        identity: { name: "Sander", surname: "Boer", image: null, email: "s.boer@student.tue.nl" },
+        profile: null,
+        languages: [],
+        interests: [],
+      });
+
+      renderScreen();
+
+      await screen.findByTestId("name-input");
+
+      const reviewButton = screen.getByTestId("review-submit-button");
+      fireEvent.press(reviewButton);
+
+      expect(mockPush).toHaveBeenCalledWith("/review-profile");
+    });
+  });
+
+  describe("Scenario 2: picture auto-saves and previews on selection", () => {
+    it("calls setIdentityProfile with imageUrl when picture is selected", async () => {
+      mockGetMyProfile.mockResolvedValue({
+        identity: { name: "Sander", surname: "Boer", image: null, email: "s.boer@student.tue.nl" },
+        profile: null,
+        languages: [],
+        interests: [],
+      });
+      mockPickAndEncode.mockResolvedValue({ imageDataUri: "data:image/jpeg;base64,abc", error: null });
+
+      renderScreen();
+
+      const pickButton = await screen.findByTestId("pick-picture-button");
+      fireEvent.press(pickButton);
+
+      await waitFor(() => {
+        expect(mockSetIdentityProfile).toHaveBeenCalledWith(
+          expect.objectContaining({ imageUrl: "data:image/jpeg;base64,abc" }),
+          expect.anything(),
+        );
+      });
+    });
+  });
+});

--- a/apps/native/__tests__/email-name-extract.test.ts
+++ b/apps/native/__tests__/email-name-extract.test.ts
@@ -1,0 +1,23 @@
+/**
+ * Tests for email-based name pre-fill utility
+ */
+import { extractNameFromEmail } from "@/utils/email-name-extract";
+import { describe, it, expect } from "@jest/globals";
+
+describe("extractNameFromEmail", () => {
+  it("extracts capitalized name and surname from firstname.lastname format", () => {
+    expect(extractNameFromEmail("sander.boer@student.tue.nl")).toEqual({ name: "Sander", surname: "Boer" });
+  });
+
+  it("extracts initial and surname from initial.lastname format", () => {
+    expect(extractNameFromEmail("s.janssen@student.tue.nl")).toEqual({ name: "S", surname: "Janssen" });
+  });
+
+  it("returns empty name and capitalized local part for no-dot email", () => {
+    expect(extractNameFromEmail("sander@tue.nl")).toEqual({ name: "", surname: "Sander" });
+  });
+
+  it("handles empty string", () => {
+    expect(extractNameFromEmail("")).toEqual({ name: "", surname: "" });
+  });
+});

--- a/apps/native/__tests__/profile-picture.test.ts
+++ b/apps/native/__tests__/profile-picture.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for task #278 — Base64 image encoding and validation for profile picture
+ *
+ * Scenario 1: Student picks a valid image
+ * Scenario 2: Student picks an oversized image
+ * Scenario 3: Student picks a non-image file
+ * Scenario 4: Student cancels the image picker
+ */
+
+const mockLaunchImageLibraryAsync = jest.fn();
+
+jest.mock("expo-image-picker", () => ({
+  launchImageLibraryAsync: () => mockLaunchImageLibraryAsync(),
+}));
+
+import {
+  validateImageMimeType,
+  validateImageSize,
+  buildDataUri,
+  pickAndEncodeProfilePicture,
+} from "@/utils/profile-picture";
+
+const SMALL_BASE64 = "A".repeat(100); // ~75 bytes
+const LARGE_BASE64 = "A".repeat(700_000); // ~525 KB, exceeds 500 KB limit
+
+describe("validateImageMimeType", () => {
+  it("accepts image/jpeg", () => {
+    expect(validateImageMimeType("image/jpeg")).toBe(true);
+  });
+
+  it("accepts image/png", () => {
+    expect(validateImageMimeType("image/png")).toBe(true);
+  });
+
+  it("rejects application/pdf", () => {
+    expect(validateImageMimeType("application/pdf")).toBe(false);
+  });
+
+  it("rejects empty string", () => {
+    expect(validateImageMimeType("")).toBe(false);
+  });
+});
+
+describe("validateImageSize", () => {
+  it("accepts base64 string within 500 KB limit", () => {
+    expect(validateImageSize(SMALL_BASE64)).toBe(true);
+  });
+
+  it("rejects base64 string exceeding 500 KB limit", () => {
+    expect(validateImageSize(LARGE_BASE64)).toBe(false);
+  });
+});
+
+describe("buildDataUri", () => {
+  it("builds a valid data URI", () => {
+    const uri = buildDataUri("image/jpeg", "abc123");
+    expect(uri).toBe("data:image/jpeg;base64,abc123");
+  });
+});
+
+describe("pickAndEncodeProfilePicture", () => {
+  beforeEach(() => {
+    mockLaunchImageLibraryAsync.mockReset();
+  });
+
+  it("Scenario 1: returns data URI for valid image under size limit", async () => {
+    mockLaunchImageLibraryAsync.mockResolvedValue({
+      canceled: false,
+      assets: [{ base64: SMALL_BASE64, mimeType: "image/jpeg" }],
+    });
+
+    const result = await pickAndEncodeProfilePicture();
+
+    expect(result.imageDataUri).toBe(`data:image/jpeg;base64,${SMALL_BASE64}`);
+    expect(result.error).toBeNull();
+  });
+
+  it("Scenario 2: rejects oversized image with error", async () => {
+    mockLaunchImageLibraryAsync.mockResolvedValue({
+      canceled: false,
+      assets: [{ base64: LARGE_BASE64, mimeType: "image/jpeg" }],
+    });
+
+    const result = await pickAndEncodeProfilePicture();
+
+    expect(result.imageDataUri).toBeNull();
+    expect(result.error).toBe("Image is too large (max 500 KB)");
+  });
+
+  it("Scenario 3: rejects non-image file with error", async () => {
+    mockLaunchImageLibraryAsync.mockResolvedValue({
+      canceled: false,
+      assets: [{ base64: SMALL_BASE64, mimeType: "application/pdf" }],
+    });
+
+    const result = await pickAndEncodeProfilePicture();
+
+    expect(result.imageDataUri).toBeNull();
+    expect(result.error).toBe("Only image files are accepted");
+  });
+
+  it("Scenario 4: returns null with no error when picker is cancelled", async () => {
+    mockLaunchImageLibraryAsync.mockResolvedValue({
+      canceled: true,
+      assets: [],
+    });
+
+    const result = await pickAndEncodeProfilePicture();
+
+    expect(result.imageDataUri).toBeNull();
+    expect(result.error).toBeNull();
+  });
+});

--- a/apps/native/__tests__/profile-tab-display.test.tsx
+++ b/apps/native/__tests__/profile-tab-display.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * Tests for task #281 — Display name, surname, and picture in the profile tab
+ *
+ * Scenario 1: Student with complete identity profile sees their details
+ * Scenario 2: Student without a profile picture sees a placeholder
+ * Scenario 3: Profile tab reflects updated values after editing
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react-native";
+import React from "react";
+
+const mockPush = jest.fn();
+const mockReplace = jest.fn();
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ push: mockPush, replace: mockReplace }),
+}));
+
+jest.mock("@/lib/auth-client", () => ({
+  authClient: {
+    useSession: () => ({ data: null }),
+    signOut: jest.fn(),
+  },
+}));
+
+const mockGetMyProfile = jest.fn();
+jest.mock("@/utils/trpc", () => ({
+  trpc: {
+    profile: {
+      getMyProfile: {
+        queryOptions: () => ({ queryKey: ["profile"], queryFn: mockGetMyProfile }),
+      },
+    },
+  },
+}));
+
+import ProfileScreen from "../app/(tabs)/profile";
+
+function renderScreen() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <ProfileScreen />
+    </QueryClientProvider>,
+  );
+}
+
+describe("#281 — Profile tab display", () => {
+  beforeEach(() => mockGetMyProfile.mockReset());
+
+  describe("Scenario 1: complete identity profile", () => {
+    it("shows full name and profile picture", async () => {
+      mockGetMyProfile.mockResolvedValue({
+        identity: { name: "Sander", surname: "Boer", image: "data:image/jpeg;base64,abc", email: "s.boer@student.tue.nl" },
+        profile: null,
+        languages: [],
+        interests: [],
+      });
+
+      renderScreen();
+
+      const fullName = await screen.findByText("Sander Boer");
+      expect(fullName).toBeTruthy();
+
+      const picture = await screen.findByLabelText("Profile picture");
+      expect(picture).toBeTruthy();
+    });
+  });
+
+  describe("Scenario 2: no profile picture → placeholder", () => {
+    it("shows placeholder avatar when image is null", async () => {
+      mockGetMyProfile.mockResolvedValue({
+        identity: { name: "Sander", surname: "Boer", image: null, email: "s.boer@student.tue.nl" },
+        profile: null,
+        languages: [],
+        interests: [],
+      });
+
+      renderScreen();
+
+      const placeholder = await screen.findByLabelText("Profile picture placeholder");
+      expect(placeholder).toBeTruthy();
+
+      const fullName = await screen.findByText("Sander Boer");
+      expect(fullName).toBeTruthy();
+    });
+  });
+
+  describe("Scenario 3: updated values reflected", () => {
+    it("displays latest name and surname from getMyProfile", async () => {
+      mockGetMyProfile.mockResolvedValue({
+        identity: { name: "Alex", surname: "Updated", image: null, email: "a.updated@student.tue.nl" },
+        profile: null,
+        languages: [],
+        interests: [],
+      });
+
+      renderScreen();
+
+      const fullName = await screen.findByText("Alex Updated");
+      expect(fullName).toBeTruthy();
+    });
+  });
+
+  describe("edge cases", () => {
+    it("shows only name when surname is null", async () => {
+      mockGetMyProfile.mockResolvedValue({
+        identity: { name: "Sander", surname: null, image: null, email: "s@student.tue.nl" },
+        profile: null,
+        languages: [],
+        interests: [],
+      });
+
+      renderScreen();
+
+      const nameText = await screen.findByText("Sander");
+      expect(nameText).toBeTruthy();
+    });
+  });
+});

--- a/apps/native/app/(tabs)/profile.tsx
+++ b/apps/native/app/(tabs)/profile.tsx
@@ -1,21 +1,54 @@
+import { useQuery } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
 import { Button } from "heroui-native";
-import { Text, View } from "react-native";
+import { Image, Text, View } from "react-native";
 
 import { Container } from "@/components/container";
 import { authClient } from "@/lib/auth-client";
+import { trpc } from "@/utils/trpc";
+
+const AVATAR_SIZE = 80;
 
 export default function ProfileScreen() {
   const router = useRouter();
-  const { data: session } = authClient.useSession();
+  const profileQuery = useQuery(trpc.profile.getMyProfile.queryOptions());
+  const identity = profileQuery.data?.identity;
+
+  const fullName = [identity?.name, identity?.surname].filter(Boolean).join(" ");
 
   return (
     <Container isScrollable={false}>
       <View className="flex-1 p-6">
-        <Text className="text-foreground text-2xl font-bold mb-2">Profile</Text>
-        {session?.user?.name && (
-          <Text className="text-muted-foreground mb-6">{session.user.name}</Text>
-        )}
+        <Text className="text-foreground text-2xl font-bold mb-4">Profile</Text>
+
+        <View className="flex-row items-center gap-4 mb-6">
+          {identity?.image ? (
+            <Image
+              source={{ uri: identity.image }}
+              style={{ width: AVATAR_SIZE, height: AVATAR_SIZE, borderRadius: AVATAR_SIZE / 2 }}
+              accessibilityLabel="Profile picture"
+            />
+          ) : (
+            <View
+              style={{ width: AVATAR_SIZE, height: AVATAR_SIZE, borderRadius: AVATAR_SIZE / 2 }}
+              className="bg-default-200 items-center justify-center"
+              accessibilityLabel="Profile picture placeholder"
+            >
+              <Text className="text-default-500 text-2xl font-bold">
+                {identity?.name?.[0]?.toUpperCase() ?? "?"}
+              </Text>
+            </View>
+          )}
+
+          <View className="flex-1">
+            {fullName ? (
+              <Text className="text-foreground text-lg font-semibold">{fullName}</Text>
+            ) : (
+              <Text className="text-muted-foreground text-sm">No name set</Text>
+            )}
+          </View>
+        </View>
+
         <Button onPress={() => router.push("/edit-profile")}>
           <Button.Label>Edit Profile</Button.Label>
         </Button>

--- a/apps/native/app/_layout.tsx
+++ b/apps/native/app/_layout.tsx
@@ -90,18 +90,20 @@ function AuthGuard() {
 
     const onEnrolmentScreen = segments[0] === "enrolment";
     const onReviewScreen = segments[0] === "review-profile";
-
+    const onEditProfileScreen = segments[0] === "edit-profile";
     const onOnboardingScreen = segments[0] === undefined;
 
     if (!session && !onEnrolmentScreen) {
       router.replace("/enrolment");
+    } else if (session && !onboardingQuery.data?.identityProfileComplete && !onEditProfileScreen && !onEnrolmentScreen) {
+      router.replace("/edit-profile");
     } else if (session && onEnrolmentScreen) {
       if (onboardingQuery.data?.complete) {
         router.replace("/suggestions");
       } else {
         router.replace("/");
       }
-    } else if (session && !onboardingQuery.data?.complete && !onOnboardingScreen && !onReviewScreen) {
+    } else if (session && !onboardingQuery.data?.complete && !onOnboardingScreen && !onReviewScreen && !onEditProfileScreen) {
       router.replace("/");
     }
   }, [session, sessionPending, onboardingQuery.data, onboardingQuery.isPending, segments]);

--- a/apps/native/app/edit-profile.tsx
+++ b/apps/native/app/edit-profile.tsx
@@ -1,11 +1,13 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
 import { Button, Card, Spinner, useToast } from "heroui-native";
-import { useState } from "react";
-import { Pressable, ScrollView, Text, View } from "react-native";
+import { useEffect, useState } from "react";
+import { Alert, Image, Pressable, ScrollView, Text, TextInput, View } from "react-native";
 
 import { Container } from "@/components/container";
 import { queryClient, trpc } from "@/utils/trpc";
+import { extractNameFromEmail } from "@/utils/email-name-extract";
+import { pickAndEncodeProfilePicture } from "@/utils/profile-picture";
 
 const LANGUAGES = [
   "English",
@@ -63,8 +65,76 @@ export default function EditProfileScreen() {
   const router = useRouter();
   const { toast } = useToast();
   const [addingType, setAddingType] = useState<LanguageType | null>(null);
+  const [nameInput, setNameInput] = useState("");
+  const [surnameInput, setSurnameInput] = useState("");
+  const [imageUri, setImageUri] = useState<string | undefined>(undefined);
+  const [identityInitialized, setIdentityInitialized] = useState(false);
 
   const profileQuery = useQuery(trpc.profile.getMyProfile.queryOptions());
+
+  const setIdentityMutation = useMutation({
+    ...trpc.profile.setIdentityProfile.mutationOptions(),
+    onSuccess: () => queryClient.invalidateQueries(),
+    onError: (e) => {
+      toast.show({ variant: "danger", label: (e as { message?: string }).message ?? "Failed to save profile." });
+    },
+  });
+
+  useEffect(() => {
+    if (identityInitialized || !profileQuery.data) return;
+    const identity = profileQuery.data.identity;
+    const email = identity?.email ?? "";
+
+    if (identity?.name || identity?.surname) {
+      setNameInput(identity.name ?? "");
+      setSurnameInput(identity.surname ?? "");
+    } else {
+      const { name, surname } = extractNameFromEmail(email);
+      setNameInput(name);
+      setSurnameInput(surname);
+    }
+
+    setImageUri(identity?.image ?? undefined);
+    setIdentityInitialized(true);
+  }, [profileQuery.data, identityInitialized]);
+
+  function handleIdentityBlur() {
+    const name = nameInput.trim();
+    const surname = surnameInput.trim();
+    if (!name || !surname) return;
+    setIdentityMutation.mutate({ name, surname, imageUrl: imageUri });
+  }
+
+  async function handlePickPicture() {
+    const result = await pickAndEncodeProfilePicture();
+    if (result.error) {
+      toast.show({ variant: "danger", label: result.error });
+      return;
+    }
+    if (result.imageDataUri) {
+      setImageUri(result.imageDataUri);
+      const name = nameInput.trim();
+      const surname = surnameInput.trim();
+      if (name && surname) {
+        setIdentityMutation.mutate({ name, surname, imageUrl: result.imageDataUri });
+      }
+    }
+  }
+
+  function handleReviewPress() {
+    const missing: string[] = [];
+    if (!nameInput.trim()) missing.push("Name");
+    if (!surnameInput.trim()) missing.push("Surname");
+    if (missing.length > 0) {
+      Alert.alert(
+        "Required fields missing",
+        `Please fill in: ${missing.join(", ")}`,
+        [{ text: "OK" }],
+      );
+      return;
+    }
+    router.push("/review-profile");
+  }
 
   const upsertMutation = useMutation({
     ...trpc.profile.upsertLanguage.mutationOptions(),
@@ -142,6 +212,58 @@ export default function EditProfileScreen() {
         keyboardShouldPersistTaps="handled"
       >
         <View className="flex-1 p-6 gap-8">
+
+          {/* Personal Info */}
+          <View>
+            <Text className="text-foreground text-xl font-bold mb-3">Personal Info</Text>
+
+            <View className="gap-3">
+              <View>
+                <Text className="text-foreground text-sm font-medium mb-1">Name</Text>
+                <TextInput
+                  testID="name-input"
+                  value={nameInput}
+                  onChangeText={setNameInput}
+                  onBlur={handleIdentityBlur}
+                  placeholder="First name"
+                  placeholderTextColor="#9ca3af"
+                  autoCapitalize="words"
+                  className="border border-border rounded-lg px-3 py-2 text-foreground bg-background"
+                />
+              </View>
+
+              <View>
+                <Text className="text-foreground text-sm font-medium mb-1">Surname</Text>
+                <TextInput
+                  testID="surname-input"
+                  value={surnameInput}
+                  onChangeText={setSurnameInput}
+                  onBlur={handleIdentityBlur}
+                  placeholder="Last name"
+                  placeholderTextColor="#9ca3af"
+                  autoCapitalize="words"
+                  className="border border-border rounded-lg px-3 py-2 text-foreground bg-background"
+                />
+              </View>
+
+              <View>
+                <Text className="text-foreground text-sm font-medium mb-2">Profile Picture</Text>
+                <Pressable onPress={handlePickPicture} testID="pick-picture-button">
+                  {imageUri ? (
+                    <Image
+                      source={{ uri: imageUri }}
+                      style={{ width: 80, height: 80, borderRadius: 40 }}
+                      accessibilityLabel="Profile picture preview"
+                    />
+                  ) : (
+                    <View className="w-20 h-20 rounded-full bg-default-200 items-center justify-center border border-dashed border-border">
+                      <Text className="text-muted-foreground text-xs text-center">Tap to add{"\n"}photo</Text>
+                    </View>
+                  )}
+                </Pressable>
+              </View>
+            </View>
+          </View>
 
           {/* Spoken Languages */}
           <View>
@@ -349,7 +471,7 @@ export default function EditProfileScreen() {
           )}
 
           <View className="mt-4 pt-4 border-t border-border">
-            <Button onPress={() => router.push("/review-profile")}>
+            <Button onPress={handleReviewPress} testID="review-submit-button">
               <Button.Label>Review & Submit Profile</Button.Label>
             </Button>
           </View>

--- a/apps/native/package.json
+++ b/apps/native/package.json
@@ -35,6 +35,7 @@
     "expo-constants": "~55.0.7",
     "expo-font": "~55.0.4",
     "expo-haptics": "~55.0.8",
+    "expo-image-picker": "^55.0.18",
     "expo-linking": "~55.0.7",
     "expo-network": "~55.0.8",
     "expo-notifications": "^55.0.18",

--- a/apps/native/utils/email-name-extract.ts
+++ b/apps/native/utils/email-name-extract.ts
@@ -1,0 +1,14 @@
+function capitalize(s: string): string {
+  return s.length === 0 ? s : s[0].toUpperCase() + s.slice(1).toLowerCase();
+}
+
+export function extractNameFromEmail(email: string): { name: string; surname: string } {
+  const local = email.split("@")[0] ?? "";
+  const parts = local.split(".");
+
+  if (parts.length >= 2) {
+    return { name: capitalize(parts[0]), surname: capitalize(parts[1]) };
+  }
+
+  return { name: "", surname: capitalize(parts[0] ?? "") };
+}

--- a/apps/native/utils/profile-picture.ts
+++ b/apps/native/utils/profile-picture.ts
@@ -1,0 +1,47 @@
+import * as ImagePicker from "expo-image-picker";
+
+const MAX_SIZE_BYTES = 500 * 1024;
+
+export function validateImageMimeType(mimeType: string): boolean {
+  return mimeType.startsWith("image/");
+}
+
+export function validateImageSize(base64: string): boolean {
+  // base64 encodes 3 bytes as 4 chars
+  const bytes = (base64.length * 3) / 4;
+  return bytes <= MAX_SIZE_BYTES;
+}
+
+export function buildDataUri(mimeType: string, base64: string): string {
+  return `data:${mimeType};base64,${base64}`;
+}
+
+export type PickResult =
+  | { imageDataUri: string; error: null }
+  | { imageDataUri: null; error: string }
+  | { imageDataUri: null; error: null };
+
+export async function pickAndEncodeProfilePicture(): Promise<PickResult> {
+  const result = await ImagePicker.launchImageLibraryAsync({
+    mediaTypes: "images",
+    base64: true,
+    quality: 0.8,
+  });
+
+  if (result.canceled) return { imageDataUri: null, error: null };
+
+  const asset = result.assets[0];
+  if (!asset?.base64) return { imageDataUri: null, error: "Could not encode image" };
+
+  const mimeType = asset.mimeType ?? "image/jpeg";
+
+  if (!validateImageMimeType(mimeType)) {
+    return { imageDataUri: null, error: "Only image files are accepted" };
+  }
+
+  if (!validateImageSize(asset.base64)) {
+    return { imageDataUri: null, error: "Image is too large (max 500 KB)" };
+  }
+
+  return { imageDataUri: buildDataUri(mimeType, asset.base64), error: null };
+}

--- a/bun.lock
+++ b/bun.lock
@@ -43,6 +43,7 @@
         "expo-constants": "~55.0.7",
         "expo-font": "~55.0.4",
         "expo-haptics": "~55.0.8",
+        "expo-image-picker": "^55.0.18",
         "expo-linking": "~55.0.7",
         "expo-network": "~55.0.8",
         "expo-notifications": "^55.0.18",
@@ -1691,6 +1692,10 @@
     "expo-haptics": ["expo-haptics@55.0.11", "", { "peerDependencies": { "expo": "*" } }, "sha512-cvayByobLtoS5Yt2JFqcBPH+1mnLHkz+Rr+H1EOCZDdTVo5T6aaAHMOZrbRBZBhxrUevAPxfz0bfyhVZj3XHzA=="],
 
     "expo-image": ["expo-image@55.0.8", "", { "dependencies": { "sf-symbols-typescript": "^2.2.0" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*", "react-native-web": "*" }, "optionalPeers": ["react-native-web"] }, "sha512-fNdvdYVcGn3g1x6o5AXHKzk4xX8U6rg2W9vFdE1pQO80kWCNReh003ypqSrGy4dD+zA8FtZjrNF3oMDGnPpIGQ=="],
+
+    "expo-image-loader": ["expo-image-loader@55.0.0", "", { "peerDependencies": { "expo": "*" } }, "sha512-NOjp56wDrfuA5aiNAybBIjqIn1IxKeGJ8CECWZncQ/GzjZfyTYAHTCyeApYkdKkMBLHINzI4BbTGSlbCa0fXXQ=="],
+
+    "expo-image-picker": ["expo-image-picker@55.0.18", "", { "dependencies": { "expo-image-loader": "~55.0.0" }, "peerDependencies": { "expo": "*" } }, "sha512-lGpPGRu+7mE8qN0ma2boRsCmfOGbdHZ2bXTpWVeWly0JCZdogGlTrYFnhTqgS8+lmiRb/UCOs7iTm2P5Rra6kw=="],
 
     "expo-keep-awake": ["expo-keep-awake@55.0.6", "", { "peerDependencies": { "expo": "*", "react": "*" } }, "sha512-acJjeHqkNxMVckEcJhGQeIksqqsarscSHJtT559bNgyiM4r14dViQ66su7bb6qDVeBt0K7z3glXI1dHVck1Zgg=="],
 

--- a/packages/api/src/__tests__/identity-profile.test.ts
+++ b/packages/api/src/__tests__/identity-profile.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Tests for task #277 — tRPC procedures to set and update Student identity profile
+ *
+ * Scenario 1: Student sets their identity profile for the first time
+ * Scenario 2: Student updates their identity profile
+ * Scenario 3: Student submits without a name or surname (validation)
+ * Scenario 4: Unauthenticated request is rejected (tRPC auth guard)
+ */
+import { describe, it, expect } from "bun:test";
+import { determineIdentityProfileEvent } from "../routers/profile-utils";
+
+describe("#277 — determineIdentityProfileEvent", () => {
+  describe("Scenario 1: first-time profile setup", () => {
+    it("emits StudentProfileCompleted when surname was NULL", () => {
+      expect(determineIdentityProfileEvent(null)).toBe("StudentProfileCompleted");
+    });
+  });
+
+  describe("Scenario 2: subsequent profile update", () => {
+    it("emits StudentProfileUpdated when surname was already set", () => {
+      expect(determineIdentityProfileEvent("Janssen")).toBe("StudentProfileUpdated");
+    });
+
+    it("emits StudentProfileUpdated for any non-null previous surname", () => {
+      expect(determineIdentityProfileEvent("")).toBe("StudentProfileUpdated");
+      expect(determineIdentityProfileEvent("Smith")).toBe("StudentProfileUpdated");
+    });
+  });
+});

--- a/packages/api/src/__tests__/onboarding-status-identity.test.ts
+++ b/packages/api/src/__tests__/onboarding-status-identity.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Tests for task #280 — Gate app routes until Student identity profile is complete
+ *
+ * Tests identityProfileComplete logic in getOnboardingStatus.
+ */
+import { describe, it, expect } from "bun:test";
+
+function identityProfileComplete(name: string | null, surname: string | null): boolean {
+  return !!(name?.trim() && surname?.trim());
+}
+
+describe("#280 — identityProfileComplete flag", () => {
+  it("Scenario 2: true when both name and surname are set", () => {
+    expect(identityProfileComplete("Sander", "Boer")).toBe(true);
+  });
+
+  it("Scenario 1: false when surname is null", () => {
+    expect(identityProfileComplete("Sander", null)).toBe(false);
+  });
+
+  it("Scenario 1: false when name is empty", () => {
+    expect(identityProfileComplete("", "Boer")).toBe(false);
+  });
+
+  it("Scenario 1: false when name is whitespace-only", () => {
+    expect(identityProfileComplete("   ", "Boer")).toBe(false);
+  });
+
+  it("Scenario 1: false when both are null", () => {
+    expect(identityProfileComplete(null, null)).toBe(false);
+  });
+});

--- a/packages/api/src/domain-events.ts
+++ b/packages/api/src/domain-events.ts
@@ -226,6 +226,18 @@ export interface StudentRemovedEvent {
   removedAt: Date;
 }
 
+// #276 — Feature #275
+export interface StudentProfileCompletedEvent {
+  userId: string;
+  completedAt: Date;
+}
+
+// #276 — Feature #275
+export interface StudentProfileUpdatedEvent {
+  userId: string;
+  updatedAt: Date;
+}
+
 type DomainEventMap = {
   LanguageProfileUpdated: [LanguageProfileUpdatedEvent];
   InterestProfileUpdated: [InterestProfileUpdatedEvent];
@@ -256,6 +268,8 @@ type DomainEventMap = {
   StudentSuspended: [StudentSuspendedEvent];
   SuspensionLifted: [SuspensionLiftedEvent];
   StudentRemoved: [StudentRemovedEvent];
+  StudentProfileCompleted: [StudentProfileCompletedEvent];
+  StudentProfileUpdated: [StudentProfileUpdatedEvent];
 };
 
 class TypedEventEmitter extends EventEmitter {

--- a/packages/api/src/routers/profile-utils.ts
+++ b/packages/api/src/routers/profile-utils.ts
@@ -1,0 +1,5 @@
+export function determineIdentityProfileEvent(
+  previousSurname: string | null,
+): "StudentProfileCompleted" | "StudentProfileUpdated" {
+  return previousSurname === null ? "StudentProfileCompleted" : "StudentProfileUpdated";
+}

--- a/packages/api/src/routers/profile.ts
+++ b/packages/api/src/routers/profile.ts
@@ -12,6 +12,7 @@ import {
 import { user } from "@sip-and-speak/db/schema/auth";
 import { protectedProcedure, router } from "../index";
 import { domainEvents } from "../domain-events";
+import { determineIdentityProfileEvent } from "./profile-utils";
 
 const interestEnum = z.enum([
   "modern_art",
@@ -102,7 +103,42 @@ async function syncMatchingEligibility(userId: string): Promise<boolean> {
   return isEligible;
 }
 
+const setIdentityProfileInput = z.object({
+  name: z.string().trim().min(1, "Name is required"),
+  surname: z.string().trim().min(1, "Surname is required"),
+  imageUrl: z.string().optional(),
+});
+
+
 export const profileRouter = router({
+  setIdentityProfile: protectedProcedure
+    .input(setIdentityProfileInput)
+    .mutation(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+
+      const existing = await db
+        .select({ surname: user.surname })
+        .from(user)
+        .where(eq(user.id, userId))
+        .limit(1);
+
+      const previousSurname = existing[0]?.surname ?? null;
+
+      await db
+        .update(user)
+        .set({ name: input.name, surname: input.surname, image: input.imageUrl ?? null })
+        .where(eq(user.id, userId));
+
+      const event = determineIdentityProfileEvent(previousSurname);
+      if (event === "StudentProfileCompleted") {
+        domainEvents.emit("StudentProfileCompleted", { userId, completedAt: new Date() });
+      } else {
+        domainEvents.emit("StudentProfileUpdated", { userId, updatedAt: new Date() });
+      }
+
+      return { success: true };
+    }),
+
   getMyProfile: protectedProcedure.query(async ({ ctx }) => {
     const userId = ctx.session.user.id;
 

--- a/packages/api/src/routers/profile.ts
+++ b/packages/api/src/routers/profile.ts
@@ -333,14 +333,25 @@ export const profileRouter = router({
   getOnboardingStatus: protectedProcedure.query(async ({ ctx }) => {
     const userId = ctx.session.user.id;
 
-    const profile = await db.query.languageProfile.findFirst({
-      where: eq(languageProfile.userId, userId),
-      columns: { onboardingComplete: true },
-    });
+    const [profile, identity] = await Promise.all([
+      db.query.languageProfile.findFirst({
+        where: eq(languageProfile.userId, userId),
+        columns: { onboardingComplete: true },
+      }),
+      db
+        .select({ name: user.name, surname: user.surname })
+        .from(user)
+        .where(eq(user.id, userId))
+        .limit(1),
+    ]);
+
+    const id = identity[0];
+    const identityProfileComplete = !!(id?.name?.trim() && id?.surname?.trim());
 
     return {
       complete: profile?.onboardingComplete ?? false,
       hasProfile: profile !== null,
+      identityProfileComplete,
     };
   }),
 

--- a/packages/api/src/routers/profile.ts
+++ b/packages/api/src/routers/profile.ts
@@ -142,24 +142,24 @@ export const profileRouter = router({
   getMyProfile: protectedProcedure.query(async ({ ctx }) => {
     const userId = ctx.session.user.id;
 
-    const profile = await db.query.languageProfile.findFirst({
-      where: eq(languageProfile.userId, userId),
-    });
-
-    const languages = await db
-      .select()
-      .from(userLanguage)
-      .where(eq(userLanguage.userId, userId));
-
-    const interests = await db
-      .select()
-      .from(userInterest)
-      .where(eq(userInterest.userId, userId));
+    const [profile, languages, interests, identity] = await Promise.all([
+      db.query.languageProfile.findFirst({
+        where: eq(languageProfile.userId, userId),
+      }),
+      db.select().from(userLanguage).where(eq(userLanguage.userId, userId)),
+      db.select().from(userInterest).where(eq(userInterest.userId, userId)),
+      db
+        .select({ name: user.name, surname: user.surname, image: user.image, email: user.email })
+        .from(user)
+        .where(eq(user.id, userId))
+        .limit(1),
+    ]);
 
     return {
       profile: profile ?? null,
       languages,
       interests,
+      identity: identity[0] ?? null,
     };
   }),
 

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -19,7 +19,8 @@
     "db:stop": "docker compose stop",
     "db:down": "docker compose down",
     "db:seed:venues": "bun run src/seed/venues.ts",
-    "db:seed:tue-locations": "bun run src/seed/tue-locations.ts"
+    "db:seed:tue-locations": "bun run src/seed/tue-locations.ts",
+    "test": "bun test"
   },
   "dependencies": {
     "@sip-and-speak/env": "workspace:*",

--- a/packages/db/src/__tests__/schema-surname.test.ts
+++ b/packages/db/src/__tests__/schema-surname.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "bun:test";
+import { user } from "../schema/auth";
+
+describe("user table schema — surname column", () => {
+  it("defines a surname column", () => {
+    expect(user.surname).toBeDefined();
+  });
+
+  it("surname is nullable (no notNull constraint)", () => {
+    const col = user.surname as { notNull: boolean };
+    expect(col.notNull).toBe(false);
+  });
+
+  it("surname is a text column", () => {
+    const col = user.surname as { dataType: string };
+    expect(col.dataType).toBe("string");
+  });
+});

--- a/packages/db/src/migrations/0016_perpetual_wendell_vaughn.sql
+++ b/packages/db/src/migrations/0016_perpetual_wendell_vaughn.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "user" ADD COLUMN "surname" text;

--- a/packages/db/src/migrations/meta/0016_snapshot.json
+++ b/packages/db/src/migrations/meta/0016_snapshot.json
@@ -1,0 +1,2174 @@
+{
+  "id": "aa51e33a-3a47-4b7c-9814-939abeaef407",
+  "prevId": "57ebfd1f-392b-448f-a580-c4465464906f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "surname": {
+          "name": "surname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "student_status": {
+          "name": "student_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attendance_report": {
+      "name": "attendance_report",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "meetup_id": {
+          "name": "meetup_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attended": {
+          "name": "attended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reported_at": {
+          "name": "reported_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "attendance_report_meetupId_idx": {
+          "name": "attendance_report_meetupId_idx",
+          "columns": [
+            {
+              "expression": "meetup_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attendance_report_meetup_id_meetup_id_fk": {
+          "name": "attendance_report_meetup_id_meetup_id_fk",
+          "tableFrom": "attendance_report",
+          "tableTo": "meetup",
+          "columnsFrom": [
+            "meetup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attendance_report_student_id_user_id_fk": {
+          "name": "attendance_report_student_id_user_id_fk",
+          "tableFrom": "attendance_report",
+          "tableTo": "user",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "attendance_report_meetup_student_unique": {
+          "name": "attendance_report_meetup_student_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "meetup_id",
+            "student_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocked_email": {
+      "name": "blocked_email",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocked_at": {
+          "name": "blocked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blocked_email_email_idx": {
+          "name": "blocked_email_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "blocked_email_email_unique": {
+          "name": "blocked_email_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation": {
+      "name": "conversation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user1_id": {
+          "name": "user1_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user2_id": {
+          "name": "user2_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meetup_id": {
+          "name": "meetup_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_user1_idx": {
+          "name": "conversation_user1_idx",
+          "columns": [
+            {
+              "expression": "user1_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_user2_idx": {
+          "name": "conversation_user2_idx",
+          "columns": [
+            {
+              "expression": "user2_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_meetupId_idx": {
+          "name": "conversation_meetupId_idx",
+          "columns": [
+            {
+              "expression": "meetup_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_user1_id_user_id_fk": {
+          "name": "conversation_user1_id_user_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user1_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_user2_id_user_id_fk": {
+          "name": "conversation_user2_id_user_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user2_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_meetup_id_meetup_id_fk": {
+          "name": "conversation_meetup_id_meetup_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "meetup",
+          "columnsFrom": [
+            "meetup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_presence": {
+      "name": "conversation_presence",
+      "schema": "",
+      "columns": {
+        "student_id": {
+          "name": "student_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_until": {
+          "name": "active_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "conversation_presence_studentId_idx": {
+          "name": "conversation_presence_studentId_idx",
+          "columns": [
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_presence_student_id_user_id_fk": {
+          "name": "conversation_presence_student_id_user_id_fk",
+          "tableFrom": "conversation_presence",
+          "tableTo": "user",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversation_presence_conversation_id_conversation_id_fk": {
+          "name": "conversation_presence_conversation_id_conversation_id_fk",
+          "tableFrom": "conversation_presence",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversation_presence_student_conv_unique": {
+          "name": "conversation_presence_student_conv_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "student_id",
+            "conversation_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.language_profile": {
+      "name": "language_profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "university": {
+          "name": "university",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "age": {
+          "name": "age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_complete": {
+          "name": "onboarding_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "language_profile_user_id_user_id_fk": {
+          "name": "language_profile_user_id_user_id_fk",
+          "tableFrom": "language_profile",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "language_profile_user_id_unique": {
+          "name": "language_profile_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_request": {
+      "name": "match_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "requester_id": {
+          "name": "requester_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receiver_id": {
+          "name": "receiver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "match_request_requesterId_idx": {
+          "name": "match_request_requesterId_idx",
+          "columns": [
+            {
+              "expression": "requester_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "match_request_receiverId_idx": {
+          "name": "match_request_receiverId_idx",
+          "columns": [
+            {
+              "expression": "receiver_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "match_request_requester_id_user_id_fk": {
+          "name": "match_request_requester_id_user_id_fk",
+          "tableFrom": "match_request",
+          "tableTo": "user",
+          "columnsFrom": [
+            "requester_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "match_request_receiver_id_user_id_fk": {
+          "name": "match_request_receiver_id_user_id_fk",
+          "tableFrom": "match_request",
+          "tableTo": "user",
+          "columnsFrom": [
+            "receiver_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meetup": {
+      "name": "meetup",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "proposer_id": {
+          "name": "proposer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receiver_id": {
+          "name": "receiver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "venue_id": {
+          "name": "venue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "reschedule_proposer_id": {
+          "name": "reschedule_proposer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reschedule_venue_id": {
+          "name": "reschedule_venue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reschedule_date": {
+          "name": "reschedule_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reschedule_time": {
+          "name": "reschedule_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "meetup_proposerId_idx": {
+          "name": "meetup_proposerId_idx",
+          "columns": [
+            {
+              "expression": "proposer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meetup_receiverId_idx": {
+          "name": "meetup_receiverId_idx",
+          "columns": [
+            {
+              "expression": "receiver_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meetup_date_idx": {
+          "name": "meetup_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "meetup_proposer_id_user_id_fk": {
+          "name": "meetup_proposer_id_user_id_fk",
+          "tableFrom": "meetup",
+          "tableTo": "user",
+          "columnsFrom": [
+            "proposer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meetup_receiver_id_user_id_fk": {
+          "name": "meetup_receiver_id_user_id_fk",
+          "tableFrom": "meetup",
+          "tableTo": "user",
+          "columnsFrom": [
+            "receiver_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "meetup_venue_id_venue_id_fk": {
+          "name": "meetup_venue_id_venue_id_fk",
+          "tableFrom": "meetup",
+          "tableTo": "venue",
+          "columnsFrom": [
+            "venue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meetup_reschedule_proposer_id_user_id_fk": {
+          "name": "meetup_reschedule_proposer_id_user_id_fk",
+          "tableFrom": "meetup",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reschedule_proposer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "meetup_reschedule_venue_id_venue_id_fk": {
+          "name": "meetup_reschedule_venue_id_venue_id_fk",
+          "tableFrom": "meetup",
+          "tableTo": "venue",
+          "columnsFrom": [
+            "reschedule_venue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message": {
+      "name": "message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_conversationId_idx": {
+          "name": "message_conversationId_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_createdAt_idx": {
+          "name": "message_createdAt_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_conversation_id_conversation_id_fk": {
+          "name": "message_conversation_id_conversation_id_fk",
+          "tableFrom": "message",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_sender_id_user_id_fk": {
+          "name": "message_sender_id_user_id_fk",
+          "tableFrom": "message",
+          "tableTo": "user",
+          "columnsFrom": [
+            "sender_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message_read_status": {
+      "name": "message_read_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_read_conversationId_userId_idx": {
+          "name": "message_read_conversationId_userId_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_read_status_conversation_id_conversation_id_fk": {
+          "name": "message_read_status_conversation_id_conversation_id_fk",
+          "tableFrom": "message_read_status",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_read_status_user_id_user_id_fk": {
+          "name": "message_read_status_user_id_user_id_fk",
+          "tableFrom": "message_read_status",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messaging_opt_in": {
+      "name": "messaging_opt_in",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "meetup_id": {
+          "name": "meetup_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "nudge_sent_at": {
+          "name": "nudge_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "messaging_opt_in_meetupId_idx": {
+          "name": "messaging_opt_in_meetupId_idx",
+          "columns": [
+            {
+              "expression": "meetup_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messaging_opt_in_meetup_id_meetup_id_fk": {
+          "name": "messaging_opt_in_meetup_id_meetup_id_fk",
+          "tableFrom": "messaging_opt_in",
+          "tableTo": "meetup",
+          "columnsFrom": [
+            "meetup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messaging_opt_in_student_id_user_id_fk": {
+          "name": "messaging_opt_in_student_id_user_id_fk",
+          "tableFrom": "messaging_opt_in",
+          "tableTo": "user",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "messaging_opt_in_meetup_student_unique": {
+          "name": "messaging_opt_in_meetup_student_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "meetup_id",
+            "student_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_comment": {
+      "name": "student_comment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "student_comment_targetId_idx": {
+          "name": "student_comment_targetId_idx",
+          "columns": [
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "student_comment_author_id_user_id_fk": {
+          "name": "student_comment_author_id_user_id_fk",
+          "tableFrom": "student_comment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "student_comment_target_id_user_id_fk": {
+          "name": "student_comment_target_id_user_id_fk",
+          "tableFrom": "student_comment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_match": {
+      "name": "student_match",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "student_a_id": {
+          "name": "student_a_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_b_id": {
+          "name": "student_b_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_request_id": {
+          "name": "match_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'matched'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "student_match_studentA_idx": {
+          "name": "student_match_studentA_idx",
+          "columns": [
+            {
+              "expression": "student_a_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "student_match_studentB_idx": {
+          "name": "student_match_studentB_idx",
+          "columns": [
+            {
+              "expression": "student_b_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "student_match_student_a_id_user_id_fk": {
+          "name": "student_match_student_a_id_user_id_fk",
+          "tableFrom": "student_match",
+          "tableTo": "user",
+          "columnsFrom": [
+            "student_a_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "student_match_student_b_id_user_id_fk": {
+          "name": "student_match_student_b_id_user_id_fk",
+          "tableFrom": "student_match",
+          "tableTo": "user",
+          "columnsFrom": [
+            "student_b_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "student_match_match_request_id_match_request_id_fk": {
+          "name": "student_match_match_request_id_match_request_id_fk",
+          "tableFrom": "student_match",
+          "tableTo": "match_request",
+          "columnsFrom": [
+            "match_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_device_token": {
+      "name": "user_device_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_device_token_userId_token_idx": {
+          "name": "user_device_token_userId_token_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_device_token_user_id_user_id_fk": {
+          "name": "user_device_token_user_id_user_id_fk",
+          "tableFrom": "user_device_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_flag": {
+      "name": "user_flag",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moderator_id": {
+          "name": "moderator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_flag_reporter_idx": {
+          "name": "user_flag_reporter_idx",
+          "columns": [
+            {
+              "expression": "reporter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_flag_target_idx": {
+          "name": "user_flag_target_idx",
+          "columns": [
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_flag_status_idx": {
+          "name": "user_flag_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_flag_reporter_id_user_id_fk": {
+          "name": "user_flag_reporter_id_user_id_fk",
+          "tableFrom": "user_flag",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_flag_target_id_user_id_fk": {
+          "name": "user_flag_target_id_user_id_fk",
+          "tableFrom": "user_flag",
+          "tableTo": "user",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_flag_moderator_id_user_id_fk": {
+          "name": "user_flag_moderator_id_user_id_fk",
+          "tableFrom": "user_flag",
+          "tableTo": "user",
+          "columnsFrom": [
+            "moderator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_interest": {
+      "name": "user_interest",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interest": {
+          "name": "interest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_interest_userId_idx": {
+          "name": "user_interest_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_interest_user_id_user_id_fk": {
+          "name": "user_interest_user_id_user_id_fk",
+          "tableFrom": "user_interest",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_interest_user_interest_unique": {
+          "name": "user_interest_user_interest_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "interest"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_language": {
+      "name": "user_language",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proficiency": {
+          "name": "proficiency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_language_userId_idx": {
+          "name": "user_language_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_language_user_id_user_id_fk": {
+          "name": "user_language_user_id_user_id_fk",
+          "tableFrom": "user_language",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_language_user_language_type_unique": {
+          "name": "user_language_user_language_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "language",
+            "type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.venue": {
+      "name": "venue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "venue_name_idx": {
+          "name": "venue_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1776279410095,
       "tag": "0015_flat_mercury",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1776700591771,
+      "tag": "0016_perpetual_wendell_vaughn",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/auth.ts
+++ b/packages/db/src/schema/auth.ts
@@ -16,6 +16,7 @@ export const user = pgTable("user", {
   email: text("email").notNull().unique(),
   emailVerified: boolean("email_verified").default(false).notNull(),
   image: text("image"),
+  surname: text("surname"),
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at")
     .defaultNow()


### PR DESCRIPTION
## Summary
- Adds `surname` column to `user` table (migration + schema tests)
- Adds `setIdentityProfile` tRPC mutation (name, surname, imageUrl)
- Adds profile picture encoding utility with validation (expo-image-picker)
- Adds Personal Info section to edit-profile screen with email-based pre-fill
- Extends profile tab to display picture, name, and surname
- Gates app routes: redirects to edit-profile until name + surname are set

## PRs merged
- #286 — DB schema migration (surname column)
- #287 — Image encoding utility
- #288 — tRPC setIdentityProfile procedure
- #289 — Profile tab display
- #290 — Profile screen identity section + email pre-fill
- #291 — Route gating

Closes #276
Closes #277
Closes #278
Closes #279
Closes #280
Closes #281
Closes #275