### PR TITLE
fix(matching): port Dutch/English bridge rule to bounded-context router

### DIFF
--- a/packages/api/src/contexts/matching/__tests__/matching-scoring.test.ts
+++ b/packages/api/src/contexts/matching/__tests__/matching-scoring.test.ts
@@ -16,9 +16,34 @@ import {
   computeInterestScore,
   computeProximityScore,
   computeCompositeScore,
+  computeBridgeRuleEligibility,
   scoreCandidates,
   type CandidateProfile,
 } from "../matching-utils";
+
+// ── computeBridgeRuleEligibility ──────────────────────────────────────────────
+
+describe("computeBridgeRuleEligibility", () => {
+  it("returns true when partner speaks Dutch and is learning Dutch", () => {
+    expect(computeBridgeRuleEligibility(["Dutch"], ["Dutch"])).toBe(true);
+  });
+
+  it("returns true when partner speaks Dutch and is learning English", () => {
+    expect(computeBridgeRuleEligibility(["Dutch"], ["English"])).toBe(true);
+  });
+
+  it("returns false when partner does not speak Dutch", () => {
+    expect(computeBridgeRuleEligibility(["English"], ["Dutch"])).toBe(false);
+  });
+
+  it("returns false when partner speaks Dutch but learns neither Dutch nor English", () => {
+    expect(computeBridgeRuleEligibility(["Dutch"], ["Spanish"])).toBe(false);
+  });
+
+  it("returns false when lists are empty", () => {
+    expect(computeBridgeRuleEligibility([], [])).toBe(false);
+  });
+});
 
 // ── computeLanguageScore ──────────────────────────────────────────────────────
 
@@ -170,15 +195,15 @@ describe("scoreCandidates", () => {
       spokenLanguages: [{ language: "English", proficiency: "C1" }],
       learningLanguages: ["Dutch"],
     });
-    const noMatch = makeCandidate({
-      userId: "no-match",
-      spokenLanguages: [{ language: "Spanish", proficiency: "B2" }],
+    const partialMatch = makeCandidate({
+      userId: "partial-match",
+      spokenLanguages: [{ language: "English", proficiency: "B2" }],
       learningLanguages: ["French"],
     });
 
-    const result = scoreCandidates(ME, [noMatch, perfect]);
+    const result = scoreCandidates(ME, [partialMatch, perfect]);
     expect(result[0]!.userId).toBe("perfect");
-    expect(result[1]!.userId).toBe("no-match");
+    expect(result[1]!.userId).toBe("partial-match");
   });
 
   it("excludes candidates who don't speak the filter language", () => {
@@ -224,6 +249,30 @@ describe("scoreCandidates", () => {
     expect(result[0]!.distance).toBeNull();
   });
 
+  it("surfaces bridge-eligible candidate with langScore 0 at effectiveLangScore 0.5", () => {
+    const bridgeCandidate = makeCandidate({
+      userId: "bridge",
+      spokenLanguages: [{ language: "Dutch", proficiency: "C2" }],
+      learningLanguages: ["English"],
+    });
+
+    const result = scoreCandidates(ME, [bridgeCandidate]);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.userId).toBe("bridge");
+    expect(result[0]!.score).toBeCloseTo(0.5 * 0.5);
+  });
+
+  it("excludes candidate with zero langScore who is not bridge-eligible", () => {
+    const noMatch = makeCandidate({
+      userId: "no-match",
+      spokenLanguages: [{ language: "Spanish", proficiency: "B2" }],
+      learningLanguages: ["French"],
+    });
+
+    const result = scoreCandidates(ME, [noMatch]);
+    expect(result).toHaveLength(0);
+  });
+
   it("near_you filter boosts proximity weight over language weight", () => {
     const me = { ...ME, latitude: 51.45, longitude: 5.45 };
     // languageMatch: perfect language, far away
@@ -234,10 +283,10 @@ describe("scoreCandidates", () => {
       latitude: 51.45 + 0.4, // ~44 km away
       longitude: 5.45,
     });
-    // nearbyMatch: imperfect language, very close
+    // nearbyMatch: partial language (one direction only), very close
     const nearbyMatch = makeCandidate({
       userId: "nearby-match",
-      spokenLanguages: [{ language: "Spanish", proficiency: "B2" }],
+      spokenLanguages: [{ language: "English", proficiency: "B2" }],
       learningLanguages: ["French"],
       latitude: 51.451, // < 1 km away
       longitude: 5.451,

--- a/packages/api/src/contexts/matching/matching-utils.ts
+++ b/packages/api/src/contexts/matching/matching-utils.ts
@@ -71,6 +71,16 @@ export function computeCompositeScore(
   return languageScore * 0.5 + interestScore * 0.3 + proximityScore * 0.2;
 }
 
+export function computeBridgeRuleEligibility(
+  partnerSpoken: string[],
+  partnerLearning: string[],
+): boolean {
+  return (
+    partnerSpoken.includes("Dutch") &&
+    (partnerLearning.includes("Dutch") || partnerLearning.includes("English"))
+  );
+}
+
 /**
  * Extract excluded user IDs from active match requests involving the given user.
  * Bidirectional: a candidate who sent a request to the user is also excluded.
@@ -129,12 +139,18 @@ export function scoreCandidates(
       if (!candidate.spokenLanguages.some((l) => l.language === filter.language)) continue;
     }
 
+    const partnerSpoken = candidate.spokenLanguages.map((l) => l.language);
     const langScore = computeLanguageScore(
       me.spoken,
       me.learning,
-      candidate.spokenLanguages.map((l) => l.language),
+      partnerSpoken,
       candidate.learningLanguages,
     );
+
+    const bridgeEligible = computeBridgeRuleEligibility(partnerSpoken, candidate.learningLanguages);
+    if (langScore === 0 && !bridgeEligible) continue;
+    const effectiveLangScore = langScore > 0 ? langScore : 0.5;
+
     const intScore = computeInterestScore(me.interests, candidate.interests);
 
     let distanceKm: number | null = null;
@@ -152,7 +168,7 @@ export function scoreCandidates(
     scored.push({
       ...candidate,
       distance: distanceKm != null ? Math.round(distanceKm * 10) / 10 : null,
-      score: computeCompositeScore(langScore, intScore, proxScore, filter?.mode),
+      score: computeCompositeScore(effectiveLangScore, intScore, proxScore, filter?.mode),
     });
   }
 


### PR DESCRIPTION
## Summary

- Adds `computeBridgeRuleEligibility` to `matching-utils.ts`: a candidate is bridge-eligible if they speak Dutch AND are learning Dutch or English
- Applies bridge-fallback in `scoreCandidates`: candidates with `langScore === 0` who are bridge-eligible are surfaced with `effectiveLangScore = 0.5` instead of being silently excluded
- Adds unit tests for `computeBridgeRuleEligibility` and the bridge-fallback path in `scoreCandidates`; updates existing tests that assumed zero-overlap candidates were included

## Test plan

- [ ] `bun test packages/api/src/contexts/matching` — all 39 tests pass
- [ ] Verify bridge-eligible candidate (speaks Dutch, learns English) appears in discover results when user speaks Dutch and learns English

Closes #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)