### PR TITLE
fix(native): full-screen confirmation modal when meetup is confirmed

### DIFF
--- a/.wolf/anatomy.md
+++ b/.wolf/anatomy.md
@@ -1,7 +1,7 @@
 # anatomy.md
 
-> Auto-maintained by OpenWolf. Last scanned: 2026-04-21T07:00:43.226Z
-> Files: 343 tracked | Anatomy hits: 0 | Misses: 0
+> Auto-maintained by OpenWolf. Last scanned: 2026-04-21T07:07:35.923Z
+> Files: 344 tracked | Anatomy hits: 0 | Misses: 0
 
 ## ../../../../tmp/
 
@@ -344,13 +344,13 @@
 
 ## apps/native/app/
 
-- `_layout.tsx` — useNotificationCategories (~2052 tok)
+- `_layout.tsx` — useNotificationCategories (~2438 tok)
 - `edit-profile.tsx` — LANGUAGES — uses useRouter, useQuery, useMutation (~3810 tok)
 - `enrolment.tsx` — OTP_RESEND_COOLDOWN — uses useRouter, useState, useEffect, useForm (~2699 tok)
 - `flag-user.tsx` — DETAIL_MAX (~1486 tok)
 - `index.tsx` — LANGUAGES (~5398 tok)
 - `propose-meetup.tsx` — ProposeMeetupScreen — uses useRouter, useState, useQuery, useMutation (~1591 tok)
-- `respond-meetup.tsx` — RespondMeetupScreen — uses useRouter, useState, useQuery, useMutation (~3171 tok)
+- `respond-meetup.tsx` — RespondMeetupScreen (~3338 tok)
 - `review-profile.tsx` — INTERESTS_LABEL — uses useRouter, useQuery, useMutation (~2394 tok)
 
 ## apps/native/app/(tabs)/
@@ -375,6 +375,7 @@
 - `container.tsx` — AnimatedView (~360 tok)
 - `language-picker-modal.tsx` — ALL_LANGUAGES — renders modal (~694 tok)
 - `match-celebration-modal.tsx` — MatchCelebrationModal — renders modal (~414 tok)
+- `meetup-confirmed-modal.tsx` — MeetupConfirmedModal — renders modal (~478 tok)
 - `onboarding-modal.tsx` — GOLD — renders modal (~7720 tok)
 - `sign-up.tsx` — signUpSchema — renders form — uses useForm (~1680 tok)
 - `theme-toggle.tsx` — StyledIonicons (~309 tok)
@@ -416,7 +417,7 @@
 ## apps/server/src/
 
 - `index.ts` — Wire domain event → push notification handlers on server start (~768 tok)
-- `notifications.ts` — Push notification service — Expo Push Notifications (~8634 tok)
+- `notifications.ts` — Push notification service — Expo Push Notifications (~11036 tok)
 
 ## apps/server/src/__tests__/
 

--- a/.wolf/buglog.json
+++ b/.wolf/buglog.json
@@ -2066,6 +2066,38 @@
       "related_bugs": [],
       "occurrences": 1,
       "last_seen": "2026-04-21T07:00:36.570Z"
+    },
+    {
+      "id": "bug-129",
+      "timestamp": "2026-04-21T07:07:19.976Z",
+      "error_message": "Incorrect value in code",
+      "file": "apps/native/app/_layout.tsx",
+      "root_cause": "Had \"@/components/onboarding-modal\"",
+      "fix": "Changed to \"@/components/meetup-confirmed-modal\"",
+      "tags": [
+        "auto-detected",
+        "wrong-value",
+        "tsx"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-04-21T07:07:19.976Z"
+    },
+    {
+      "id": "bug-130",
+      "timestamp": "2026-04-21T07:07:26.140Z",
+      "error_message": "Null/undefined access in ",
+      "file": "apps/native/app/_layout.tsx",
+      "root_cause": "Property access on potentially null/undefined value",
+      "fix": "Added null safety (optional chaining or null check)",
+      "tags": [
+        "auto-detected",
+        "null-safety",
+        "tsx"
+      ],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-04-21T07:07:26.140Z"
     }
   ]
 }

