### PR TITLE
refactor(notifications): Step C — enrich events with value objects

### DIFF
--- a/apps/server/src/__tests__/notification-builders.test.ts
+++ b/apps/server/src/__tests__/notification-builders.test.ts
@@ -9,10 +9,15 @@ import {
 
 describe("buildMatchRequestSentRecipes", () => {
   it("returns one recipe targeting the receiver", () => {
-    const recipes = buildMatchRequestSentRecipes(
-      { matchRequestId: "mr-1", requesterId: "u1", receiverId: "u2", sentAt: new Date() },
-      { requesterName: "Alice", offeredLanguage: "Dutch", targetedLanguage: "English" },
-    );
+    const recipes = buildMatchRequestSentRecipes({
+      matchRequestId: "mr-1",
+      requesterId: "u1",
+      requesterName: "Alice",
+      offeredLanguage: "Dutch",
+      targetedLanguage: "English",
+      receiverId: "u2",
+      sentAt: new Date(),
+    });
     expect(recipes).toHaveLength(1);
     expect(recipes[0]?.recipientId).toBe("u2");
     expect(recipes[0]?.title).toBe("New match request");
@@ -22,10 +27,13 @@ describe("buildMatchRequestSentRecipes", () => {
 
 describe("buildMatchRequestAcceptedRecipes", () => {
   it("returns one recipe targeting the requester with category", () => {
-    const recipes = buildMatchRequestAcceptedRecipes(
-      { matchRequestId: "mr-1", requesterId: "u1", receiverId: "u2", acceptedAt: new Date() },
-      { receiverName: "Bob" },
-    );
+    const recipes = buildMatchRequestAcceptedRecipes({
+      matchRequestId: "mr-1",
+      requesterId: "u1",
+      receiverId: "u2",
+      receiverName: "Bob",
+      acceptedAt: new Date(),
+    });
     expect(recipes).toHaveLength(1);
     expect(recipes[0]?.recipientId).toBe("u1");
     expect(recipes[0]?.body).toBe("Bob accepted your request");

--- a/apps/server/src/__tests__/notifications-conversation-opened.test.ts
+++ b/apps/server/src/__tests__/notifications-conversation-opened.test.ts
@@ -97,14 +97,18 @@ function makeConversationOpenedEvent(
     conversationId: string;
     meetupId: string;
     studentAId: string;
+    studentAName: string;
     studentBId: string;
+    studentBName: string;
   }> = {},
 ) {
   return {
     conversationId: overrides.conversationId ?? "conv-1",
     meetupId: overrides.meetupId ?? "meetup-1",
     studentAId: overrides.studentAId ?? STUDENT_A_ID,
+    studentAName: overrides.studentAName ?? "Alice",
     studentBId: overrides.studentBId ?? STUDENT_B_ID,
+    studentBName: overrides.studentBName ?? "Bob",
     openedAt: new Date(),
   };
 }

--- a/apps/server/src/__tests__/notifications-match-accepted.test.ts
+++ b/apps/server/src/__tests__/notifications-match-accepted.test.ts
@@ -90,12 +90,13 @@ import { handleMatchRequestAccepted } from "../notifications";
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 function makeAcceptedEvent(
-  overrides: Partial<{ requesterId: string; receiverId: string; matchRequestId: string }> = {},
+  overrides: Partial<{ requesterId: string; receiverId: string; matchRequestId: string; receiverName: string }> = {},
 ) {
   return {
     matchRequestId: overrides.matchRequestId ?? "req-123",
     requesterId: overrides.requesterId ?? "requester-id",
     receiverId: overrides.receiverId ?? "receiver-id",
+    receiverName: overrides.receiverName ?? "Alice",
     acceptedAt: new Date(),
   };
 }

--- a/apps/server/src/__tests__/notifications-messaging-nudge.test.ts
+++ b/apps/server/src/__tests__/notifications-messaging-nudge.test.ts
@@ -97,12 +97,14 @@ function makeNudgeEvent(
   overrides: Partial<{
     meetupId: string;
     acceptingStudentId: string;
+    acceptingStudentName: string;
     pendingStudentId: string;
   }> = {},
 ) {
   return {
     meetupId: overrides.meetupId ?? "meetup-1",
     acceptingStudentId: overrides.acceptingStudentId ?? ACCEPTING_STUDENT_ID,
+    acceptingStudentName: overrides.acceptingStudentName ?? "Alice",
     pendingStudentId: overrides.pendingStudentId ?? PENDING_STUDENT_ID,
   };
 }

--- a/apps/server/src/__tests__/notifications-messaging-opt-in.test.ts
+++ b/apps/server/src/__tests__/notifications-messaging-opt-in.test.ts
@@ -92,12 +92,14 @@ import { handleMessagingOptInPrompted } from "../notifications";
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 function makeOptInEvent(
-  overrides: Partial<{ meetupId: string; studentAId: string; studentBId: string }> = {},
+  overrides: Partial<{ meetupId: string; studentAId: string; studentAName: string; studentBId: string; studentBName: string }> = {},
 ) {
   return {
     meetupId: overrides.meetupId ?? "meetup-1",
     studentAId: overrides.studentAId ?? STUDENT_A_ID,
+    studentAName: overrides.studentAName ?? "Alice",
     studentBId: overrides.studentBId ?? STUDENT_B_ID,
+    studentBName: overrides.studentBName ?? "Bob",
     promptedAt: new Date(),
   };
 }

--- a/apps/server/src/notification-builders.ts
+++ b/apps/server/src/notification-builders.ts
@@ -25,29 +25,23 @@ import type {
 import { buildMatchRequestNotificationBody } from "@sip-and-speak/api/routers/matching-utils";
 import type { Recipe } from "./notification-recipe";
 
-export function buildMatchRequestSentRecipes(
-  event: MatchRequestSentEvent,
-  ctx: { requesterName: string; offeredLanguage: string | null; targetedLanguage: string | null },
-): Recipe[] {
+export function buildMatchRequestSentRecipes(event: MatchRequestSentEvent): Recipe[] {
   return [
     {
       recipientId: event.receiverId,
       title: "New match request",
-      body: buildMatchRequestNotificationBody(ctx.requesterName, ctx.offeredLanguage, ctx.targetedLanguage),
+      body: buildMatchRequestNotificationBody(event.requesterName, event.offeredLanguage, event.targetedLanguage),
       data: { matchRequestId: event.matchRequestId, requesterId: event.requesterId },
     },
   ];
 }
 
-export function buildMatchRequestAcceptedRecipes(
-  event: MatchRequestAcceptedEvent,
-  ctx: { receiverName: string },
-): Recipe[] {
+export function buildMatchRequestAcceptedRecipes(event: MatchRequestAcceptedEvent): Recipe[] {
   return [
     {
       recipientId: event.requesterId,
       title: "Your match request was accepted!",
-      body: `${ctx.receiverName} accepted your request`,
+      body: `${event.receiverName} accepted your request`,
       data: { matchRequestId: event.matchRequestId, matchedWithUserId: event.receiverId, type: "match_accepted" },
       category: "match_accepted",
     },
@@ -163,45 +157,36 @@ export function buildMeetupNotAttendedRecipes(event: MeetupNotAttendedEvent): Re
   ];
 }
 
-export function buildMessagingOptInPromptedRecipes(
-  event: MessagingOptInPromptedEvent,
-  ctx: { studentAName: string; studentBName: string },
-): Recipe[] {
+export function buildMessagingOptInPromptedRecipes(event: MessagingOptInPromptedEvent): Recipe[] {
   const data = { meetupId: event.meetupId, type: "messaging_opt_in", deepLink: `/messaging/opt-in/${event.meetupId}` };
   return [
     {
       recipientId: event.studentAId,
       title: "Want to keep in touch?",
-      body: `${ctx.studentBName} completed a S&S moment with you — would you like to message them?`,
+      body: `${event.studentBName} completed a S&S moment with you — would you like to message them?`,
       data,
     },
     {
       recipientId: event.studentBId,
       title: "Want to keep in touch?",
-      body: `${ctx.studentAName} completed a S&S moment with you — would you like to message them?`,
+      body: `${event.studentAName} completed a S&S moment with you — would you like to message them?`,
       data,
     },
   ];
 }
 
-export function buildMessagingNudgeRecipes(
-  event: MessagingNudgeNeededEvent,
-  ctx: { acceptingStudentName: string },
-): Recipe[] {
+export function buildMessagingNudgeRecipes(event: MessagingNudgeNeededEvent): Recipe[] {
   return [
     {
       recipientId: event.pendingStudentId,
       title: "Your match wants to message you!",
-      body: `${ctx.acceptingStudentName} accepted messaging — let them know if you're in!`,
+      body: `${event.acceptingStudentName} accepted messaging — let them know if you're in!`,
       data: { meetupId: event.meetupId, type: "messaging_nudge", deepLink: `/messaging/opt-in/${event.meetupId}` },
     },
   ];
 }
 
-export function buildConversationOpenedRecipes(
-  event: ConversationOpenedEvent,
-  ctx: { studentAName: string; studentBName: string },
-): Recipe[] {
+export function buildConversationOpenedRecipes(event: ConversationOpenedEvent): Recipe[] {
   const data = {
     conversationId: event.conversationId,
     meetupId: event.meetupId,
@@ -212,13 +197,13 @@ export function buildConversationOpenedRecipes(
     {
       recipientId: event.studentAId,
       title: "Your messaging channel is open!",
-      body: `${ctx.studentBName} also accepted — you can now message each other.`,
+      body: `${event.studentBName} also accepted — you can now message each other.`,
       data,
     },
     {
       recipientId: event.studentBId,
       title: "Your messaging channel is open!",
-      body: `${ctx.studentAName} also accepted — you can now message each other.`,
+      body: `${event.studentAName} also accepted — you can now message each other.`,
       data,
     },
   ];

--- a/apps/server/src/notifications.ts
+++ b/apps/server/src/notifications.ts
@@ -4,8 +4,7 @@
  */
 import { and, eq, inArray, or } from "drizzle-orm";
 import { db } from "@sip-and-speak/db";
-import { userLanguage, conversationPresence, meetup, conversation } from "@sip-and-speak/db/schema/sip-and-speak";
-import { user } from "@sip-and-speak/db/schema/auth";
+import { conversationPresence, meetup, conversation } from "@sip-and-speak/db/schema/sip-and-speak";
 import {
   domainEvents,
   type MatchRequestSentEvent,
@@ -59,22 +58,11 @@ import {
 import { dispatch } from "./notification-recipe";
 
 async function handleMatchRequestSent(event: MatchRequestSentEvent): Promise<void> {
-  const [requesterResult, requesterLanguages] = await Promise.all([
-    db.select({ name: user.name }).from(user).where(eq(user.id, event.requesterId)).limit(1),
-    db.select({ language: userLanguage.language, type: userLanguage.type }).from(userLanguage).where(eq(userLanguage.userId, event.requesterId)),
-  ]);
-  const requesterName = requesterResult[0]?.name ?? "Someone";
-  const offeredLanguage = requesterLanguages.find((l) => l.type === "spoken")?.language ?? null;
-  const targetedLanguage = requesterLanguages.find((l) => l.type === "learning")?.language ?? null;
-  await dispatch(buildMatchRequestSentRecipes(event, { requesterName, offeredLanguage, targetedLanguage }));
+  await dispatch(buildMatchRequestSentRecipes(event));
 }
 
 export async function handleMatchRequestAccepted(event: MatchRequestAcceptedEvent): Promise<void> {
-  const [receiverResult] = await Promise.all([
-    db.select({ name: user.name }).from(user).where(eq(user.id, event.receiverId)).limit(1),
-  ]);
-  const receiverName = receiverResult[0]?.name ?? "Someone";
-  await dispatch(buildMatchRequestAcceptedRecipes(event, { receiverName }));
+  await dispatch(buildMatchRequestAcceptedRecipes(event));
 }
 
 export async function handleMatchRequestDeclined(event: MatchRequestDeclinedEvent): Promise<void> {
@@ -122,31 +110,15 @@ async function handleMeetupNotAttended(event: MeetupNotAttendedEvent): Promise<v
 }
 
 export async function handleMessagingOptInPrompted(event: MessagingOptInPromptedEvent): Promise<void> {
-  const [studentAResult, studentBResult] = await Promise.all([
-    db.select({ name: user.name }).from(user).where(eq(user.id, event.studentAId)).limit(1),
-    db.select({ name: user.name }).from(user).where(eq(user.id, event.studentBId)).limit(1),
-  ]);
-  const studentAName = studentAResult[0]?.name ?? "Your match";
-  const studentBName = studentBResult[0]?.name ?? "Your match";
-  await dispatch(buildMessagingOptInPromptedRecipes(event, { studentAName, studentBName }));
+  await dispatch(buildMessagingOptInPromptedRecipes(event));
 }
 
 export async function handleMessagingNudge(event: MessagingNudgeNeededEvent): Promise<void> {
-  const [acceptingResult] = await Promise.all([
-    db.select({ name: user.name }).from(user).where(eq(user.id, event.acceptingStudentId)).limit(1),
-  ]);
-  const acceptingStudentName = acceptingResult[0]?.name ?? "Your match";
-  await dispatch(buildMessagingNudgeRecipes(event, { acceptingStudentName }));
+  await dispatch(buildMessagingNudgeRecipes(event));
 }
 
 export async function handleConversationOpened(event: ConversationOpenedEvent): Promise<void> {
-  const [studentAResult, studentBResult] = await Promise.all([
-    db.select({ name: user.name }).from(user).where(eq(user.id, event.studentAId)).limit(1),
-    db.select({ name: user.name }).from(user).where(eq(user.id, event.studentBId)).limit(1),
-  ]);
-  const studentAName = studentAResult[0]?.name ?? "Your match";
-  const studentBName = studentBResult[0]?.name ?? "Your match";
-  await dispatch(buildConversationOpenedRecipes(event, { studentAName, studentBName }));
+  await dispatch(buildConversationOpenedRecipes(event));
 }
 
 export async function handleMessagingDeclineOutcome(event: MessagingDeclineOutcomeEvent): Promise<void> {

--- a/packages/api/src/domain-events.ts
+++ b/packages/api/src/domain-events.ts
@@ -18,6 +18,9 @@ export interface ProfileCompletedEvent {
 export interface MatchRequestSentEvent {
   matchRequestId: string;
   requesterId: string;
+  requesterName: string;
+  offeredLanguage: string | null;
+  targetedLanguage: string | null;
   receiverId: string;
   sentAt: Date;
 }
@@ -26,6 +29,7 @@ export interface MatchRequestAcceptedEvent {
   matchRequestId: string;
   requesterId: string;
   receiverId: string;
+  receiverName: string;
   acceptedAt: Date;
 }
 
@@ -140,7 +144,9 @@ export interface MeetupNotAttendedEvent {
 export interface MessagingOptInPromptedEvent {
   meetupId: string;
   studentAId: string;
+  studentAName: string;
   studentBId: string;
+  studentBName: string;
   promptedAt: Date;
 }
 
@@ -162,7 +168,9 @@ export interface ConversationOpenedEvent {
   conversationId: string;
   meetupId: string;
   studentAId: string;
+  studentAName: string;
   studentBId: string;
+  studentBName: string;
   openedAt: Date;
 }
 
@@ -176,6 +184,7 @@ export interface MessagingNudgeNeededEvent {
   meetupId: string;
   /** The student who accepted and triggered the nudge */
   acceptingStudentId: string;
+  acceptingStudentName: string;
   /** The student who has not yet responded and should receive the nudge */
   pendingStudentId: string;
 }

--- a/packages/api/src/routers/matching.ts
+++ b/packages/api/src/routers/matching.ts
@@ -419,9 +419,20 @@ export const matchingRouter = router({
         receiverId: input.receiverId,
       });
 
+      const [requesterRow, requesterLanguages] = await Promise.all([
+        db.select({ name: user.name }).from(user).where(eq(user.id, requesterId)).limit(1),
+        db.select({ language: userLanguage.language, type: userLanguage.type }).from(userLanguage).where(eq(userLanguage.userId, requesterId)),
+      ]);
+      const requesterName = requesterRow[0]?.name ?? "Someone";
+      const offeredLanguage = requesterLanguages.find((l) => l.type === "spoken")?.language ?? null;
+      const targetedLanguage = requesterLanguages.find((l) => l.type === "learning")?.language ?? null;
+
       domainEvents.emit("MatchRequestSent", {
         matchRequestId: created.id,
         requesterId,
+        requesterName,
+        offeredLanguage,
+        targetedLanguage,
         receiverId: input.receiverId,
         sentAt: new Date(),
       });
@@ -467,10 +478,14 @@ export const matchingRouter = router({
         receiverId,
       });
 
+      const [receiverRow] = await db.select({ name: user.name }).from(user).where(eq(user.id, receiverId)).limit(1);
+      const receiverName = receiverRow?.name ?? "Someone";
+
       domainEvents.emit("MatchRequestAccepted", {
         matchRequestId: input.matchRequestId,
         requesterId: request.requesterId,
         receiverId,
+        receiverName,
         acceptedAt: new Date(),
       });
 

--- a/packages/api/src/routers/meetup.ts
+++ b/packages/api/src/routers/meetup.ts
@@ -1098,10 +1098,16 @@ export const meetupRouter = router({
             });
 
             // #138 — Prompt both Students to opt in to messaging after a completed meetup
+            const [studentARow, studentBRow] = await Promise.all([
+              db.select({ name: user.name }).from(user).where(eq(user.id, existing.proposerId)).limit(1),
+              db.select({ name: user.name }).from(user).where(eq(user.id, existing.receiverId)).limit(1),
+            ]);
             domainEvents.emit("MessagingOptInPrompted", {
               meetupId: input.meetupId,
               studentAId: existing.proposerId,
+              studentAName: studentARow[0]?.name ?? "Your match",
               studentBId: existing.receiverId,
+              studentBName: studentBRow[0]?.name ?? "Your match",
               promptedAt: new Date(),
             });
           }

--- a/packages/api/src/routers/messaging.ts
+++ b/packages/api/src/routers/messaging.ts
@@ -123,9 +123,11 @@ export const messagingRouter = router({
             .returning({ id: messagingOptIn.id });
 
           if (updated.length > 0) {
+            const [acceptingRow] = await db.select({ name: user.name }).from(user).where(eq(user.id, studentId)).limit(1);
             domainEvents.emit("MessagingNudgeNeeded", {
               meetupId: input.meetupId,
               acceptingStudentId: studentId,
+              acceptingStudentName: acceptingRow?.name ?? "Your match",
               pendingStudentId: partnerId,
             });
           }
@@ -153,11 +155,17 @@ export const messagingRouter = router({
             console.log(
               `[messaging] conversation opened conversationId=${newConversation.id} meetupId=${input.meetupId}`,
             );
+            const [studentARow, studentBRow] = await Promise.all([
+              db.select({ name: user.name }).from(user).where(eq(user.id, studentId)).limit(1),
+              db.select({ name: user.name }).from(user).where(eq(user.id, partnerId)).limit(1),
+            ]);
             domainEvents.emit("ConversationOpened", {
               conversationId: newConversation.id,
               meetupId: input.meetupId,
               studentAId: studentId,
+              studentAName: studentARow[0]?.name ?? "Your match",
               studentBId: partnerId,
+              studentBName: studentBRow[0]?.name ?? "Your match",
               openedAt: newConversation.createdAt,
             });
           }


### PR DESCRIPTION
## Summary

Step C of the notification dispatcher deepening. Builds on Steps A (#297) and B (#298).

**Surprise**: the typed event bus was already in place (\`TypedEventEmitter\` in \`packages/api/src/domain-events.ts\`). Step C therefore reduces to **event enrichment only** — no bus wrapping work needed.

### Enriched event payloads

Producer puts in the event what producer already loaded (or fetches with one targeted query right before emit). Consumer never re-queries.

- \`MatchRequestSentEvent\`: + \`requesterName\`, \`offeredLanguage\`, \`targetedLanguage\`
- \`MatchRequestAcceptedEvent\`: + \`receiverName\`
- \`MessagingOptInPromptedEvent\`: + \`studentAName\`, \`studentBName\`
- \`MessagingNudgeNeededEvent\`: + \`acceptingStudentName\`
- \`ConversationOpenedEvent\`: + \`studentAName\`, \`studentBName\`

### Knock-on simplifications

- Builders drop their \`ctx\` parameter — read directly from event.
- Handlers in \`notifications.ts\` collapse to a single \`dispatch(builder(event))\` call. The fetch-context blocks die.
- \`notifications.ts\` no longer needs \`user\` or \`userLanguage\` imports.
- 4 test files have their event-factory functions updated to include the new fields.

## Test plan

- [x] \`bun test\` — 52 pass / 60 fail. Identical to post-Step-B baseline.
- [x] \`bunx tsc -b\` — 10 errors, identical to baseline (pre-existing chat.ts + 2 test files).
- [ ] Smoke test on dev: send a real match request, accept, confirm push fires with enriched data.

## What's next

- D. Move \`notification-*.ts\` to a new \`packages/notifications\` workspace package. Apps/server gains a single import.