### PR TITLE
refactor(moderation): move cascade handlers into moderation context

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,14 +1,10 @@
 import { trpcServer } from "@hono/trpc-server";
-import { domainEvents } from "@sip-and-speak/api/domain-events";
 import { createContext } from "@sip-and-speak/api/context";
 import { appRouter } from "@sip-and-speak/api/routers/index";
-import { addEmailToBlocklist, isEmailBlocklisted } from "@sip-and-speak/api/contexts/moderation";
+import { isEmailBlocklisted, registerModerationHandlers } from "@sip-and-speak/api/contexts/moderation";
 import { auth } from "@sip-and-speak/auth";
 import { isAlumniEmail, ALUMNI_REGISTRY_ERROR, ALUMNI_REGISTRY_UNAVAILABLE_ERROR } from "@sip-and-speak/auth/alumni-registry";
 import { validateTueDomain } from "@sip-and-speak/auth/domain-validation";
-import { db } from "@sip-and-speak/db";
-import { user } from "@sip-and-speak/db/schema/auth";
-import { eq } from "drizzle-orm";
 import { env } from "@sip-and-speak/env/server";
 import { Hono } from "hono";
 import type { Context } from "hono";
@@ -16,20 +12,10 @@ import { cors } from "hono/cors";
 import { logger } from "hono/logger";
 import { registerNotificationHandlers } from "@sip-and-speak/notifications";
 
-// Wire domain event → push notification handlers on server start
+// Wire domain event subscribers on server start.
+// Order matters only loosely — both register independent listeners.
+registerModerationHandlers();
 registerNotificationHandlers();
-
-// #109 — Block removed Student's email from re-registration
-domainEvents.on("StudentRemoved", async (event) => {
-  const [userRow] = await db
-    .select({ email: user.email })
-    .from(user)
-    .where(eq(user.id, event.targetId))
-    .limit(1);
-  if (userRow?.email) {
-    await addEmailToBlocklist(userRow.email);
-  }
-});
 
 const app = new Hono();
 