--- a/.wolf/hooks/_session.json
+++ b/.wolf/hooks/_session.json
@@ -26,13 +26,96 @@
       "count": 2,
       "tokens": 8634,
       "first_read": "2026-04-21T06:57:48.710Z"
+    },
+    "/Users/sander/personal/sip-and-speak/apps/native/app/respond-meetup.tsx": {
+      "count": 1,
+      "tokens": 3171,
+      "first_read": "2026-04-21T07:06:31.433Z"
     }
   },
-  "files_written": [],
-  "edit_counts": {},
-  "anatomy_hits": 5,
+  "files_written": [
+    {
+      "file": "/Users/sander/personal/sip-and-speak/apps/native/components/meetup-confirmed-modal.tsx",
+      "action": "create",
+      "tokens": 478,
+      "at": "2026-04-21T07:06:29.452Z"
+    },
+    {
+      "file": "/Users/sander/personal/sip-and-speak/apps/native/app/respond-meetup.tsx",
+      "action": "edit",
+      "tokens": 137,
+      "at": "2026-04-21T07:06:48.338Z"
+    },
+    {
+      "file": "/Users/sander/personal/sip-and-speak/apps/native/app/respond-meetup.tsx",
+      "action": "edit",
+      "tokens": 110,
+      "at": "2026-04-21T07:06:52.020Z"
+    },
+    {
+      "file": "/Users/sander/personal/sip-and-speak/apps/native/app/respond-meetup.tsx",
+      "action": "edit",
+      "tokens": 197,
+      "at": "2026-04-21T07:06:58.226Z"
+    },
+    {
+      "file": "/Users/sander/personal/sip-and-speak/apps/native/app/respond-meetup.tsx",
+      "action": "edit",
+      "tokens": 181,
+      "at": "2026-04-21T07:07:03.502Z"
+    },
+    {
+      "file": "/Users/sander/personal/sip-and-speak/apps/native/app/respond-meetup.tsx",
+      "action": "edit",
+      "tokens": 127,
+      "at": "2026-04-21T07:07:07.939Z"
+    },
+    {
+      "file": "/Users/sander/personal/sip-and-speak/apps/native/app/respond-meetup.tsx",
+      "action": "edit",
+      "tokens": 20,
+      "at": "2026-04-21T07:07:11.042Z"
+    },
+    {
+      "file": "/Users/sander/personal/sip-and-speak/apps/server/src/notifications.ts",
+      "action": "edit",
+      "tokens": 21,
+      "at": "2026-04-21T07:07:15.560Z"
+    },
+    {
+      "file": "/Users/sander/personal/sip-and-speak/apps/native/app/_layout.tsx",
+      "action": "edit",
+      "tokens": 74,
+      "at": "2026-04-21T07:07:19.975Z"
+    },
+    {
+      "file": "/Users/sander/personal/sip-and-speak/apps/native/app/_layout.tsx",
+      "action": "edit",
+      "tokens": 261,
+      "at": "2026-04-21T07:07:26.139Z"
+    },
+    {
+      "file": "/Users/sander/personal/sip-and-speak/apps/native/app/_layout.tsx",
+      "action": "edit",
+      "tokens": 40,
+      "at": "2026-04-21T07:07:31.861Z"
+    },
+    {
+      "file": "/Users/sander/personal/sip-and-speak/apps/native/app/_layout.tsx",
+      "action": "edit",
+      "tokens": 172,
+      "at": "2026-04-21T07:07:35.934Z"
+    }
+  ],
+  "edit_counts": {
+    "apps/native/components/meetup-confirmed-modal.tsx": 1,
+    "apps/native/app/respond-meetup.tsx": 6,
+    "apps/server/src/notifications.ts": 1,
+    "apps/native/app/_layout.tsx": 4
+  },
+  "anatomy_hits": 6,
   "anatomy_misses": 0,
   "repeated_reads_warned": 1,
   "cerebrum_warnings": 0,
