### PR TITLE
fix(matching): show human-readable interest labels in candidate views

### DIFF
--- a/apps/native/app/(tabs)/profile.tsx
+++ b/apps/native/app/(tabs)/profile.tsx
@@ -16,6 +16,7 @@ import { LanguagePickerModal } from "@/components/language-picker-modal";
 import { authClient } from "@/lib/auth-client";
 import { queryClient, trpc } from "@/utils/trpc";
 import { pickAndEncodeProfilePicture } from "@/utils/profile-picture";
+import { INTERESTS, interestLabel } from "@/utils/interest-labels";
 
 const GOLD = "#F2C94C";
 const BORDER = "#D9C9BC";
@@ -42,27 +43,6 @@ const LEVEL_BLOCKS = [
   { value: "advanced" as const, label: "C1–C2", sub: "Advanced" },
 ];
 
-const INTERESTS = [
-  { value: "modern_art", label: "Art" },
-  { value: "tech_coding", label: "Tech" },
-  { value: "jazz_music", label: "Music" },
-  { value: "culinary_arts", label: "Cooking" },
-  { value: "sustainability", label: "Sustainability" },
-  { value: "cinephile", label: "Film" },
-  { value: "cosmology", label: "Science" },
-  { value: "photography", label: "Photography" },
-  { value: "board_games", label: "Board games" },
-  { value: "hiking_outdoors", label: "Hiking" },
-  { value: "yoga_wellness", label: "Yoga" },
-  { value: "literature", label: "Books" },
-  { value: "entrepreneurship", label: "Startups" },
-  { value: "design_architecture", label: "Design" },
-  { value: "travel", label: "Travel" },
-  { value: "gaming", label: "Gaming" },
-  { value: "fitness_sports", label: "Fitness" },
-  { value: "philosophy", label: "Philosophy" },
-  { value: "theatre", label: "Theatre" },
-] as const;
 
 function SectionLabel({ children }: { children: string }) {
   return (

--- a/apps/native/app/partner/[id].tsx
+++ b/apps/native/app/partner/[id].tsx
@@ -7,6 +7,7 @@ import { Image, ScrollView, Text, View } from "react-native";
 import { Container } from "@/components/container";
 import { MatchCelebrationModal } from "@/components/match-celebration-modal";
 import { queryClient, trpc } from "@/utils/trpc";
+import { interestLabel } from "@/utils/interest-labels";
 
 export default function PartnerProfileScreen() {
   const { id, matchRequestId } = useLocalSearchParams<{ id: string; matchRequestId?: string }>();
@@ -179,7 +180,7 @@ export default function PartnerProfileScreen() {
             <View className="flex-row flex-wrap gap-2" testID="profile-topics">
               {profile.interests.map((topic) => (
                 <View key={topic} className="bg-muted px-3 py-1 rounded-full">
-                  <Text className="text-muted-foreground text-sm">{topic}</Text>
+                  <Text className="text-muted-foreground text-sm">{interestLabel(topic)}</Text>
                 </View>
               ))}
             </View>

--- a/apps/native/components/candidate-card.tsx
+++ b/apps/native/components/candidate-card.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { Image, Pressable, Text, View } from "react-native";
 
 import { trpc } from "@/utils/trpc";
+import { interestLabel } from "@/utils/interest-labels";
 
 interface CandidateCardProps {
   userId: string;
@@ -104,7 +105,7 @@ export function CandidateCard({
           <View className="flex-row flex-wrap gap-1" testID="candidate-conversation-topics">
             {interests.map((topic) => (
               <View key={topic} className="bg-muted px-2 py-0.5 rounded-full">
-                <Text className="text-muted-foreground text-xs">{topic}</Text>
+                <Text className="text-muted-foreground text-xs">{interestLabel(topic)}</Text>
               </View>
             ))}
           </View>

--- a/apps/native/components/match-card.tsx
+++ b/apps/native/components/match-card.tsx
@@ -3,6 +3,7 @@ import { Image, Pressable, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { trpc } from "@/utils/trpc";
+import { interestLabel } from "@/utils/interest-labels";
 import {
   getLanguageCode,
   getLanguageFlag,
@@ -242,7 +243,7 @@ export function MatchCard({
                   className="font-manrope-semi text-brand-foreground"
                   style={{ fontSize: 13 }}
                 >
-                  {topic.replace(/_/g, " ")}
+                  {interestLabel(topic)}
                 </Text>
               </View>
             ))}

--- a/apps/native/components/onboarding-modal.tsx
+++ b/apps/native/components/onboarding-modal.tsx
@@ -19,6 +19,7 @@ import { LanguagePickerModal } from "@/components/language-picker-modal";
 import { authClient } from "@/lib/auth-client";
 import { queryClient, trpc } from "@/utils/trpc";
 import { pickAndEncodeProfilePicture } from "@/utils/profile-picture";
+import { INTERESTS } from "@/utils/interest-labels";
 
 const GOLD = "#F2C94C";
 const MUTED_BORDER = "#D9C9BC";
@@ -40,27 +41,6 @@ const LEVEL_BLOCKS = [
   { value: "advanced" as LearningProficiency, label: "C1–C2", sub: "Advanced" },
 ];
 
-const INTERESTS: { value: InterestValue; label: string }[] = [
-  { value: "modern_art", label: "Art" },
-  { value: "tech_coding", label: "Tech" },
-  { value: "jazz_music", label: "Music" },
-  { value: "culinary_arts", label: "Cooking" },
-  { value: "sustainability", label: "Sustainability" },
-  { value: "cinephile", label: "Film" },
-  { value: "cosmology", label: "Cosmology" },
-  { value: "photography", label: "Photography" },
-  { value: "board_games", label: "Board games" },
-  { value: "hiking_outdoors", label: "Hiking" },
-  { value: "yoga_wellness", label: "Yoga" },
-  { value: "literature", label: "Literature" },
-  { value: "entrepreneurship", label: "Startups" },
-  { value: "design_architecture", label: "Design" },
-  { value: "travel", label: "Travel" },
-  { value: "gaming", label: "Gaming" },
-  { value: "fitness_sports", label: "Football" },
-  { value: "philosophy", label: "Philosophy" },
-  { value: "theatre", label: "Theatre" },
-];
 
 const LANGUAGE_FLAGS: Record<string, string> = {
   Afrikaans: "🇿🇦", Albanian: "🇦🇱", Arabic: "🇸🇦", Armenian: "🇦🇲",

--- a/apps/native/utils/interest-labels.ts
+++ b/apps/native/utils/interest-labels.ts
@@ -1,0 +1,27 @@
+const INTERESTS = [
+  { value: "modern_art", label: "Art" },
+  { value: "tech_coding", label: "Tech" },
+  { value: "jazz_music", label: "Music" },
+  { value: "culinary_arts", label: "Cooking" },
+  { value: "sustainability", label: "Sustainability" },
+  { value: "cinephile", label: "Film" },
+  { value: "cosmology", label: "Science" },
+  { value: "photography", label: "Photography" },
+  { value: "board_games", label: "Board games" },
+  { value: "hiking_outdoors", label: "Hiking" },
+  { value: "yoga_wellness", label: "Yoga" },
+  { value: "literature", label: "Books" },
+  { value: "entrepreneurship", label: "Startups" },
+  { value: "design_architecture", label: "Design" },
+  { value: "travel", label: "Travel" },
+  { value: "gaming", label: "Gaming" },
+  { value: "fitness_sports", label: "Fitness" },
+  { value: "philosophy", label: "Philosophy" },
+  { value: "theatre", label: "Theatre" },
+] as const;
+
+export function interestLabel(value: string): string {
+  return INTERESTS.find((i) => i.value === value)?.label ?? value;
+}
+
+export { INTERESTS };


### PR DESCRIPTION
## Summary
Candidate interests were displayed as raw enum values (e.g. `tech_coding`) instead of labels (e.g. "Tech"). Extracted the INTERESTS lookup into a shared utility and applied it everywhere interests are rendered.

## Changes
- New `apps/native/utils/interest-labels.ts` — exports `INTERESTS` array and `interestLabel()` helper
- Applied `interestLabel(topic)` in `candidate-card.tsx`, `match-card.tsx`, `partner/[id].tsx`
- `profile.tsx` and `onboarding-modal.tsx` now import from shared util (removes duplication and unifies labels)

## Test plan
- [ ] Candidate cards show "Tech", "Art" etc. instead of `tech_coding`, `modern_art`
- [ ] Match deck cards show readable labels
- [ ] Partner profile screen shows readable labels
- [ ] Own profile screen unchanged
- [ ] Onboarding interest picker unchanged

Closes #317