### PR TITLE
fix(moderation): suspended Students can no longer send messages

### DIFF
--- a/packages/api/src/contexts/conversation/chat.ts
+++ b/packages/api/src/contexts/conversation/chat.ts
@@ -13,7 +13,6 @@ import {
 } from "@sip-and-speak/db/schema/sip-and-speak";
 import { user } from "@sip-and-speak/db/schema/auth";
 import {
-  checkConversationAccess,
   checkReadAccess,
   computeIsUnread,
   computeMarkReadAt,
@@ -160,59 +159,6 @@ export const chatRouter = router({
         })),
         nextCursor: hasMore ? chronological[chronological.length - 1]?.id : undefined,
       };
-    }),
-
-  sendMessage: protectedProcedure
-    .input(
-      z.object({
-        conversationId: z.string(),
-        content: z.string().min(1).max(2000),
-      }),
-    )
-    .mutation(async ({ ctx, input }) => {
-      const userId = ctx.session.user.id;
-
-      // #100 — Guard: suspended Students cannot send messages
-      const [sender] = await db
-        .select({ studentStatus: user.studentStatus })
-        .from(user)
-        .where(eq(user.id, userId))
-        .limit(1);
-      if (sender?.studentStatus === "suspended") {
-        throw new TRPCError({ code: "FORBIDDEN", message: "Suspended Students cannot send messages." });
-      }
-
-      // Verify user is part of this conversation
-      const conv = await db
-        .select()
-        .from(conversation)
-        .where(
-          and(
-            eq(conversation.id, input.conversationId),
-            or(
-              eq(conversation.user1Id, userId),
-              eq(conversation.user2Id, userId),
-            ),
-          ),
-        )
-        .limit(1);
-
-      // #111 — Guard: reject sends on non-open conversations (suspended or closed)
-      const access = checkConversationAccess(conv[0], userId);
-      if (!access.allowed) {
-        throw new TRPCError({ code: "FORBIDDEN", message: access.error });
-      }
-
-      const [newMessage] = await db
-        .insert(message)
-        .values({
-          conversationId: input.conversationId,
-          senderId: userId,
-          content: input.content,
-        })
-        .returning();
-
-      return newMessage;
     }),
 
   startConversation: protectedProcedure