-  "stop_count": 2
+  "stop_count": 3
 }

--- a/.wolf/memory.md
+++ b/.wolf/memory.md
@@ -863,3 +863,17 @@
 | Time | Action | File(s) | Outcome | ~Tokens |
 |------|--------|---------|---------|--------|
 | 09:01 | hotfix #284 — MatchCelebrationModal for in-app match feedback | apps/native/components/match-celebration-modal.tsx, apps/native/app/partner/[id].tsx, apps/native/app/_layout.tsx | PR #294 opened | ~800 |
+| 09:06 | Created apps/native/components/meetup-confirmed-modal.tsx | — | ~478 |
+| 09:06 | Edited apps/native/app/respond-meetup.tsx | added 1 import(s) | ~137 |
+| 09:06 | Edited apps/native/app/respond-meetup.tsx | CSS: venueName, date, time | ~110 |
+| 09:06 | Edited apps/native/app/respond-meetup.tsx | CSS: venueName, date, time | ~197 |
+| 09:07 | Edited apps/native/app/respond-meetup.tsx | 19→21 lines | ~181 |
+| 09:07 | Edited apps/native/app/respond-meetup.tsx | expanded (+10 lines) | ~127 |
+| 09:07 | Edited apps/native/app/respond-meetup.tsx | 5→6 lines | ~20 |
+| 09:07 | Edited apps/server/src/notifications.ts | inline fix | ~21 |
+| 09:07 | Edited apps/native/app/_layout.tsx | added 1 import(s) | ~74 |
+| 09:07 | Edited apps/native/app/_layout.tsx | added optional chaining | ~261 |
+| 09:07 | Edited apps/native/app/_layout.tsx | 1→2 lines | ~40 |
+| 09:07 | Edited apps/native/app/_layout.tsx | expanded (+9 lines) | ~172 |
+| 09:08 | fix #285 — MeetupConfirmedModal for in-app meetup confirmation feedback | apps/native/components/meetup-confirmed-modal.tsx, apps/native/app/respond-meetup.tsx, apps/native/app/_layout.tsx, apps/server/src/notifications.ts | PR #295 opened | ~900 |
+| 09:08 | Session end: 12 writes across 4 files (meetup-confirmed-modal.tsx, respond-meetup.tsx, notifications.ts, _layout.tsx) | 6 reads | ~19794 tok |

