### PR TITLE
fix(meetup): show contextual dialog when negotiation exhausts all rounds

### DIFF
--- a/apps/native/app/respond-meetup.tsx
+++ b/apps/native/app/respond-meetup.tsx
@@ -69,9 +69,17 @@ export default function RespondMeetupScreen() {
   const declineMutation = useMutation(
     trpc.meetup.declineProposal.mutationOptions({
       onSuccess: () => {
-        Alert.alert("Proposal declined", "The proposal has been declined.");
         invalidateQueries();
-        router.back();
+        if (!proposal?.canCounterPropose) {
+          Alert.alert(
+            "No match found",
+            "Oops, you couldn't find a suitable timeslot to meet. You can try to propose a meeting again.",
+            [{ text: "OK", onPress: () => router.back() }],
+          );
+        } else {
+          Alert.alert("Proposal declined", "The proposal has been declined.");
+          router.back();
+        }
       },
       onError: (err) => setError(err.message),
     }),

--- a/apps/native/hooks/use-notification-tap-handler.ts
+++ b/apps/native/hooks/use-notification-tap-handler.ts
@@ -25,6 +25,11 @@ export function useNotificationTapHandler() {
       return;
     }
 
+    if (type === "meetup_declined") {
+      router.push("/");
+      return;
+    }
+
     if (type === "message_received") {
       const conversationId = typeof data?.conversationId === "string" ? data.conversationId : undefined;
       if (conversationId) router.push(`/chat/${conversationId}`);


### PR DESCRIPTION
## Summary
When a receiver declines at the final negotiation round (round 3 of 3), both students were shown generic messages with no guidance. Fixed two gaps:
1. Receiver now sees a contextual "couldn't find a timeslot" dialog instead of the generic "proposal declined" alert
2. Proposer's `meetup_declined` notification tap now routes to home (previously fell through the handler with no navigation)

## Changes
- `respond-meetup.tsx`: `declineMutation.onSuccess` branches on `proposal.canCounterPropose` — final round shows the "No match found" dialog; non-final rounds keep the existing alert
- `use-notification-tap-handler.ts`: added `meetup_declined` case routing to `/`

## Test plan
- [ ] Round 1–2 decline: receiver sees "The proposal has been declined." + navigates back (unchanged)
- [ ] Round 3 decline: receiver sees "Oops, you couldn't find a suitable timeslot..." dialog
- [ ] Tapping a `meetup_declined` push notification navigates to home screen
- [ ] Other notification types unaffected

Closes #320