### PR TITLE
refactor(api): route meetup→conversation through public surface

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -5,6 +5,9 @@
     ".": {
       "default": "./src/index.ts"
     },
+    "./contexts/conversation": {
+      "default": "./src/contexts/conversation/index.ts"
+    },
     "./contexts/moderation": {
       "default": "./src/contexts/moderation/index.ts"
     },

--- a/packages/api/src/contexts/conversation/index.ts
+++ b/packages/api/src/contexts/conversation/index.ts
@@ -1,0 +1,3 @@
+export { chatRouter } from "./chat";
+export { messagingRouter } from "./messaging";
+export { getMessagingStateForUserMeetups, type MeetupMessagingState } from "./queries";

--- a/packages/api/src/contexts/conversation/queries.ts
+++ b/packages/api/src/contexts/conversation/queries.ts
@@ -1,0 +1,52 @@
+import { eq, or } from "drizzle-orm";
+import { db } from "@sip-and-speak/db";
+import { conversation, messagingOptIn, meetup } from "@sip-and-speak/db/schema/sip-and-speak";
+
+export interface MeetupMessagingState {
+  mine: "accept" | "decline" | null;
+  partner: "accept" | "decline" | null;
+  conversationId: string | null;
+}
+
+/**
+ * Returns per-meetup messaging state for every meetup the given Student is part of.
+ * Owned by the Conversation context so other contexts (Scheduling) don't query
+ * conversation/messagingOptIn tables directly.
+ */
+export async function getMessagingStateForUserMeetups(
+  userId: string,
+): Promise<Map<string, MeetupMessagingState>> {
+  const [optIns, conversations] = await Promise.all([
+    db
+      .select({
+        meetupId: messagingOptIn.meetupId,
+        studentId: messagingOptIn.studentId,
+        response: messagingOptIn.response,
+      })
+      .from(messagingOptIn)
+      .innerJoin(meetup, eq(meetup.id, messagingOptIn.meetupId))
+      .where(or(eq(meetup.proposerId, userId), eq(meetup.receiverId, userId))),
+    db
+      .select({ meetupId: conversation.meetupId, id: conversation.id })
+      .from(conversation)
+      .where(or(eq(conversation.user1Id, userId), eq(conversation.user2Id, userId))),
+  ]);
+
+  const result = new Map<string, MeetupMessagingState>();
+
+  for (const row of optIns) {
+    const entry = result.get(row.meetupId) ?? { mine: null, partner: null, conversationId: null };
+    if (row.studentId === userId) entry.mine = row.response;
+    else entry.partner = row.response;
+    result.set(row.meetupId, entry);
+  }
+
+  for (const c of conversations) {
+    if (c.meetupId === null) continue;
+    const entry = result.get(c.meetupId) ?? { mine: null, partner: null, conversationId: null };
+    entry.conversationId = c.id;
+    result.set(c.meetupId, entry);
+  }
+
+  return result;
+}

--- a/packages/api/src/contexts/scheduling/meetup.ts
+++ b/packages/api/src/contexts/scheduling/meetup.ts
@@ -2,7 +2,8 @@ import { and, eq, or, sql, count } from "drizzle-orm";
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { db } from "@sip-and-speak/db";
-import { meetup, venue, studentMatch, attendanceReport, messagingOptIn, conversation } from "@sip-and-speak/db/schema/sip-and-speak";
+import { meetup, venue, studentMatch, attendanceReport } from "@sip-and-speak/db/schema/sip-and-speak";
+import { getMessagingStateForUserMeetups } from "../conversation";
 import { user } from "@sip-and-speak/db/schema/auth";
 import { protectedProcedure, router } from "../../index";
 import { domainEvents } from "../../domain-events";
