### PR TITLE
fix(onboarding): add back navigation and fix cross-list language blocking

### DIFF
--- a/apps/native/app/index.tsx
+++ b/apps/native/app/index.tsx
@@ -708,26 +708,41 @@ export default function OnboardingScreen() {
                 </>
               )}
               {step === 3 && (
-                <GoldButton
-                  onPress={handleStep3Continue}
-                  disabled={spokenLanguages.length === 0}
-                  label="Continue →"
-                />
+                <>
+                  <GoldButton
+                    onPress={handleStep3Continue}
+                    disabled={spokenLanguages.length === 0}
+                    label="Continue →"
+                  />
+                  <Pressable onPress={() => setStep(2)} className="items-center py-2.5">
+                    <Text className="font-manrope text-sm" style={{ color: "#8A7570" }}>← Back</Text>
+                  </Pressable>
+                </>
               )}
               {step === 4 && (
-                <GoldButton
-                  onPress={handleStep4Continue}
-                  disabled={learningLanguages.length === 0}
-                  label="Continue →"
-                />
+                <>
+                  <GoldButton
+                    onPress={handleStep4Continue}
+                    disabled={learningLanguages.length === 0}
+                    label="Continue →"
+                  />
+                  <Pressable onPress={() => setStep(3)} className="items-center py-2.5">
+                    <Text className="font-manrope text-sm" style={{ color: "#8A7570" }}>← Back</Text>
+                  </Pressable>
+                </>
               )}
               {step === 5 && (
-                <GoldButton
-                  onPress={handleFinish}
-                  loading={upsertMutation.isPending}
-                  disabled={interests.length < 3}
-                  label="Finish — find matches →"
-                />
+                <>
+                  <GoldButton
+                    onPress={handleFinish}
+                    loading={upsertMutation.isPending}
+                    disabled={interests.length < 3}
+                    label="Finish — find matches →"
+                  />
+                  <Pressable onPress={() => setStep(4)} className="items-center py-2.5">
+                    <Text className="font-manrope text-sm" style={{ color: "#8A7570" }}>← Back</Text>
+                  </Pressable>
+                </>
               )}
             </View>
           </View>
@@ -737,10 +752,11 @@ export default function OnboardingScreen() {
       <LanguagePickerModal
         visible={pickerTarget !== null}
         title={pickerTarget === "spoken" ? "Add spoken language" : "Add learning language"}
-        disabledLanguages={[
-          ...spokenLanguages.map((l) => l.language),
-          ...learningLanguages.map((l) => l.language),
-        ]}
+        disabledLanguages={
+          pickerTarget === "spoken"
+            ? spokenLanguages.map((l) => l.language)
+            : learningLanguages.map((l) => l.language)
+        }
         onSelect={(lang) => {
           if (pickerTarget === "spoken") {
             setSpokenLanguages((prev) => [...prev, { language: lang, proficiency: "beginner" }]);

--- a/apps/native/components/onboarding-modal.tsx
+++ b/apps/native/components/onboarding-modal.tsx
@@ -593,26 +593,41 @@ export function OnboardingModal() {
                   </>
                 )}
                 {step === 3 && (
-                  <GoldButton
-                    onPress={handleStep3Continue}
-                    disabled={spokenLanguages.length === 0}
-                    label="Continue →"
-                  />
+                  <>
+                    <GoldButton
+                      onPress={handleStep3Continue}
+                      disabled={spokenLanguages.length === 0}
+                      label="Continue →"
+                    />
+                    <Pressable onPress={() => setStep(2)} className="items-center py-2.5">
+                      <Text className="font-manrope text-sm" style={{ color: "#8A7570" }}>← Back</Text>
+                    </Pressable>
+                  </>
                 )}
                 {step === 4 && (
-                  <GoldButton
-                    onPress={handleStep4Continue}
-                    disabled={learningLanguages.length === 0}
-                    label="Continue →"
-                  />
+                  <>
+                    <GoldButton
+                      onPress={handleStep4Continue}
+                      disabled={learningLanguages.length === 0}
+                      label="Continue →"
+                    />
+                    <Pressable onPress={() => setStep(3)} className="items-center py-2.5">
+                      <Text className="font-manrope text-sm" style={{ color: "#8A7570" }}>← Back</Text>
+                    </Pressable>
+                  </>
                 )}
                 {step === 5 && (
-                  <GoldButton
-                    onPress={handleFinish}
-                    loading={upsertMutation.isPending}
-                    disabled={interests.length < 3}
-                    label="Finish — find matches →"
-                  />
+                  <>
+                    <GoldButton
+                      onPress={handleFinish}
+                      loading={upsertMutation.isPending}
+                      disabled={interests.length < 3}
+                      label="Finish — find matches →"
+                    />
+                    <Pressable onPress={() => setStep(4)} className="items-center py-2.5">
+                      <Text className="font-manrope text-sm" style={{ color: "#8A7570" }}>← Back</Text>
+                    </Pressable>
+                  </>
                 )}
               </View>
             </View>
@@ -623,10 +638,11 @@ export function OnboardingModal() {
       <LanguagePickerModal
         visible={pickerTarget !== null}
         title={pickerTarget === "spoken" ? "Add spoken language" : "Add learning language"}
-        disabledLanguages={[
-          ...spokenLanguages.map((l) => l.language),
-          ...learningLanguages.map((l) => l.language),
-        ]}
+        disabledLanguages={
+          pickerTarget === "spoken"
+            ? spokenLanguages.map((l) => l.language)
+            : learningLanguages.map((l) => l.language)
+        }
         onSelect={(lang) => {
           if (pickerTarget === "spoken") {
             setSpokenLanguages((p) => [...p, { language: lang, proficiency: "beginner" }]);


### PR DESCRIPTION
## Summary
Two onboarding issues fixed:
1. No back navigation existed — once a student moved forward, there was no way to correct earlier selections
2. Spoken languages were incorrectly disabled in the learning language picker, blocking students who wanted to learn a language they'd also listed as spoken

## Changes
- `onboarding-modal.tsx` + `index.tsx`: added "← Back" `Pressable` for steps 3, 4, 5
- Fixed `disabledLanguages` to pass only same-list languages to each picker (spoken picker disables already-added spoken languages only; learning picker disables already-added learning languages only)

## Test plan
- [ ] Step 3 (spoken languages): "← Back" navigates to step 2
- [ ] Step 4 (learning languages): "← Back" navigates to step 3 — spoken language now selectable
- [ ] Step 5 (interests): "← Back" navigates to step 4
- [ ] In-progress state preserved when navigating backwards (spoken/learning/interest selections not lost)
- [ ] Final "Continue" / "Finish" still validates and submits correctly
- [ ] Profile editing screen `LanguagePickerModal` unaffected

Closes #310