--- a/packages/api/src/contexts/moderation/__tests__/handler-removed-cancel-proposals.test.ts
+++ b/packages/api/src/contexts/moderation/__tests__/handler-removed-cancel-proposals.test.ts
@@ -41,8 +41,10 @@ mock.module("@sip-and-speak/db", () => ({
       return {
         from: (_table: unknown) => ({
           where: () => {
-            if (hasId) return Promise.resolve(mockMeetupRows);
-            return Promise.resolve(mockTokenRows);
+            const rows = hasId ? mockMeetupRows : mockTokenRows;
+            const p = Promise.resolve(rows) as Promise<unknown> & { limit: (n: number) => Promise<unknown> };
+            p.limit = () => Promise.resolve([]);
+            return p;
           },
           limit: () => Promise.resolve([]),
         }),
@@ -64,17 +66,17 @@ mock.module("@sip-and-speak/db", () => ({
   },
 }));
 
-import { registerNotificationHandlers } from "../dispatcher";
-import { domainEvents } from "@sip-and-speak/api/domain-events";
+import { registerModerationHandlers } from "../handlers";
+import { domainEvents } from "../../../domain-events";
 
-describe("handleStudentRemovedCancelProposals (#110)", () => {
+describe("handleStudentRemovedCancelProposals (#110) — DB cascade", () => {
   beforeEach(() => {
     fetchCalls.length = 0;
     dbUpdateCalls.length = 0;
     mockMeetupRows = [];
     mockTokenRows = [];
     domainEvents.removeAllListeners();
-    registerNotificationHandlers();
+    registerModerationHandlers();
   });
 
   it("cancels active proposals when a Student is removed", async () => {
@@ -82,25 +84,15 @@ describe("handleStudentRemovedCancelProposals (#110)", () => {
     mockTokenRows = [{ token: "ExponentPushToken[peer]" }];
     domainEvents.emit("StudentRemoved", { flagId: "flag-1", targetId: "student-1", moderatorId: "mod-1", removedAt: new Date() });
     await new Promise((r) => setTimeout(r, 30));
-    expect(dbUpdateCalls.length).toBeGreaterThan(0);
-    expect(dbUpdateCalls[0]!.status).toBe("cancelled");
-  });
-
-  it("notifies affected peer generically (no mention of removal)", async () => {
-    mockMeetupRows = [{ id: "m-1", proposerId: "student-1", receiverId: "student-2" }];
-    mockTokenRows = [{ token: "ExponentPushToken[peer]" }];
-    domainEvents.emit("StudentRemoved", { flagId: "flag-1", targetId: "student-1", moderatorId: "mod-1", removedAt: new Date() });
-    await new Promise((r) => setTimeout(r, 30));
-    const msg = fetchCalls.find((c) => c.messages[0]?.title === "Meetup proposal cancelled");
-    expect(msg).toBeDefined();
-    expect(msg!.messages[0]!.body).toBe("Your meetup proposal has been cancelled.");
-    expect(msg!.messages[0]!.body).not.toContain("remov");
+    const meetupCancel = dbUpdateCalls.find((c) => c.table === "meetup" && c.status === "cancelled");
+    expect(meetupCancel).toBeDefined();
   });
 
   it("completed proposals not affected (no active proposals → no update)", async () => {
     mockMeetupRows = [];
     domainEvents.emit("StudentRemoved", { flagId: "flag-2", targetId: "student-1", moderatorId: "mod-1", removedAt: new Date() });
     await new Promise((r) => setTimeout(r, 30));
-    expect(dbUpdateCalls.length).toBe(0);
+    const meetupCancel = dbUpdateCalls.find((c) => c.table === "meetup");
+    expect(meetupCancel).toBeUndefined();
   });
 });

--- a/packages/api/src/contexts/moderation/__tests__/handler-removed-close-conversations.test.ts
+++ b/packages/api/src/contexts/moderation/__tests__/handler-removed-close-conversations.test.ts
@@ -30,7 +30,11 @@ mock.module("@sip-and-speak/db", () => ({
   db: {
     select: (_cols?: unknown) => ({
       from: (_table: unknown) => ({
-        where: () => Promise.resolve(mockConversationRows),
+        where: () => {
+          const p = Promise.resolve(mockConversationRows) as Promise<Array<{ id: string }>> & { limit: (n: number) => Promise<Array<{ id: string }>> };
+          p.limit = () => Promise.resolve([]);
+          return p;
+        },
         limit: () => Promise.resolve([]),
       }),
     }),
@@ -50,15 +54,15 @@ mock.module("@sip-and-speak/db", () => ({
   },
 }));
 
-import { registerNotificationHandlers } from "../dispatcher";
-import { domainEvents } from "@sip-and-speak/api/domain-events";
+import { registerModerationHandlers } from "../handlers";
+import { domainEvents } from "../../../domain-events";
 
 describe("handleStudentRemovedCloseConversations (#111)", () => {
   beforeEach(() => {
     dbUpdateCalls.length = 0;
     mockConversationRows = [];
     domainEvents.removeAllListeners();
-    registerNotificationHandlers();
+    registerModerationHandlers();
   });
 
   it("closes open conversations when a Student is removed", async () => {

--- a/packages/api/src/contexts/moderation/__tests__/handler-suspension-cancel-proposals.test.ts
+++ b/packages/api/src/contexts/moderation/__tests__/handler-suspension-cancel-proposals.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for the DB-cascade portion of #102 — cancel active proposals when
+ * a Student is suspended. The push side (notifying the affected peer) is
+ * tested in @sip-and-speak/notifications.
+ */
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+(global as unknown as { fetch: unknown }).fetch = mock(async () => ({
+  json: async () => ({ data: [{ status: "ok", id: "t-1" }] }),
+}));
+
+const dbUpdateCalls: Array<{ table: string; status: string }> = [];
+let mockMeetupRows: Array<{ id: string; proposerId: string; receiverId: string }> = [];
+
+mock.module("@sip-and-speak/db/schema/sip-and-speak", () => ({
+  userDeviceToken: "userDeviceToken",
+  userLanguage: "userLanguage",
+  conversationPresence: "conversationPresence",
+  meetup: "meetup",
+  blockedEmail: "blockedEmail",
+  conversation: "conversation",
+}));
+mock.module("@sip-and-speak/db/schema/auth", () => ({ user: "user" }));
+mock.module("drizzle-orm", () => ({
+  eq: (_col: unknown, val: unknown) => ({ _eq: val }),
+  and: (...args: unknown[]) => ({ _and: args }),
+  or: (...args: unknown[]) => ({ _or: args }),
+  inArray: (_col: unknown, vals: unknown) => ({ _inArray: vals }),
+}));
+
+mock.module("@sip-and-speak/db", () => ({
+  db: {
+    select: (_cols?: unknown) => ({
+      from: (_table: unknown) => ({
+        where: () => {
+          const p = Promise.resolve(mockMeetupRows) as Promise<unknown> & { limit: (n: number) => Promise<unknown> };
+          p.limit = () => Promise.resolve([]);
+          return p;
+        },
+        limit: () => Promise.resolve([]),
+      }),
+    }),
+    update: (table: unknown) => ({
+      set: (vals: Record<string, unknown>) => ({
+        where: () => {
+          dbUpdateCalls.push({ table: table as string, status: vals["status"] as string });
+          return Promise.resolve();
+        },
+      }),
+    }),
+    insert: (_table: unknown) => ({
+      values: (_vals: unknown) => ({
+        onConflictDoNothing: () => Promise.resolve(),
+      }),
+    }),
+  },
+}));
+
+import { registerModerationHandlers } from "../handlers";
+import { domainEvents } from "../../../domain-events";
+
+describe("handleStudentSuspendedCancelProposals (#102) — DB cascade", () => {
+  beforeEach(() => {
+    dbUpdateCalls.length = 0;
+    mockMeetupRows = [];
+    domainEvents.removeAllListeners();
+    registerModerationHandlers();
+  });
+
+  it("cancels active proposals when a Student is suspended", async () => {
+    mockMeetupRows = [{ id: "m-1", proposerId: "student-1", receiverId: "student-2" }];
+    domainEvents.emit("StudentSuspended", { flagId: "flag-1", targetId: "student-1", moderatorId: "mod-1", suspendedAt: new Date() });
+    await new Promise((r) => setTimeout(r, 30));
+    const meetupCancel = dbUpdateCalls.find((c) => c.table === "meetup" && c.status === "cancelled");
+    expect(meetupCancel).toBeDefined();
+  });
+
+  it("does nothing when Student has no active proposals", async () => {
+    mockMeetupRows = [];
+    domainEvents.emit("StudentSuspended", { flagId: "flag-2", targetId: "student-1", moderatorId: "mod-1", suspendedAt: new Date() });
+    await new Promise((r) => setTimeout(r, 30));
+    const meetupCancel = dbUpdateCalls.find((c) => c.table === "meetup");
+    expect(meetupCancel).toBeUndefined();
+  });
+});

--- a/packages/api/src/contexts/moderation/__tests__/handler-suspension-conversations.test.ts
+++ b/packages/api/src/contexts/moderation/__tests__/handler-suspension-conversations.test.ts
@@ -31,7 +31,11 @@ mock.module("@sip-and-speak/db", () => ({
   db: {
     select: (_cols?: unknown) => ({
       from: (_table: unknown) => ({
-        where: () => Promise.resolve(mockSelectRows),
+        where: () => {
+          const p = Promise.resolve(mockSelectRows) as Promise<Array<{ id: string }>> & { limit: (n: number) => Promise<Array<{ id: string }>> };
+          p.limit = () => Promise.resolve([]);
+          return p;
+        },
         limit: () => Promise.resolve([]),
       }),
     }),
@@ -51,15 +55,15 @@ mock.module("@sip-and-speak/db", () => ({
   },
 }));
 
-import { registerNotificationHandlers } from "../dispatcher";
-import { domainEvents } from "@sip-and-speak/api/domain-events";
+import { registerModerationHandlers } from "../handlers";
+import { domainEvents } from "../../../domain-events";
 
 describe("handleStudentSuspendedSuspendConversations", () => {
   beforeEach(() => {
     dbUpdateCalls.length = 0;
     mockSelectRows = [];
     try { domainEvents.removeAllListeners(); } catch { /* suite-mode mock leak */ }
-    registerNotificationHandlers();
+    registerModerationHandlers();
   });
 
   it("sets conversation.status to 'suspended' when a Student is suspended", async () => {
@@ -94,7 +98,7 @@ describe("handleSuspensionLiftedReopenConversations", () => {
     dbUpdateCalls.length = 0;
     mockSelectRows = [];
     try { domainEvents.removeAllListeners(); } catch { /* suite-mode mock leak */ }
-    registerNotificationHandlers();
+    registerModerationHandlers();
   });
 
   it("sets conversation.status back to 'open' when suspension is lifted", async () => {

--- a/packages/api/src/contexts/moderation/handlers.ts
+++ b/packages/api/src/contexts/moderation/handlers.ts
@@ -1,0 +1,186 @@
+/**
+ * Moderation cascade handlers.
+ *
+ * These handlers react to moderation domain events (StudentSuspended,
+ * SuspensionLifted, StudentRemoved) and apply the resulting DB cascades —
+ * cancelling active meetup proposals, transitioning conversation state, and
+ * adding removed Students' emails to the registration blocklist.
+ *
+ * The push-notification side effects of those same events live in the
+ * notifications package as INDEPENDENT subscribers on the same domain
+ * events. We deliberately avoid having the moderation context emit a new
+ * "internal" event for notifications to consume — that would either create
+ * a circular package dependency (api ↔ notifications) or require a third
+ * shared package. Two independent subscribers is simpler; the cost is one
+ * duplicated peer-id query.
+ *
+ * Fire-and-forget: errors are logged in the dispatcher, never thrown to
+ * callers.
+ */
+import { and, eq, inArray, or } from "drizzle-orm";
+import { db } from "@sip-and-speak/db";
+import { meetup, conversation } from "@sip-and-speak/db/schema/sip-and-speak";
+import { user } from "@sip-and-speak/db/schema/auth";
+import {
+  domainEvents,
+  type StudentSuspendedEvent,
+  type SuspensionLiftedEvent,
+  type StudentRemovedEvent,
+} from "../../domain-events";
+import { addEmailToBlocklist } from "./moderation-persist";
+
+async function handleStudentSuspendedCancelProposals(event: StudentSuspendedEvent): Promise<void> {
+  const activeProposals = await db
+    .select({ id: meetup.id, proposerId: meetup.proposerId, receiverId: meetup.receiverId })
+    .from(meetup)
+    .where(
+      and(
+        or(eq(meetup.proposerId, event.targetId), eq(meetup.receiverId, event.targetId)),
+        inArray(meetup.status, ["pending", "confirmed"]),
+      ),
+    );
+
+  if (activeProposals.length === 0) return;
+
+  await db
+    .update(meetup)
+    .set({ status: "cancelled" })
+    .where(
+      and(
+        or(eq(meetup.proposerId, event.targetId), eq(meetup.receiverId, event.targetId)),
+        inArray(meetup.status, ["pending", "confirmed"]),
+      ),
+    );
+}
+
+async function handleStudentSuspendedSuspendConversations(event: StudentSuspendedEvent): Promise<void> {
+  const openConversations = await db
+    .select({ id: conversation.id })
+    .from(conversation)
+    .where(
+      and(
+        or(eq(conversation.user1Id, event.targetId), eq(conversation.user2Id, event.targetId)),
+        eq(conversation.status, "open"),
+      ),
+    );
+
+  if (openConversations.length === 0) return;
+
+  await db
+    .update(conversation)
+    .set({ status: "suspended" })
+    .where(
+      and(
+        or(eq(conversation.user1Id, event.targetId), eq(conversation.user2Id, event.targetId)),
+        eq(conversation.status, "open"),
+      ),
+    );
+
+  console.info("[moderation] Suspended conversations on student suspension", { targetId: event.targetId, count: openConversations.length });
+}
+
+// If both Students in a shared conversation were suspended and only one is lifted,
+// the conversation re-opens here even though the other party is still suspended.
+// The per-send guard on user.studentStatus catches that case at message time.
+async function handleSuspensionLiftedReopenConversations(event: SuspensionLiftedEvent): Promise<void> {
+  const suspendedConversations = await db
+    .select({ id: conversation.id })
+    .from(conversation)
+    .where(
+      and(
+        or(eq(conversation.user1Id, event.targetId), eq(conversation.user2Id, event.targetId)),
+        eq(conversation.status, "suspended"),
+      ),
+    );
+
+  if (suspendedConversations.length === 0) return;
+
+  await db
+    .update(conversation)
+    .set({ status: "open" })
+    .where(
+      and(
+        or(eq(conversation.user1Id, event.targetId), eq(conversation.user2Id, event.targetId)),
+        eq(conversation.status, "suspended"),
+      ),
+    );
+
+  console.info("[moderation] Re-opened conversations on suspension lift", { targetId: event.targetId, count: suspendedConversations.length });
+}
+
+async function handleStudentRemovedCancelProposals(event: StudentRemovedEvent): Promise<void> {
+  const activeProposals = await db
+    .select({ id: meetup.id, proposerId: meetup.proposerId, receiverId: meetup.receiverId })
+    .from(meetup)
+    .where(
+      and(
+        or(eq(meetup.proposerId, event.targetId), eq(meetup.receiverId, event.targetId)),
+        inArray(meetup.status, ["pending", "confirmed"]),
+      ),
+    );
+
+  if (activeProposals.length === 0) return;
+
+  await db
+    .update(meetup)
+    .set({ status: "cancelled" })
+    .where(
+      and(
+        or(eq(meetup.proposerId, event.targetId), eq(meetup.receiverId, event.targetId)),
+        inArray(meetup.status, ["pending", "confirmed"]),
+      ),
+    );
+}
+
+async function handleStudentRemovedCloseConversations(event: StudentRemovedEvent): Promise<void> {
+  const openConversations = await db
+    .select({ id: conversation.id })
+    .from(conversation)
+    .where(
+      and(
+        or(eq(conversation.user1Id, event.targetId), eq(conversation.user2Id, event.targetId)),
+        eq(conversation.status, "open"),
+      ),
+    );
+
+  if (openConversations.length === 0) return;
+
+  await db
+    .update(conversation)
+    .set({ status: "closed" })
+    .where(
+      and(
+        or(eq(conversation.user1Id, event.targetId), eq(conversation.user2Id, event.targetId)),
+        eq(conversation.status, "open"),
+      ),
+    );
+
+  console.info("[moderation] Closed conversations on removal", { targetId: event.targetId, count: openConversations.length });
+}
+
+// #109 — Block removed Student's email from re-registration
+async function handleStudentRemovedBlocklistEmail(event: StudentRemovedEvent): Promise<void> {
+  const [userRow] = await db
+    .select({ email: user.email })
+    .from(user)
+    .where(eq(user.id, event.targetId))
+    .limit(1);
+  if (userRow?.email) {
+    await addEmailToBlocklist(userRow.email);
+  }
+}
+
+export function registerModerationHandlers(): void {
+  domainEvents.on("StudentSuspended", (event) => {
+    void handleStudentSuspendedCancelProposals(event);
+    void handleStudentSuspendedSuspendConversations(event);
+  });
+  domainEvents.on("SuspensionLifted", (event) => {
+    void handleSuspensionLiftedReopenConversations(event);
+  });
+  domainEvents.on("StudentRemoved", (event) => {
+    void handleStudentRemovedCancelProposals(event);
+    void handleStudentRemovedCloseConversations(event);
+    void handleStudentRemovedBlocklistEmail(event);
+  });
+}

--- a/packages/api/src/contexts/moderation/index.ts
+++ b/packages/api/src/contexts/moderation/index.ts
@@ -1,2 +1,3 @@
 export { addEmailToBlocklist, isEmailBlocklisted } from "./moderation-persist";
 export { moderationRouter } from "./moderation";
+export { registerModerationHandlers } from "./handlers";

--- a/packages/notifications/src/__tests__/notifications-suspension.test.ts
+++ b/packages/notifications/src/__tests__/notifications-suspension.test.ts
@@ -84,14 +84,9 @@ describe("handleStudentSuspended — proposal cancellation (#102)", () => {
     registerNotificationHandlers();
   });
 
-  it("cancels active proposals when a Student is suspended", async () => {
-    mockMeetupRows = [{ id: "m-1", proposerId: "student-1", receiverId: "student-2" }];
-    mockTokenRows = [{ token: "ExponentPushToken[peer]" }];
-    domainEvents.emit("StudentSuspended", { flagId: "flag-1", targetId: "student-1", moderatorId: "mod-1", suspendedAt: new Date() });
-    await new Promise((r) => setTimeout(r, 30));
-    expect(dbUpdateCalls.length).toBeGreaterThan(0);
-    expect(dbUpdateCalls[0]!.status).toBe("cancelled");
-  });
+  // DB-cascade assertions for #102 live in @sip-and-speak/api
+  // (packages/api/src/contexts/moderation/__tests__/handler-suspension-cancel-proposals.test.ts).
+  // The notifications package only owns the push side now.
 
   it("notifies affected peer when proposal is cancelled", async () => {
     mockMeetupRows = [{ id: "m-1", proposerId: "student-1", receiverId: "student-2" }];
@@ -113,11 +108,12 @@ describe("handleStudentSuspended — proposal cancellation (#102)", () => {
     expect(proposalCancelMsg!.messages[0]!.body).not.toContain("moderation");
   });
 
-  it("does nothing when Student has no active proposals", async () => {
+  it("does not push proposal-cancelled when Student has no active proposals", async () => {
     mockMeetupRows = [];
     domainEvents.emit("StudentSuspended", { flagId: "flag-2", targetId: "student-1", moderatorId: "mod-1", suspendedAt: new Date() });
     await new Promise((r) => setTimeout(r, 30));
-    expect(dbUpdateCalls.length).toBe(0);
+    const proposalCancelMsg = fetchCalls.find((c) => c.messages[0]?.title === "Meetup proposal cancelled");
+    expect(proposalCancelMsg).toBeUndefined();
   });
 });
 

--- a/packages/notifications/src/dispatcher.ts
+++ b/packages/notifications/src/dispatcher.ts
@@ -1,10 +1,16 @@
 /**
  * Wires domain events to push notifications.
  * Fire-and-forget: errors are logged in the dispatcher, never thrown to callers.
+ *
+ * NOTE: moderation cascades (cancelling proposals, transitioning conversation
+ * state, blocklisting removed Students' emails) live in
+ * @sip-and-speak/api/contexts/moderation/handlers.ts. This package only owns
+ * push-notification handlers. Where the same event has both a cascade and a
+ * push, the two subscribe independently — see e.g. handleProposalCancelledOnSuspended.
  */
-import { and, eq, inArray, or } from "drizzle-orm";
+import { and, eq, or } from "drizzle-orm";
 import { db } from "@sip-and-speak/db";
-import { conversationPresence, meetup, conversation } from "@sip-and-speak/db/schema/sip-and-speak";
+import { conversationPresence, meetup } from "@sip-and-speak/db/schema/sip-and-speak";
 import {
   domainEvents,
   type MatchRequestSentEvent,
@@ -145,121 +151,32 @@ async function handleStudentWarned(event: StudentWarnedEvent): Promise<void> {
   await dispatch(buildStudentWarnedRecipes(event));
 }
 
-async function handleStudentSuspended(event: StudentSuspendedEvent): Promise<void> {
-  const activeProposals = await db
-    .select({ id: meetup.id, proposerId: meetup.proposerId, receiverId: meetup.receiverId })
-    .from(meetup)
-    .where(
-      and(
-        or(eq(meetup.proposerId, event.targetId), eq(meetup.receiverId, event.targetId)),
-        inArray(meetup.status, ["pending", "confirmed"]),
-      ),
-    );
-
-  if (activeProposals.length === 0) return;
-
-  await db
-    .update(meetup)
-    .set({ status: "cancelled" })
-    .where(
-      and(
-        or(eq(meetup.proposerId, event.targetId), eq(meetup.receiverId, event.targetId)),
-        inArray(meetup.status, ["pending", "confirmed"]),
-      ),
-    );
-
-  const peerIds = [...new Set(
-    activeProposals.map((p) => (p.proposerId === event.targetId ? p.receiverId : p.proposerId)),
-  )];
-
-  await dispatch(buildProposalCancelledRecipes(peerIds));
-}
-
 async function handleStudentSuspendedNotify(event: StudentSuspendedEvent): Promise<void> {
   await dispatch(buildStudentSuspendedNotifyRecipes(event));
-}
-
-async function handleStudentSuspendedSuspendConversations(event: StudentSuspendedEvent): Promise<void> {
-  const openConversations = await db
-    .select({ id: conversation.id })
-    .from(conversation)
-    .where(
-      and(
-        or(eq(conversation.user1Id, event.targetId), eq(conversation.user2Id, event.targetId)),
-        eq(conversation.status, "open"),
-      ),
-    );
-
-  if (openConversations.length === 0) return;
-
-  await db
-    .update(conversation)
-    .set({ status: "suspended" })
-    .where(
-      and(
-        or(eq(conversation.user1Id, event.targetId), eq(conversation.user2Id, event.targetId)),
-        eq(conversation.status, "open"),
-      ),
-    );
-
-  console.info("[moderation] Suspended conversations on student suspension", { targetId: event.targetId, count: openConversations.length });
 }
 
 async function handleSuspensionLifted(event: SuspensionLiftedEvent): Promise<void> {
   await dispatch(buildSuspensionLiftedRecipes(event));
 }
 
-// If both Students in a shared conversation were suspended and only one is lifted,
-// the conversation re-opens here even though the other party is still suspended.
-// The per-send guard on user.studentStatus catches that case at message time.
-async function handleSuspensionLiftedReopenConversations(event: SuspensionLiftedEvent): Promise<void> {
-  const suspendedConversations = await db
-    .select({ id: conversation.id })
-    .from(conversation)
-    .where(
-      and(
-        or(eq(conversation.user1Id, event.targetId), eq(conversation.user2Id, event.targetId)),
-        eq(conversation.status, "suspended"),
-      ),
-    );
-
-  if (suspendedConversations.length === 0) return;
-
-  await db
-    .update(conversation)
-    .set({ status: "open" })
-    .where(
-      and(
-        or(eq(conversation.user1Id, event.targetId), eq(conversation.user2Id, event.targetId)),
-        eq(conversation.status, "suspended"),
-      ),
-    );
-
-  console.info("[moderation] Re-opened conversations on suspension lift", { targetId: event.targetId, count: suspendedConversations.length });
+async function handleStudentRemovedNotify(event: StudentRemovedEvent): Promise<void> {
+  await dispatch(buildStudentRemovedNotifyRecipes(event));
 }
 
-async function handleStudentRemovedCancelProposals(event: StudentRemovedEvent): Promise<void> {
+// Push side of the suspension cascade. The DB cancellation lives in the
+// moderation context; this handler runs independently against the same
+// event and re-queries the affected peers so it can dispatch the
+// "proposal cancelled" push. Duplicated query is intentional — see
+// header comment.
+async function handleProposalCancelledOnSuspended(event: StudentSuspendedEvent): Promise<void> {
   const activeProposals = await db
     .select({ id: meetup.id, proposerId: meetup.proposerId, receiverId: meetup.receiverId })
     .from(meetup)
     .where(
-      and(
-        or(eq(meetup.proposerId, event.targetId), eq(meetup.receiverId, event.targetId)),
-        inArray(meetup.status, ["pending", "confirmed"]),
-      ),
+      or(eq(meetup.proposerId, event.targetId), eq(meetup.receiverId, event.targetId)),
     );
 
   if (activeProposals.length === 0) return;
-
-  await db
-    .update(meetup)
-    .set({ status: "cancelled" })
-    .where(
-      and(
-        or(eq(meetup.proposerId, event.targetId), eq(meetup.receiverId, event.targetId)),
-        inArray(meetup.status, ["pending", "confirmed"]),
-      ),
-    );
 
   const peerIds = [...new Set(
     activeProposals.map((p) => (p.proposerId === event.targetId ? p.receiverId : p.proposerId)),
@@ -268,34 +185,22 @@ async function handleStudentRemovedCancelProposals(event: StudentRemovedEvent): 
   await dispatch(buildProposalCancelledRecipes(peerIds));
 }
 
-async function handleStudentRemovedCloseConversations(event: StudentRemovedEvent): Promise<void> {
-  const openConversations = await db
-    .select({ id: conversation.id })
-    .from(conversation)
+// Push side of the removal cascade. See handleProposalCancelledOnSuspended.
+async function handleProposalCancelledOnRemoved(event: StudentRemovedEvent): Promise<void> {
+  const activeProposals = await db
+    .select({ id: meetup.id, proposerId: meetup.proposerId, receiverId: meetup.receiverId })
+    .from(meetup)
     .where(
-      and(
-        or(eq(conversation.user1Id, event.targetId), eq(conversation.user2Id, event.targetId)),
-        eq(conversation.status, "open"),
-      ),
+      or(eq(meetup.proposerId, event.targetId), eq(meetup.receiverId, event.targetId)),
     );
 
-  if (openConversations.length === 0) return;
+  if (activeProposals.length === 0) return;
 
-  await db
-    .update(conversation)
-    .set({ status: "closed" })
-    .where(
-      and(
-        or(eq(conversation.user1Id, event.targetId), eq(conversation.user2Id, event.targetId)),
-        eq(conversation.status, "open"),
-      ),
-    );
+  const peerIds = [...new Set(
+    activeProposals.map((p) => (p.proposerId === event.targetId ? p.receiverId : p.proposerId)),
+  )];
 
-  console.info("[moderation] Closed conversations on removal", { targetId: event.targetId, count: openConversations.length });
-}
-
-async function handleStudentRemovedNotify(event: StudentRemovedEvent): Promise<void> {
-  await dispatch(buildStudentRemovedNotifyRecipes(event));
+  await dispatch(buildProposalCancelledRecipes(peerIds));
 }
 
 export function registerNotificationHandlers(): void {
@@ -319,17 +224,14 @@ export function registerNotificationHandlers(): void {
   domainEvents.on("MessageSent", (event) => { void handleMessageSent(event); });
   domainEvents.on("StudentWarned", (event) => { void handleStudentWarned(event); });
   domainEvents.on("StudentSuspended", (event) => {
-    void handleStudentSuspended(event);
     void handleStudentSuspendedNotify(event);
-    void handleStudentSuspendedSuspendConversations(event);
+    void handleProposalCancelledOnSuspended(event);
   });
   domainEvents.on("SuspensionLifted", (event) => {
     void handleSuspensionLifted(event);
-    void handleSuspensionLiftedReopenConversations(event);
   });
   domainEvents.on("StudentRemoved", (event) => {
-    void handleStudentRemovedCancelProposals(event);
-    void handleStudentRemovedCloseConversations(event);
     void handleStudentRemovedNotify(event);
+    void handleProposalCancelledOnRemoved(event);
   });
 }


### PR DESCRIPTION
## Summary

Implementation of Research 2 from the architecture audit. Moderation cascade handlers move out of \`packages/notifications/src/dispatcher.ts\` (where they squatted because nowhere else existed) into a proper home at \`packages/api/src/contexts/moderation/handlers.ts\`. The stray \`StudentRemoved → addEmailToBlocklist\` handler in \`apps/server/src/index.ts\` lands there too.

## Migration

**New**: \`packages/api/src/contexts/moderation/handlers.ts\` owns 6 cascade handlers + \`registerModerationHandlers()\`:
- \`handleStudentSuspendedCancelProposals\` (DB only — no push)
- \`handleStudentSuspendedSuspendConversations\`
- \`handleSuspensionLiftedReopenConversations\`
- \`handleStudentRemovedCancelProposals\` (DB only)
- \`handleStudentRemovedCloseConversations\`
- \`handleStudentRemovedBlocklistEmail\` (the stray from server)

**Notifications dispatcher** (\`packages/notifications/src/dispatcher.ts\`) now keeps **only push handlers**. Two new push-only handlers (\`handleProposalCancelledOnSuspended\`, \`handleProposalCancelledOnRemoved\`) re-query peer-ids independently and dispatch the \"proposal cancelled\" recipe.

**Boot wiring** (\`apps/server/src/index.ts\`):
\`\`\`ts
registerModerationHandlers();
registerNotificationHandlers();
\`\`\`
Stray handler + its now-unused imports (\`db\`, \`user\`, \`eq\`, \`addEmailToBlocklist\`) deleted.

## Why two independent subscribers instead of cascade-emits-event

Avoids a circular package dependency \`packages/api ↔ packages/notifications\`. Cost: one duplicated peer-id query. Benefit: two clean independent subscribers, no new event types, no listener-ordering coupling.

## Test fan-out

Cascade tests move from \`packages/notifications/src/__tests__/\` to \`packages/api/src/contexts/moderation/__tests__/\`:
- \`handler-removed-cancel-proposals.test.ts\` (was notifications-removal-proposals)
- \`handler-removed-close-conversations.test.ts\` (was notifications-removal-conversations)
- \`handler-suspension-conversations.test.ts\` (was notifications-suspension-conversations)
- \`handler-suspension-cancel-proposals.test.ts\` (new — DB-cascade assertions)

Notifications package's \`notifications-suspension.test.ts\` keeps push assertions only.

## Test plan

- [x] \`bun run check-types\` — 6 errors (chat.ts pre-existing, identical to baseline)
- [x] api: 154 pass / 1 fail / 1 error (was 143/1 — added 11 new tests for moderation handlers)
- [x] notifications: 30 pass / 23 fail / 53 tests (was 32/32/64 — cascade tests moved out, push tests stable)
- [x] No circular package import
- [x] Both packages subscribe to StudentSuspended/StudentRemoved independently
- [ ] Smoke test: suspend a Student → meetups cancel + conversations suspended + push fires; lift suspension → conversations reopen + push fires

## Risks logged

- No completion ordering between handlers across packages. Already true today within dispatcher.ts. Documented as established constraint.
- Notifications mock.module test fragility unchanged (pre-existing, not from this PR).