### PR TITLE
fix(native): full-screen celebration modal when match forms

### DIFF
--- a/apps/native/app/_layout.tsx
+++ b/apps/native/app/_layout.tsx
@@ -17,7 +17,7 @@ import { focusManager, QueryClientProvider, useMutation } from "@tanstack/react-
 import { useFonts } from "expo-font";
 import { Stack, useRootNavigationState, useRouter, useSegments } from "expo-router";
 import * as SplashScreen from "expo-splash-screen";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { HeroUINativeProvider } from "heroui-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { KeyboardProvider } from "react-native-keyboard-controller";
@@ -29,6 +29,7 @@ import { authClient } from "@/lib/auth-client";
 import { AppThemeProvider } from "@/contexts/app-theme-context";
 import { queryClient, trpc } from "@/utils/trpc";
 import { useNotificationTapHandler } from "@/hooks/use-notification-tap-handler";
+import { MatchCelebrationModal } from "@/components/match-celebration-modal";
 import { OnboardingModal } from "@/components/onboarding-modal"; // edge-case: complete but no identity
 
 SplashScreen.preventAutoHideAsync();
@@ -64,6 +65,31 @@ function useDeviceTokenRegistration(isLoggedIn: boolean) {
     void register();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isLoggedIn]);
+}
+
+interface MatchAlert {
+  partnerName: string;
+  partnerId: string;
+}
+
+function useForegroundMatchAlert(): [MatchAlert | null, () => void] {
+  const [alert, setAlert] = useState<MatchAlert | null>(null);
+
+  useEffect(() => {
+    const subscription = Notifications.addNotificationReceivedListener((notification) => {
+      const data = notification.request.content.data as Record<string, unknown> | undefined;
+      if (data?.type !== "match_accepted") return;
+      const partnerId = typeof data.matchedWithUserId === "string" ? data.matchedWithUserId : null;
+      if (!partnerId) return;
+      // Extract name from notification body ("X accepted your request")
+      const body = notification.request.content.body ?? "";
+      const partnerName = body.replace(" accepted your request", "") || "Your match";
+      setAlert({ partnerName, partnerId });
+    });
+    return () => subscription.remove();
+  }, []);
+
+  return [alert, () => setAlert(null)];
 }
 
 function AuthGuard() {
@@ -155,6 +181,8 @@ export default function Layout() {
     }
   }, [fontsLoaded]);
 
+  const [matchAlert, dismissMatchAlert] = useForegroundMatchAlert();
+
   if (!fontsLoaded) {
     return null;
   }