--- a/.wolf/token-ledger.json
+++ b/.wolf/token-ledger.json
@@ -2,14 +2,14 @@
   "version": 1,
   "created_at": "2026-04-10T10:02:44.507Z",
   "lifetime": {
-    "total_tokens_estimated": 1153936,
-    "total_reads": 607,
-    "total_writes": 816,
+    "total_tokens_estimated": 1173730,
+    "total_reads": 613,
+    "total_writes": 828,
     "total_sessions": 50,
-    "anatomy_hits": 504,
+    "anatomy_hits": 510,
     "anatomy_misses": 103,
-    "repeated_reads_blocked": 170,
-    "estimated_savings_vs_bare_cli": 679879
+    "repeated_reads_blocked": 171,
+    "estimated_savings_vs_bare_cli": 689713
   },
   "sessions": [
     {
@@ -8983,6 +8983,119 @@
         "writes_count": 0,
         "repeated_reads_blocked": 1,
         "anatomy_lookups": 5
+      }
+    },
+    {
+      "id": "session-2026-04-21-0855",
+      "started": "2026-04-21T06:55:45.833Z",
+      "ended": "2026-04-21T07:08:48.363Z",
+      "reads": [
+        {
+          "file": "/Users/sander/personal/sip-and-speak/apps/native/__tests__/notification-match-accepted.test.tsx",
+          "tokens_estimated": 1085,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/apps/native/hooks/use-notification-tap-handler.ts",
+          "tokens_estimated": 561,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/apps/native/app/partner/[id].tsx",
+          "tokens_estimated": 2944,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/apps/native/app/_layout.tsx",
+          "tokens_estimated": 1581,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/apps/server/src/notifications.ts",
+          "tokens_estimated": 8634,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/apps/native/app/respond-meetup.tsx",
+          "tokens_estimated": 3171,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        }
+      ],
+      "writes": [
+        {
+          "file": "/Users/sander/personal/sip-and-speak/apps/native/components/meetup-confirmed-modal.tsx",
+          "tokens_estimated": 478,
+          "action": "create"
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/apps/native/app/respond-meetup.tsx",
+          "tokens_estimated": 137,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/apps/native/app/respond-meetup.tsx",
+          "tokens_estimated": 110,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/apps/native/app/respond-meetup.tsx",
+          "tokens_estimated": 197,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/apps/native/app/respond-meetup.tsx",
+          "tokens_estimated": 181,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/apps/native/app/respond-meetup.tsx",
+          "tokens_estimated": 127,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/apps/native/app/respond-meetup.tsx",
+          "tokens_estimated": 20,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/apps/server/src/notifications.ts",
+          "tokens_estimated": 21,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/apps/native/app/_layout.tsx",
+          "tokens_estimated": 74,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/apps/native/app/_layout.tsx",
+          "tokens_estimated": 261,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/apps/native/app/_layout.tsx",
+          "tokens_estimated": 40,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/sander/personal/sip-and-speak/apps/native/app/_layout.tsx",
+          "tokens_estimated": 172,
+          "action": "edit"
+        }
+      ],
+      "totals": {
+        "input_tokens_estimated": 17976,
+        "output_tokens_estimated": 1818,
+        "reads_count": 6,
+        "writes_count": 12,
+        "repeated_reads_blocked": 1,
+        "anatomy_lookups": 6
       }
     }
   ],

--- a/apps/native/app/_layout.tsx
+++ b/apps/native/app/_layout.tsx
@@ -30,6 +30,7 @@ import { AppThemeProvider } from "@/contexts/app-theme-context";
 import { queryClient, trpc } from "@/utils/trpc";
 import { useNotificationTapHandler } from "@/hooks/use-notification-tap-handler";
 import { MatchCelebrationModal } from "@/components/match-celebration-modal";
+import { MeetupConfirmedModal } from "@/components/meetup-confirmed-modal";
 import { OnboardingModal } from "@/components/onboarding-modal"; // edge-case: complete but no identity
 
 SplashScreen.preventAutoHideAsync();
@@ -85,6 +86,31 @@ function useForegroundMatchAlert(): [MatchAlert | null, () => void] {
       const body = notification.request.content.body ?? "";
       const partnerName = body.replace(" accepted your request", "") || "Your match";
       setAlert({ partnerName, partnerId });
+    });
+    return () => subscription.remove();
+  }, []);
+
+  return [alert, () => setAlert(null)];
+}
+
+interface MeetupAlert {
+  venueName: string;
+  date: string;
+  time: string;
+}
+
+function useForegroundMeetupAlert(): [MeetupAlert | null, () => void] {
+  const [alert, setAlert] = useState<MeetupAlert | null>(null);
+
+  useEffect(() => {
+    const subscription = Notifications.addNotificationReceivedListener((notification) => {
+      const data = notification.request.content.data as Record<string, unknown> | undefined;
+      if (data?.type !== "meetup_confirmed") return;
+      const venueName = typeof data.venueName === "string" ? data.venueName : null;
+      const date = typeof data.date === "string" ? data.date : null;
+      const time = typeof data.time === "string" ? data.time : null;
+      if (!venueName || !date || !time) return;
+      setAlert({ venueName, date, time });
     });
     return () => subscription.remove();
   }, []);
@@ -182,6 +208,7 @@ export default function Layout() {
   }, [fontsLoaded]);
 
   const [matchAlert, dismissMatchAlert] = useForegroundMatchAlert();
