### PR TITLE
fix(meetup): raise counter-proposal round limit from 3 to 5

### DIFF
--- a/apps/native/__tests__/respond-meetup.test.tsx
+++ b/apps/native/__tests__/respond-meetup.test.tsx
@@ -1,6 +1,6 @@
 /**
  * Tests for task #71 — Build proposal response UI (accept / counter-propose / decline)
- * Tests for task #73 — Enforce max 3 counter-proposal rounds — remove counter option at round 3
+ * Tests for task #73 — Enforce max 5 counter-proposal rounds — remove counter option at round 5
  */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react-native";
@@ -137,11 +137,11 @@ describe("#71 — Proposal response UI", () => {
   });
 });
 
-// ─── Task #73: round 3 hides counter-propose ──────────────────────────────────
+// ─── Task #73: round 5 hides counter-propose ──────────────────────────────────
 
 describe("#73 — Round enforcement in UI", () => {
-  it("hides Counter-propose action at round 3", async () => {
-    mockProposalData = { ...baseProposal, round: 3, canCounterPropose: false };
+  it("hides Counter-propose action at round 5", async () => {
+    mockProposalData = { ...baseProposal, round: 5, canCounterPropose: false };
 
     renderWithQuery(<RespondMeetupScreen />);
 
@@ -153,8 +153,8 @@ describe("#73 — Round enforcement in UI", () => {
     expect(screen.getByTestId("decline-btn")).toBeTruthy();
   });
 
-  it("shows Counter-propose action at round 2", async () => {
-    mockProposalData = { ...baseProposal, round: 2, canCounterPropose: true };
+  it("shows Counter-propose action at round 4", async () => {
+    mockProposalData = { ...baseProposal, round: 4, canCounterPropose: true };
 
     renderWithQuery(<RespondMeetupScreen />);
 

--- a/apps/native/app/respond-meetup.tsx
+++ b/apps/native/app/respond-meetup.tsx
@@ -152,7 +152,7 @@ export default function RespondMeetupScreen() {
         <ScrollView contentContainerStyle={{ padding: 16 }}>
           <Text className="text-foreground text-2xl font-manrope-bold mb-1">Counter-propose</Text>
           <Text testID="counter-round-label" className="text-muted-foreground font-manrope text-sm mb-6">
-            Round {proposal.round + 1} of 3
+            Round {proposal.round + 1} of 5
           </Text>
 
           <Text className="font-manrope-semi text-[11px] tracking-[2px] uppercase mb-2" style={{ color: "#8A7570" }}>Location</Text>
@@ -265,7 +265,7 @@ export default function RespondMeetupScreen() {
       <ScrollView contentContainerStyle={{ padding: 16 }}>
         <Text className="text-foreground text-2xl font-manrope-bold mb-1">Meetup proposal</Text>
         <Text testID="round-label" className="text-muted-foreground font-manrope text-sm mb-6">
-          Round {proposal.round} of 3
+          Round {proposal.round} of 5
         </Text>
 
         <View className="bg-card border border-border rounded-2xl p-4 mb-6">

--- a/packages/api/src/contexts/scheduling/__tests__/meetup-rounds.test.ts
+++ b/packages/api/src/contexts/scheduling/__tests__/meetup-rounds.test.ts
@@ -1,9 +1,9 @@
 /**
- * Tests for task #73 — Enforce max 3 counter-proposal rounds
+ * Tests for task #73 — Enforce max counter-proposal rounds
  *
  * Covers:
  *   - canCounterPropose flag correctly derived from round number
- *   - Counter-propose is only allowed when round < 3
+ *   - Counter-propose is only allowed when round < 5
  */
 import { describe, it, expect } from "bun:test";
 
@@ -18,11 +18,15 @@ describe("#73 — round enforcement", () => {
     expect(canCounterPropose(2)).toBe(true);
   });
 
-  it("blocks counter-propose at round 3 (maximum reached)", () => {
-    expect(canCounterPropose(3)).toBe(false);
+  it("allows counter-propose at round 4", () => {
+    expect(canCounterPropose(4)).toBe(true);
   });
 
-  it("blocks counter-propose beyond round 3", () => {
-    expect(canCounterPropose(4)).toBe(false);
+  it("blocks counter-propose at round 5 (maximum reached)", () => {
+    expect(canCounterPropose(5)).toBe(false);
+  });
+
+  it("blocks counter-propose beyond round 5", () => {
+    expect(canCounterPropose(6)).toBe(false);
   });
 });

--- a/packages/api/src/contexts/scheduling/meetup-utils.ts
+++ b/packages/api/src/contexts/scheduling/meetup-utils.ts
@@ -26,9 +26,9 @@ export function isRescheduleNoOp(
   );
 }
 
-/** Counter-proposals are capped at round 3. */
+/** Counter-proposals are capped at round 5. */
 export function canCounterPropose(round: number): boolean {
-  return round < 3;
+  return round < 5;
 }
 
 export type AttendanceOutcome = "completed" | "not_attended" | "pending";

--- a/packages/api/src/contexts/scheduling/meetup.ts
+++ b/packages/api/src/contexts/scheduling/meetup.ts
@@ -268,7 +268,7 @@ export const meetupRouter = router({
         });
       }
 
-      // #73 — Reject counter-propose when round is already at 3
+      // #73 — Reject counter-propose when round is already at 5
       if (!canCounterPropose(existing.meetup.round)) {
         throw new TRPCError({
           code: "BAD_REQUEST",
@@ -565,7 +565,7 @@ export const meetupRouter = router({
     return {
       meetupId: row.meetup.id,
       round: row.meetup.round,
-      canCounterPropose: row.meetup.round < 3,
+      canCounterPropose: row.meetup.round < 5,
       venue: row.venue,
       date: row.meetup.date,
       time: row.meetup.time,


### PR DESCRIPTION
## Summary

- Raises the max counter-proposal round limit from 3 to 5 everywhere
- Server now rejects counter-proposals at round 5 (via `canCounterPropose` utility)
- Client UI hides the counter-propose button at round 5 and shows "X of 5" round display
- Tests updated to assert the new limit

## Test plan

- [ ] `bun test packages/api/src/contexts/scheduling/__tests__/meetup-rounds.test.ts` — all 5 pass
- [ ] `respond-meetup.test.tsx` updated: hides button at round 5, shows at round 4
- [ ] Server rejects counter-propose call when `round >= 5` with `BAD_REQUEST`

Closes #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)