@@ -167,6 +195,14 @@ export default function Layout() {
             <HeroUINativeProvider>
               <AuthGuard />
               <OnboardingModal />
+              {matchAlert && (
+                <MatchCelebrationModal
+                  visible
+                  partnerName={matchAlert.partnerName}
+                  partnerId={matchAlert.partnerId}
+                  onDismiss={dismissMatchAlert}
+                />
+              )}
               <StackLayout />
             </HeroUINativeProvider>
           </AppThemeProvider>

--- a/apps/native/app/partner/[id].tsx
+++ b/apps/native/app/partner/[id].tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 import { Image, ScrollView, Text, View } from "react-native";
 
 import { Container } from "@/components/container";
+import { MatchCelebrationModal } from "@/components/match-celebration-modal";
 import { queryClient, trpc } from "@/utils/trpc";
 
 export default function PartnerProfileScreen() {
@@ -24,6 +25,7 @@ export default function PartnerProfileScreen() {
   );
 
   const [sendConflictError, setSendConflictError] = useState<string | null>(null);
+  const [showCelebration, setShowCelebration] = useState(false);
 
   const sendRequestMutation = useMutation({
     ...trpc.matching.sendMatchRequest.mutationOptions(),
@@ -39,6 +41,7 @@ export default function PartnerProfileScreen() {
     onSuccess: () => {
       queryClient.invalidateQueries(trpc.matching.getIncomingRequests.queryOptions());
       queryClient.invalidateQueries(trpc.matching.getMyMatches.queryOptions());
+      setShowCelebration(true);
     },
   });
 
@@ -90,6 +93,15 @@ export default function PartnerProfileScreen() {
   const requestIsAccepted = statusQuery.data?.matchRequestStatus === "accepted";
 
   return (
+    <>
+      {profile && (
+        <MatchCelebrationModal
+          visible={showCelebration}
+          partnerName={profile.name}
+          partnerId={id}
+          onDismiss={() => setShowCelebration(false)}
+        />
+      )}
     <Container isScrollable={false}>
       <ScrollView contentContainerStyle={{ padding: 16 }}>
         {/* Header: photo + name */}
@@ -321,5 +333,6 @@ export default function PartnerProfileScreen() {
         </Button>
       </ScrollView>
     </Container>
+    </>
   );
 }

--- a/apps/native/components/match-celebration-modal.tsx
+++ b/apps/native/components/match-celebration-modal.tsx
@@ -1,0 +1,41 @@
+import { useRouter } from "expo-router";
+import { Button } from "heroui-native";
+import { Modal, Text, View } from "react-native";
+
+interface Props {
+  visible: boolean;
+  partnerName: string;
+  partnerId: string;
+  onDismiss: () => void;
+}
+
+export function MatchCelebrationModal({ visible, partnerName, partnerId, onDismiss }: Props) {
+  const router = useRouter();
+
+  function handlePropose() {
+    onDismiss();
+    router.push({ pathname: "/propose-meetup", params: { partnerId, partnerName } });
+  }
+
+  return (
+    <Modal visible={visible} animationType="slide" presentationStyle="fullScreen">
+      <View className="flex-1 bg-background items-center justify-center px-8 gap-6">
+        <Text className="text-6xl">🎉</Text>
+        <Text className="text-foreground text-3xl font-bold text-center">
+          It's a match!
+        </Text>
+        <Text className="text-muted-foreground text-center text-lg">
+          You and {partnerName} are now matched. Propose a meetup to start practising together.
+        </Text>
+        <View className="w-full gap-3">
+          <Button testID="celebration-propose-btn" variant="primary" onPress={handlePropose}>
+            <Button.Label>Propose a meetup</Button.Label>
+          </Button>
+          <Button testID="celebration-dismiss-btn" variant="ghost" onPress={onDismiss}>
+            <Button.Label>Maybe later</Button.Label>
+          </Button>
+        </View>
+      </View>
+    </Modal>
+  );
+}


### PR DESCRIPTION
Fixes #284

## Impact
Neither party saw any in-app visual feedback when a Match was formed. Push notification fired correctly, but the app showed nothing.

## Root cause
The `acceptMatchRequest` mutation result was only reflected as a small inline banner — no full-screen feedback. There was no foreground push listener to handle the requester side.

## Fix
- Added `MatchCelebrationModal` component: full-screen slide-up modal with emoji, partner name, "Propose a meetup" CTA, and "Maybe later" dismiss.
- In `partner/[id].tsx`: `acceptMutation.onSuccess` now sets `showCelebration = true`, triggering the modal for the accepting Student (Student B).
- In `_layout.tsx`: added `useForegroundMatchAlert` hook using `Notifications.addNotificationReceivedListener`. When a `match_accepted` push arrives while the app is in foreground, it parses the notification body for the partner name and renders the global `MatchCelebrationModal` for the requesting Student (Student A).

## Risk
- Push notification tap-to-navigate behavior is unchanged (handled by `useNotificationTapHandler`, not touched).
- Partner profile screen layout unchanged below the modal.
- Match declined flow not touched.

## Pre-existing failures
`apps/server/src/__tests__/notifications-reschedule-proposed.test.ts` and `notifications-meetup-confirmed.test.ts` have pre-existing TS errors unrelated to this change.
