### PR TITLE
fix(notifications): wire apps/server to @sip-and-speak/notifications (Step D follow-up)

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -15,6 +15,7 @@
     "@sip-and-speak/auth": "workspace:*",
     "@sip-and-speak/db": "workspace:*",
     "@sip-and-speak/env": "workspace:*",
+    "@sip-and-speak/notifications": "workspace:*",
     "@trpc/server": "catalog:",
     "better-auth": "catalog:",
     "dotenv": "catalog:",

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -14,7 +14,7 @@ import { Hono } from "hono";
 import type { Context } from "hono";
 import { cors } from "hono/cors";
 import { logger } from "hono/logger";
-import { registerNotificationHandlers } from "./notifications";
+import { registerNotificationHandlers } from "@sip-and-speak/notifications";
 
 // Wire domain event → push notification handlers on server start
 registerNotificationHandlers();

--- a/bun.lock
+++ b/bun.lock
@@ -93,6 +93,7 @@
         "@sip-and-speak/auth": "workspace:*",
         "@sip-and-speak/db": "workspace:*",
         "@sip-and-speak/env": "workspace:*",
+        "@sip-and-speak/notifications": "workspace:*",
         "@trpc/server": "catalog:",
         "better-auth": "catalog:",
         "dotenv": "catalog:",
@@ -217,6 +218,20 @@
         "@t3-oss/env-core": "^0.13.1",
         "dotenv": "catalog:",
         "zod": "catalog:",
+      },
+      "devDependencies": {
+        "@sip-and-speak/config": "workspace:*",
+        "@types/bun": "catalog:",
+        "typescript": "^5",
+      },
+    },
+    "packages/notifications": {
+      "name": "@sip-and-speak/notifications",
+      "version": "0.0.0",
+      "dependencies": {
+        "@sip-and-speak/api": "workspace:*",
+        "@sip-and-speak/db": "workspace:*",
+        "drizzle-orm": "^0.45.2",
       },
       "devDependencies": {
         "@sip-and-speak/config": "workspace:*",
@@ -1007,6 +1022,8 @@
     "@sip-and-speak/db": ["@sip-and-speak/db@workspace:packages/db"],
 
     "@sip-and-speak/env": ["@sip-and-speak/env@workspace:packages/env"],
+
+    "@sip-and-speak/notifications": ["@sip-and-speak/notifications@workspace:packages/notifications"],
 
     "@sip-and-speak/ui": ["@sip-and-speak/ui@workspace:packages/ui"],
 

--- a/packages/api/src/__tests__/matching.test.ts
+++ b/packages/api/src/__tests__/matching.test.ts
@@ -1,11 +1,10 @@
 /**
  * Tests for:
  *   #125 — Exclude requested candidates from future suggestion lists
- *   #131 — Include requester name and language summary in notification payload
  */
 import { describe, expect, it } from "bun:test";
 
-import { buildExcludedUserIds, buildMatchRequestNotificationBody } from "../routers/matching-utils";
+import { buildExcludedUserIds } from "../routers/matching-utils";
 
 const ME = "user-me";
 
@@ -39,26 +38,3 @@ describe("#125 — buildExcludedUserIds", () => {
   });
 });
 
-// ─── #131: Notification payload composition ─────────────────────────────────
-
-describe("#131 — buildMatchRequestNotificationBody", () => {
-  it("includes requester name and language summary when profile is complete", () => {
-    const body = buildMatchRequestNotificationBody("Ana", "Portuguese", "Dutch");
-    expect(body).toBe("Ana wants to meet you — speaks Portuguese, learning Dutch");
-  });
-
-  it("omits language summary when requester profile is incomplete (no languages)", () => {
-    const body = buildMatchRequestNotificationBody("Ana", null, null);
-    expect(body).toBe("Ana wants to meet you");
-  });
-
-  it("omits language summary when only offered language is present", () => {
-    const body = buildMatchRequestNotificationBody("Ana", "Portuguese", null);
-    expect(body).toBe("Ana wants to meet you");
-  });
-
-  it("omits language summary when only targeted language is present", () => {
-    const body = buildMatchRequestNotificationBody("Ana", null, "Dutch");
-    expect(body).toBe("Ana wants to meet you");
-  });
-});

--- a/packages/api/src/routers/matching-utils.ts
+++ b/packages/api/src/routers/matching-utils.ts
@@ -87,22 +87,6 @@ export function computeCompositeScore(
 }
 
 /**
- * Compose the push notification body for a MatchRequestSent event.
- * Includes language summary only when both offered and targeted languages are known.
- * Format: "{name} wants to meet you — speaks {offered}, learning {targeted}"
- */
-export function buildMatchRequestNotificationBody(
-  requesterName: string,
-  offeredLanguage: string | null,
-  targetedLanguage: string | null,
-): string {
-  if (offeredLanguage && targetedLanguage) {
-    return `${requesterName} wants to meet you — speaks ${offeredLanguage}, learning ${targetedLanguage}`;
-  }
-  return `${requesterName} wants to meet you`;
-}
-
-/**
  * Extract excluded user IDs from active match requests involving the given user.
  * Bidirectional: a candidate who sent a request to the user is also excluded.
  */


### PR DESCRIPTION
Follow-up to #300. Those edits were in my working tree but missed by the Step D commit (only the new package files were staged). Without this, apps/server fails to start because ./notifications no longer exists.

5 files: apps/server import + dep, bun.lock regen, matching-utils export removal, matching.test.ts cleanup.