### PR TITLE
fix(native): show language validation warnings on profile tab

### DIFF
--- a/apps/native/app/(tabs)/profile.tsx
+++ b/apps/native/app/(tabs)/profile.tsx
@@ -289,6 +289,14 @@ export default function ProfileScreen() {
           {/* Spoken languages */}
           <View>
             <SectionLabel>Languages I speak</SectionLabel>
+            {spokenLanguages.length === 0 && (
+              <Text
+                className="font-manrope text-[13px] mb-3"
+                style={{ color: "#C0876A" }}
+              >
+                Add at least one spoken language to activate matching
+              </Text>
+            )}
             <View className="gap-3">
               {spokenLanguages.map((sl) => (
                 <View
@@ -374,6 +382,14 @@ export default function ProfileScreen() {
           {/* Learning languages */}
           <View>
             <SectionLabel>Languages I'm learning</SectionLabel>
+            {learningLanguages.length === 0 && (
+              <Text
+                className="font-manrope text-[13px] mb-3"
+                style={{ color: "#C0876A" }}
+              >
+                Add at least one language you are learning to activate matching
+              </Text>
+            )}
             <View className="gap-3">
               {learningLanguages.map((ll) => (
                 <View


### PR DESCRIPTION
## Summary

- Profile tab (`apps/native/app/(tabs)/profile.tsx`) silently rendered empty Spoken / Learning language sections with no hint that matching requires at least one of each.
- Added destructive-tone inline warning text under each empty section, matching the existing Interests `< MIN_INTERESTS` warning pattern.

## Context

Issue #283 originally pointed at `edit-profile.tsx` and `review-profile.tsx`, which were removed in the onboarding redesign (commit 435afd2). The onboarding flow (`app/index.tsx`, `components/onboarding-modal.tsx`) already gates the Next button with `disabled={langs.length === 0}` and renders a `validationError`, so the onboarding path is already covered. This PR closes the remaining gap on the profile-edit tab, where edits persist live (no submit button to gate) but the user needed a visible signal that their profile is not match-eligible.

## Test plan

- [ ] Open Profile tab with zero spoken languages → warning "Add at least one spoken language to activate matching" visible.
- [ ] Open Profile tab with zero learning languages → warning "Add at least one language you are learning to activate matching" visible.
- [ ] Add a language in either section → corresponding warning disappears.
- [ ] Verify existing Interests warning still renders as before.

Closes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)