@@ -643,7 +644,7 @@ export const meetupRouter = router({
   getConfirmed: protectedProcedure.query(async ({ ctx }) => {
     const userId = ctx.session.user.id;
 
-    const [rows, myReports, optIns, conversations] = await Promise.all([
+    const [rows, myReports, messagingState] = await Promise.all([
       db
         .select({
           meetup: meetup,
@@ -681,38 +682,15 @@ export const meetupRouter = router({
         })
         .from(attendanceReport)
         .where(eq(attendanceReport.studentId, userId)),
-      // Opt-in responses (mine + partner) for completed/confirmed meetups
-      db
-        .select({
-          meetupId: messagingOptIn.meetupId,
-          studentId: messagingOptIn.studentId,
-          response: messagingOptIn.response,
-        })
-        .from(messagingOptIn)
-        .innerJoin(meetup, eq(meetup.id, messagingOptIn.meetupId))
-        .where(or(eq(meetup.proposerId, userId), eq(meetup.receiverId, userId))),
-      // Open conversations
-      db
-        .select({ meetupId: conversation.meetupId, id: conversation.id })
-        .from(conversation)
-        .where(or(eq(conversation.user1Id, userId), eq(conversation.user2Id, userId))),
+      // Conversation context owns its own data — Scheduling consumes the surface
+      getMessagingStateForUserMeetups(userId),
     ]);
 
     const myReportMap = new Map(myReports.map((r) => [r.meetupId, r]));
-    const conversationMap = new Map(
-      conversations.filter((c) => c.meetupId !== null).map((c) => [c.meetupId as string, c.id]),
-    );
-    const optInByMeetup = new Map<string, { mine: "accept" | "decline" | null; partner: "accept" | "decline" | null }>();
-    for (const row of optIns) {
-      const entry = optInByMeetup.get(row.meetupId) ?? { mine: null, partner: null };
-      if (row.studentId === userId) entry.mine = row.response;
-      else entry.partner = row.response;
-      optInByMeetup.set(row.meetupId, entry);
-    }
 
     return rows.map((row) => {
       const myReport = myReportMap.get(row.meetup.id);
-      const optIn = optInByMeetup.get(row.meetup.id) ?? { mine: null, partner: null };
+      const messaging = messagingState.get(row.meetup.id) ?? { mine: null, partner: null, conversationId: null };
       return {
         meetupId: row.meetup.id,
         date: row.meetup.date,
@@ -737,9 +715,9 @@ export const meetupRouter = router({
         myRating: myReport?.rating ?? null,
         // Messaging opt-in state for post-meetup hero
         optIn: {
-          mine: optIn.mine,
-          partner: optIn.partner,
-          conversationId: conversationMap.get(row.meetup.id) ?? null,
+          mine: messaging.mine,
+          partner: messaging.partner,
+          conversationId: messaging.conversationId,
         },
       };
     });

--- a/packages/api/src/routers/index.ts
+++ b/packages/api/src/routers/index.ts
@@ -4,9 +4,8 @@ import { matchingRouter } from "../contexts/matching/matching";
 import { venueRouter } from "../contexts/scheduling/venue";
 import { adminVenueRouter } from "../contexts/scheduling/venue-admin";
 import { meetupRouter } from "../contexts/scheduling/meetup";
-import { chatRouter } from "../contexts/conversation/chat";
-import { messagingRouter } from "../contexts/conversation/messaging";
-import { moderationRouter } from "../contexts/moderation/moderation";
+import { chatRouter, messagingRouter } from "../contexts/conversation";
+import { moderationRouter } from "../contexts/moderation";
 
 export const appRouter = router({
   healthCheck: publicProcedure.query(() => {


### PR DESCRIPTION
## Finding 1 from the bounded-context audit

\`meetup.ts\` queried \`conversation\` + \`messagingOptIn\` tables directly to build the \`getConfirmed\` view's messaging-state field. Scheduling reading Conversation tables = **bounded-context discipline broken at the data layer**.

## The fix

- \`packages/api/src/contexts/conversation/queries.ts\` owns \`getMessagingStateForUserMeetups(userId)\` — runs the join and returns \`Map<meetupId, { mine, partner, conversationId }>\`.
- \`packages/api/src/contexts/conversation/index.ts\` is the new public surface (chatRouter, messagingRouter, the query function).
- \`api/package.json\` adds \`./contexts/conversation\` exports entry (mirrors moderation's pattern from PR #305).
- \`meetup.ts\`: drops \`messagingOptIn\` + \`conversation\` schema imports; replaces two raw queries with one call. Result shape unchanged — getConfirmed callers see no difference.
- \`routers/index.ts\`: imports both routers from the conversation public surface (and moderation's — bonus cleanup).

## Result

Scheduling has zero references to Conversation tables. Cross-context coupling lives only at the surface (public function call), not at the data layer.

## Test plan

- [x] \`bun run check-types\` — 6 errors, all pre-existing in chat.ts
- [x] \`bun test\` per package — unchanged
- [ ] Smoke test: \`getConfirmed\` returns correct messaging state for confirmed/completed meetups