--- a/packages/api/src/contexts/conversation/messaging.ts
+++ b/packages/api/src/contexts/conversation/messaging.ts
@@ -214,6 +214,18 @@ export const messagingRouter = router({
     .mutation(async ({ ctx, input }) => {
       const senderId = ctx.session.user.id;
 
+      // Suspended/removed Students cannot send. Belt-and-braces with the
+      // conversation.status cascade in handleStudentSuspendedSuspendConversations
+      // — this guard catches edge cases where conversation status is stale.
+      const [sender] = await db
+        .select({ studentStatus: user.studentStatus })
+        .from(user)
+        .where(eq(user.id, senderId))
+        .limit(1);
+      if (sender?.studentStatus === "suspended" || sender?.studentStatus === "removed") {
+        throw new TRPCError({ code: "FORBIDDEN", message: "Suspended or removed Students cannot send messages." });
+      }
+
       // #146 — Access gate: fail fast before any validation or DB write
       const [conv] = await db
         .select({

--- a/packages/notifications/src/__tests__/notifications-suspension-conversations.test.ts
+++ b/packages/notifications/src/__tests__/notifications-suspension-conversations.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Tests for handleStudentSuspendedSuspendConversations + handleSuspensionLiftedReopenConversations
+ * — cascade conversation.status to "suspended" / "open" on moderation events.
+ */
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+(global as unknown as { fetch: unknown }).fetch = mock(async () => ({
+  json: async () => ({ data: [{ status: "ok", id: "t-1" }] }),
+}));
+
+const dbUpdateCalls: Array<{ table: string; status: string }> = [];
+let mockSelectRows: Array<{ id: string }> = [];
+
+mock.module("@sip-and-speak/db/schema/sip-and-speak", () => ({
+  userDeviceToken: "userDeviceToken",
+  userLanguage: "userLanguage",
+  conversationPresence: "conversationPresence",
+  meetup: "meetup",
+  blockedEmail: "blockedEmail",
+  conversation: "conversation",
+}));
+mock.module("@sip-and-speak/db/schema/auth", () => ({ user: "user" }));
+mock.module("drizzle-orm", () => ({
+  eq: (_col: unknown, val: unknown) => ({ _eq: val }),
+  and: (...args: unknown[]) => ({ _and: args }),
+  or: (...args: unknown[]) => ({ _or: args }),
+  inArray: (_col: unknown, vals: unknown) => ({ _inArray: vals }),
+}));
+
+mock.module("@sip-and-speak/db", () => ({
+  db: {
+    select: (_cols?: unknown) => ({
+      from: (_table: unknown) => ({
+        where: () => Promise.resolve(mockSelectRows),
+        limit: () => Promise.resolve([]),
+      }),
+    }),
+    update: (table: unknown) => ({
+      set: (vals: Record<string, unknown>) => ({
+        where: () => {
+          dbUpdateCalls.push({ table: table as string, status: vals["status"] as string });
+          return Promise.resolve();
+        },
+      }),
+    }),
+    insert: (_table: unknown) => ({
+      values: (_vals: unknown) => ({
+        onConflictDoNothing: () => Promise.resolve(),
+      }),
+    }),
+  },
+}));
+
+import { registerNotificationHandlers } from "../dispatcher";
+import { domainEvents } from "@sip-and-speak/api/domain-events";
+
+describe("handleStudentSuspendedSuspendConversations", () => {
+  beforeEach(() => {
+    dbUpdateCalls.length = 0;
+    mockSelectRows = [];
+    try { domainEvents.removeAllListeners(); } catch { /* suite-mode mock leak */ }
+    registerNotificationHandlers();
+  });
+
+  it("sets conversation.status to 'suspended' when a Student is suspended", async () => {
+    mockSelectRows = [{ id: "conv-1" }];
+    domainEvents.emit("StudentSuspended", {
+      flagId: "flag-1",
+      targetId: "student-1",
+      moderatorId: "mod-1",
+      suspendedAt: new Date(),
+    });
+    await new Promise((r) => setTimeout(r, 30));
+    const cascade = dbUpdateCalls.find((c) => c.table === "conversation" && c.status === "suspended");
+    expect(cascade).toBeDefined();
+  });
+
+  it("does not update conversations when none are open", async () => {
+    mockSelectRows = [];
+    domainEvents.emit("StudentSuspended", {
+      flagId: "flag-2",
+      targetId: "student-2",
+      moderatorId: "mod-1",
+      suspendedAt: new Date(),
+    });
+    await new Promise((r) => setTimeout(r, 30));
+    const cascade = dbUpdateCalls.find((c) => c.table === "conversation");
+    expect(cascade).toBeUndefined();
+  });
+});
+
+describe("handleSuspensionLiftedReopenConversations", () => {
+  beforeEach(() => {
+    dbUpdateCalls.length = 0;
+    mockSelectRows = [];
+    try { domainEvents.removeAllListeners(); } catch { /* suite-mode mock leak */ }
+    registerNotificationHandlers();
+  });
+
+  it("sets conversation.status back to 'open' when suspension is lifted", async () => {
+    mockSelectRows = [{ id: "conv-1" }];
+    domainEvents.emit("SuspensionLifted", {
+      targetId: "student-1",
+      moderatorId: "mod-1",
+      liftedAt: new Date(),
+    });
+    await new Promise((r) => setTimeout(r, 30));
+    const reopen = dbUpdateCalls.find((c) => c.table === "conversation" && c.status === "open");
+    expect(reopen).toBeDefined();
+  });
+
+  it("does not update when no suspended conversations exist", async () => {
+    mockSelectRows = [];
+    domainEvents.emit("SuspensionLifted", {
+      targetId: "student-2",
+      moderatorId: "mod-1",
+      liftedAt: new Date(),
+    });
+    await new Promise((r) => setTimeout(r, 30));
+    const reopen = dbUpdateCalls.find((c) => c.table === "conversation");
+    expect(reopen).toBeUndefined();
+  });
+});

--- a/packages/notifications/src/dispatcher.ts
+++ b/packages/notifications/src/dispatcher.ts
@@ -179,8 +179,63 @@ async function handleStudentSuspendedNotify(event: StudentSuspendedEvent): Promi
   await dispatch(buildStudentSuspendedNotifyRecipes(event));
 }
 
+async function handleStudentSuspendedSuspendConversations(event: StudentSuspendedEvent): Promise<void> {
+  const openConversations = await db
+    .select({ id: conversation.id })
+    .from(conversation)
+    .where(
+      and(
+        or(eq(conversation.user1Id, event.targetId), eq(conversation.user2Id, event.targetId)),
+        eq(conversation.status, "open"),
+      ),
+    );
+
+  if (openConversations.length === 0) return;
+
+  await db
+    .update(conversation)
+    .set({ status: "suspended" })
+    .where(
+      and(
+        or(eq(conversation.user1Id, event.targetId), eq(conversation.user2Id, event.targetId)),
+        eq(conversation.status, "open"),
+      ),
+    );
+
+  console.info("[moderation] Suspended conversations on student suspension", { targetId: event.targetId, count: openConversations.length });
+}
+
 async function handleSuspensionLifted(event: SuspensionLiftedEvent): Promise<void> {
   await dispatch(buildSuspensionLiftedRecipes(event));
+}
+
+// If both Students in a shared conversation were suspended and only one is lifted,
+// the conversation re-opens here even though the other party is still suspended.
+// The per-send guard on user.studentStatus catches that case at message time.
+async function handleSuspensionLiftedReopenConversations(event: SuspensionLiftedEvent): Promise<void> {
+  const suspendedConversations = await db
+    .select({ id: conversation.id })
+    .from(conversation)
+    .where(
+      and(
+        or(eq(conversation.user1Id, event.targetId), eq(conversation.user2Id, event.targetId)),
+        eq(conversation.status, "suspended"),
+      ),
+    );
+
+  if (suspendedConversations.length === 0) return;
+
+  await db
+    .update(conversation)
+    .set({ status: "open" })
+    .where(
+      and(
+        or(eq(conversation.user1Id, event.targetId), eq(conversation.user2Id, event.targetId)),
+        eq(conversation.status, "suspended"),
+      ),
+    );
+
+  console.info("[moderation] Re-opened conversations on suspension lift", { targetId: event.targetId, count: suspendedConversations.length });
 }
 
 async function handleStudentRemovedCancelProposals(event: StudentRemovedEvent): Promise<void> {
@@ -266,8 +321,12 @@ export function registerNotificationHandlers(): void {
   domainEvents.on("StudentSuspended", (event) => {
     void handleStudentSuspended(event);
     void handleStudentSuspendedNotify(event);
+    void handleStudentSuspendedSuspendConversations(event);
   });
-  domainEvents.on("SuspensionLifted", (event) => { void handleSuspensionLifted(event); });
+  domainEvents.on("SuspensionLifted", (event) => {
+    void handleSuspensionLifted(event);
+    void handleSuspensionLiftedReopenConversations(event);
+  });
   domainEvents.on("StudentRemoved", (event) => {
     void handleStudentRemovedCancelProposals(event);
     void handleStudentRemovedCloseConversations(event);


### PR DESCRIPTION
## The bug

Surfaced during the bounded-context audit (PR #303). Three things lined up:

1. \`apps/native\` calls \`trpc.messaging.sendMessage\`. \`chat.sendMessage\` had **zero callers** — dead code.
2. The dead \`chat.sendMessage\` was **the only path** with a \`user.studentStatus === \"suspended\"\` guard. \`messaging.sendMessage\` (the live path) trusted \`conversation.status\` alone.
3. \`handleStudentSuspended\` cancels active meetup proposals but **never touched \`conversation.status\`**. The schema comment _\"Trust & Moderation can suspend a conversation\"_ described intent that was not implemented.

**Effect**: a Student suspended by a Moderator could keep sending messages in any conversation that was already open at suspension time, and the recipient got push notifications for each.

## The fix

Two layers, defense-in-depth:

### Layer 1 — cascade conversation status on moderation events
- \`handleStudentSuspendedSuspendConversations\` — sets all open conversations involving the suspended Student to \`status: \"suspended\"\`.
- \`handleSuspensionLiftedReopenConversations\` — flips \`suspended\` → \`open\` on lift. Simple version doesn't check the other participant's status; the per-send guard below catches that edge.

### Layer 2 — per-send guard
\`messaging.sendMessage\` now rejects \`FORBIDDEN\` when sender's \`studentStatus\` is \`suspended\` or \`removed\`.

### Cleanup
Delete \`chat.sendMessage\` (zero callers) + its now-unused \`checkConversationAccess\` import.

## Test plan

- [x] \`bun run check-types\` — 6 errors, all pre-existing in chat.ts, identical to baseline
- [x] \`bun test\` per package: 32 pass / 32 fail in notifications (was 30/30; +2 stable from new handlers, +2 fragile that pass standalone but fail in suite — same mock.module leak pattern as existing tests). API/auth/db unchanged.
- [x] New tests pass standalone (\`bun test src/__tests__/notifications-suspension-conversations.test.ts\` → 4/4)
- [ ] Smoke test on dev: suspend a Student, confirm they can't send to existing conversation; lift suspension, confirm they can again.

## Frontend follow-up

\`apps/native/app/chat/[conversationId].tsx\` calls \`sendMessage.mutate\` and may now receive a FORBIDDEN error for suspended users. Worth a UI ticket to show a friendly explainer ("your account is suspended") instead of the raw tRPC error.