+  const [meetupAlert, dismissMeetupAlert] = useForegroundMeetupAlert();
 
   if (!fontsLoaded) {
     return null;
@@ -201,6 +228,15 @@ export default function Layout() {
                   partnerName={matchAlert.partnerName}
                   partnerId={matchAlert.partnerId}
                   onDismiss={dismissMatchAlert}
+                />
+              )}
+              {meetupAlert && (
+                <MeetupConfirmedModal
+                  visible
+                  venueName={meetupAlert.venueName}
+                  date={meetupAlert.date}
+                  time={meetupAlert.time}
+                  onDismiss={dismissMeetupAlert}
                 />
               )}
               <StackLayout />

--- a/apps/native/app/respond-meetup.tsx
+++ b/apps/native/app/respond-meetup.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { Alert, ScrollView, Text, TextInput, TouchableOpacity, View } from "react-native";
 
 import { Container } from "@/components/container";
+import { MeetupConfirmedModal } from "@/components/meetup-confirmed-modal";
 import { trpc, queryClient } from "@/utils/trpc";
 
 export default function RespondMeetupScreen() {
@@ -17,6 +18,7 @@ export default function RespondMeetupScreen() {
   const [date, setDate] = useState("");
   const [time, setTime] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const [confirmed, setConfirmed] = useState<{ venueName: string; date: string; time: string } | null>(null);
 
   const proposalQuery = useQuery(trpc.meetup.getPendingIncoming.queryOptions());
   const venuesQuery = useQuery(trpc.venue.listForPicker.queryOptions());
@@ -31,18 +33,21 @@ export default function RespondMeetupScreen() {
   // Prefer the deep-linked meetupId, fall back to incoming proposal from query
   const activeMeetupId = meetupIdParam ?? proposal?.meetupId;
 
-  function invalidateAndGoBack() {
+  function invalidateQueries() {
     void queryClient.invalidateQueries(trpc.meetup.getPendingIncoming.queryOptions());
     void queryClient.invalidateQueries(trpc.meetup.list.queryOptions({ status: "pending" }));
     void queryClient.invalidateQueries(trpc.meetup.pendingCount.queryOptions());
-    router.back();
   }
 
   const acceptMutation = useMutation(
     trpc.meetup.acceptProposal.mutationOptions({
       onSuccess: () => {
-        Alert.alert("Meetup confirmed!", "Your meetup has been confirmed.");
-        invalidateAndGoBack();
+        invalidateQueries();
+        if (proposal) {
+          setConfirmed({ venueName: proposal.venue.name, date: proposal.date, time: proposal.time });
+        } else {
+          router.back();
+        }
       },
       onError: (err) => setError(err.message),
     }),
@@ -52,7 +57,8 @@ export default function RespondMeetupScreen() {
     trpc.meetup.counterPropose.mutationOptions({
       onSuccess: () => {
         Alert.alert("Counter-proposal sent!", "Your counter-proposal has been sent.");
-        invalidateAndGoBack();
+        invalidateQueries();
+        router.back();
       },
       onError: (err) => setError(err.message),
     }),
@@ -62,7 +68,8 @@ export default function RespondMeetupScreen() {
     trpc.meetup.declineProposal.mutationOptions({
       onSuccess: () => {
         Alert.alert("Proposal declined", "The proposal has been declined.");
-        invalidateAndGoBack();
+        invalidateQueries();
+        router.back();
       },
       onError: (err) => setError(err.message),
     }),
@@ -221,6 +228,16 @@ export default function RespondMeetupScreen() {
   }
 
   return (
+    <>
+      {confirmed && (
+        <MeetupConfirmedModal
+          visible
+          venueName={confirmed.venueName}
+          date={confirmed.date}
+          time={confirmed.time}
+          onDismiss={() => { setConfirmed(null); router.back(); }}
+        />
+      )}
     <Container>
       <ScrollView contentContainerStyle={{ padding: 16 }}>
         <Text className="text-foreground text-2xl font-bold mb-1">Meetup proposal</Text>
@@ -300,5 +317,6 @@ export default function RespondMeetupScreen() {
         </View>
       </ScrollView>
     </Container>
+    </>
   );
 }

--- a/apps/native/components/meetup-confirmed-modal.tsx
+++ b/apps/native/components/meetup-confirmed-modal.tsx
@@ -1,0 +1,43 @@
+import { Button } from "heroui-native";
+import { Modal, Text, View } from "react-native";
+
+interface Props {
+  visible: boolean;
+  venueName: string;
+  date: string;
+  time: string;
+  onDismiss: () => void;
+}
+
+export function MeetupConfirmedModal({ visible, venueName, date, time, onDismiss }: Props) {
+  return (
+    <Modal visible={visible} animationType="slide" presentationStyle="fullScreen">
+      <View className="flex-1 bg-background items-center justify-center px-8 gap-6">
+        <Text className="text-6xl">📅</Text>
+        <Text className="text-foreground text-3xl font-bold text-center">
+          Meetup confirmed!
+        </Text>
+        <View className="bg-muted rounded-2xl px-6 py-5 w-full gap-2">
+          <View className="flex-row items-center gap-2">
+            <Text className="text-muted-foreground text-sm w-16">Where</Text>
+            <Text testID="confirmed-venue" className="text-foreground font-semibold flex-1">
+              {venueName}
+            </Text>
+          </View>
+          <View className="flex-row items-center gap-2">
+            <Text className="text-muted-foreground text-sm w-16">When</Text>
+            <Text testID="confirmed-datetime" className="text-foreground font-semibold flex-1">
+              {date} at {time}
+            </Text>
+          </View>
+        </View>
+        <Text className="text-muted-foreground text-center">
+          You'll both receive a reminder closer to the time.
+        </Text>
+        <Button testID="meetup-confirmed-dismiss-btn" variant="primary" className="w-full" onPress={onDismiss}>
+          <Button.Label>Got it</Button.Label>
+        </Button>
+      </View>
+    </Modal>
+  );
+}

--- a/apps/server/src/notifications.ts
+++ b/apps/server/src/notifications.ts
@@ -275,7 +275,7 @@ async function handleMeetupConfirmed(event: MeetupConfirmedEvent): Promise<void>
     to: token,
     title: "Meetup confirmed! 🎉",
     body: `${venueName} · ${date} at ${time}`,
-    data: { meetupId, type: "meetup_confirmed" },
+    data: { meetupId, type: "meetup_confirmed", venueName, date, time },
   }));
 
   try {


### PR DESCRIPTION
Fixes #285

## Impact
Neither party saw any in-app visual feedback when a Meetup was confirmed. Push notification fired correctly, but the app showed only a bare `Alert.alert` for the acceptor and nothing for the proposer.

## Root cause
- `respond-meetup.tsx` used `Alert.alert` (native OS dialog) instead of a proper in-app modal.
- No foreground push listener handled `meetup_confirmed` for the proposing Student.
- The `meetup_confirmed` notification data payload didn't include venue/date/time, making it impossible for a foreground listener to render details without an extra fetch.

## Fix
- Added `MeetupConfirmedModal` component: full-screen slide-up modal showing venue, date, time, and a "Got it" dismiss button.
- In `respond-meetup.tsx`: `acceptProposal.onSuccess` now captures the venue/date/time from the already-loaded proposal and shows the modal. Navigation back happens on modal dismiss.
- In `notifications.ts`: added `venueName`, `date`, `time` to the `meetup_confirmed` push data payload.
- In `_layout.tsx`: added `useForegroundMeetupAlert` hook using `Notifications.addNotificationReceivedListener`; renders a global `MeetupConfirmedModal` for the proposing Student when the notification arrives in-app.

## Risk
- `Alert.alert` for counter-propose and decline flows is unchanged.
- `MeetupConfirmed` push notification delivery flow is unchanged (only the `data` payload is extended, not the `title`/`body`).
- Reschedule and cancellation flows not touched.

## Pre-existing failures
`apps/server/src/__tests__/notifications-reschedule-proposed.test.ts` and `notifications-meetup-confirmed.test.ts` have pre-existing TS errors unrelated to this change.
