### PR TITLE
fix: first suggested time stays highlighted after selecting another (#342)

### DIFF
--- a/apps/native/app/propose-meetup.tsx
+++ b/apps/native/app/propose-meetup.tsx
@@ -307,7 +307,7 @@ export default function ProposeMeetupScreen() {
                 activeOpacity={0.85}
                 className="rounded-2xl px-5 py-4 flex-row items-center"
                 style={{
-                  backgroundColor: selected ? GOLD : isTop ? GOLD_TINT : "#FFFFFF",
+                  backgroundColor: selected ? GOLD : "#FFFFFF",
                   borderWidth: 1.5,
                   borderColor: selected ? GOLD : MUTED_BORDER,
                 }}


### PR DESCRIPTION
Removes the `isTop` condition from the time-option background color. The first suggested time always rendered gold-tinted regardless of selection state — after picking a different option, both appeared highlighted simultaneously.

Closes #342