### PR TITLE
refactor(moderation): give context a public surface

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -2,7 +2,7 @@ import { trpcServer } from "@hono/trpc-server";
 import { domainEvents } from "@sip-and-speak/api/domain-events";
 import { createContext } from "@sip-and-speak/api/context";
 import { appRouter } from "@sip-and-speak/api/routers/index";
-import { addEmailToBlocklist, isEmailBlocklisted } from "@sip-and-speak/api/contexts/moderation/moderation-persist";
+import { addEmailToBlocklist, isEmailBlocklisted } from "@sip-and-speak/api/contexts/moderation";
 import { auth } from "@sip-and-speak/auth";
 import { isAlumniEmail, ALUMNI_REGISTRY_ERROR, ALUMNI_REGISTRY_UNAVAILABLE_ERROR } from "@sip-and-speak/auth/alumni-registry";
 import { validateTueDomain } from "@sip-and-speak/auth/domain-validation";

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -5,6 +5,9 @@
     ".": {
       "default": "./src/index.ts"
     },
+    "./contexts/moderation": {
+      "default": "./src/contexts/moderation/index.ts"
+    },
     "./*": {
       "default": "./src/*.ts"
     }

--- a/packages/api/src/contexts/moderation/index.ts
+++ b/packages/api/src/contexts/moderation/index.ts
@@ -1,0 +1,2 @@
+export { addEmailToBlocklist, isEmailBlocklisted } from "./moderation-persist";
+export { moderationRouter } from "./moderation";


### PR DESCRIPTION
## The leak (Finding 3 from the bounded-context audit)

\`apps/server/src/index.ts\` was importing \`addEmailToBlocklist\` + \`isEmailBlocklisted\` from \`@sip-and-speak/api/contexts/moderation/moderation-persist\` — a context-internal persist file. Apps reaching across a package boundary into the persist sublayer.

## The fix

Add \`packages/api/src/contexts/moderation/index.ts\` re-exporting the public surface:
\`\`\`ts
export { addEmailToBlocklist, isEmailBlocklisted } from \"./moderation-persist\";
export { moderationRouter } from \"./moderation\";
\`\`\`

Server imports from \`@sip-and-speak/api/contexts/moderation\`. Persist file is internal again.

The api package's \`exports\` field only resolves wildcard \`./*\` to \`.ts\` files, not directory \`index.ts\` — added an explicit \`./contexts/moderation\` entry.

## Pattern

Each context can declare its own public surface when external consumers need one. Identity, Matching, Scheduling, Conversation don't need one yet. When they do, the same pattern applies: \`contexts/<name>/index.ts\` + explicit exports entry.

## Test plan

- [x] \`bun run check-types\` — 6 errors, all pre-existing in chat.ts
- [x] All packages' tests unchanged from baseline
- [ ] Smoke test: removed Student → email shows in blocklist; signup with blocklisted email rejected

## Out of scope (logged in memory backlog)

The \`StudentRemoved\` → \`addEmailToBlocklist\` event handler still lives in \`apps/server/src/index.ts\`. Server should not orchestrate moderation cascades; future PR could move it into a moderation event handler module (similar to how notifications/dispatcher.ts owns its handlers).