### PR TITLE
fix: hero-confirmed venue overflow, reschedule label, and accept button (#336 #337 #338)

### DIFF
--- a/apps/native/app/(tabs)/home.tsx
+++ b/apps/native/app/(tabs)/home.tsx
@@ -1,9 +1,9 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
 import { Image, Pressable, Text, View } from "react-native";
 
 import { Container } from "@/components/container";
-import { trpc } from "@/utils/trpc";
+import { trpc, queryClient } from "@/utils/trpc";
 import { HeroNoMeetup } from "@/components/home/hero-nomeetup";
 import { HeroMatchFound } from "@/components/home/hero-matchfound";
 import { HeroWaiting } from "@/components/home/hero-waiting";
@@ -32,6 +32,12 @@ export default function HomeScreen() {
   const initial = (name || "?").charAt(0).toUpperCase();
 
   const incomingRequestsQuery = useQuery(trpc.matching.getIncomingRequests.queryOptions());
+
+  const acceptRescheduleMutation = useMutation(trpc.meetup.acceptReschedule.mutationOptions({
+    onSuccess: () => {
+      void queryClient.invalidateQueries(trpc.meetup.getConfirmed.queryOptions());
+    },
+  }));
 
   const { hero, secondaries } = resolveHomeState({
     confirmed: confirmedQuery.data ?? [],
@@ -87,6 +93,9 @@ export default function HomeScreen() {
           <HeroConfirmed
             meetup={hero.meetup}
             onReschedule={() => router.push("/(tabs)/confirmed-meetups")}
+            onAcceptReschedule={() =>
+              acceptRescheduleMutation.mutate({ meetupId: hero.meetup.meetupId })
+            }
           />
         );
       case "waiting":

--- a/apps/native/components/home/hero-confirmed.tsx
+++ b/apps/native/components/home/hero-confirmed.tsx
@@ -7,6 +7,7 @@ import type { ConfirmedMeetup } from "./home-state";
 type Props = {
   meetup: ConfirmedMeetup;
   onReschedule: () => void;
+  onAcceptReschedule?: () => void;
 };
 
 function openDirections(venueName: string) {
@@ -19,15 +20,17 @@ function openDirections(venueName: string) {
   void Linking.openURL(url);
 }
 
-export function HeroConfirmed({ meetup, onReschedule }: Props) {
+export function HeroConfirmed({ meetup, onReschedule, onAcceptReschedule }: Props) {
   const initial = (meetup.partner.name || "?").charAt(0).toUpperCase();
   const dayName = formatDayFull(meetup.date).toUpperCase();
 
   const rescheduleLabel = meetup.reschedulePending
     ? meetup.rescheduleIsFromMe
       ? "Reschedule pending…"
-      : "Partner proposed reschedule"
+      : "Answer"
     : "Reschedule";
+
+  const partnerProposedReschedule = meetup.reschedulePending && !meetup.rescheduleIsFromMe;
 
   return (
     <View>
@@ -75,7 +78,7 @@ export function HeroConfirmed({ meetup, onReschedule }: Props) {
         >
           {dayName}
         </Text>
-        <View className="flex-row items-end justify-between mt-1">
+        <View className="mt-1">
           <Text
             testID="hero-confirmed-time"
             className="text-brand-foreground font-jakarta"
@@ -83,14 +86,12 @@ export function HeroConfirmed({ meetup, onReschedule }: Props) {
           >
             {meetup.time}
           </Text>
-          <View className="items-end mb-2">
-            <Text
-              className="text-brand-foreground font-manrope-bold"
-              style={{ fontSize: 14 }}
-            >
-              {meetup.venue.name}
-            </Text>
-          </View>
+          <Text
+            className="text-brand-foreground font-manrope-bold"
+            style={{ fontSize: 14 }}
+          >
+            {meetup.venue.name}
+          </Text>
         </View>
 
         <View className="flex-row gap-3 mt-5">
@@ -104,16 +105,28 @@ export function HeroConfirmed({ meetup, onReschedule }: Props) {
               Directions
             </Text>
           </Pressable>
+          {partnerProposedReschedule && onAcceptReschedule && (
+            <Pressable
+              testID="accept-reschedule-btn"
+              onPress={onAcceptReschedule}
+              className="flex-1 items-center justify-center rounded-full"
+              style={{ height: 52, backgroundColor: "#1A1A1A" }}
+            >
+              <Text className="font-manrope-bold" style={{ fontSize: 14, color: GOLD }}>
+                Accept
+              </Text>
+            </Pressable>
+          )}
           <Pressable
             testID="reschedule-btn"
             onPress={onReschedule}
-            disabled={meetup.reschedulePending}
+            disabled={meetup.rescheduleIsFromMe && meetup.reschedulePending}
             className="flex-1 items-center justify-center rounded-full"
             style={{
               height: 52,
               borderWidth: 1.5,
               borderColor: "#1A1A1A",
-              opacity: meetup.reschedulePending ? 0.6 : 1,
+              opacity: meetup.rescheduleIsFromMe && meetup.reschedulePending ? 0.6 : 1,
             }}
           >
             <Text className="font-manrope-bold" style={{ fontSize: 14 }}>


### PR DESCRIPTION
Three visual/interaction bugs in `hero-confirmed.tsx`:

- **#336** — Venue name was in a `flex-row` alongside the time, causing long names to overflow. Changed to `flex-col` so venue name always renders below the time within the card.
- **#337** — "Partner proposed reschedule" label was too long and overflowed the button; button was also disabled. Shortened to "Answer" and enabled the button when the partner is the reschedule proposer.
- **#338** — No accept action was available when a partner proposed a reschedule. Added an "Accept" button (visible only when `reschedulePending && !rescheduleIsFromMe`) wired to the `acceptReschedule` tRPC mutation in `home.tsx`.

Closes #336
Closes #337
Closes #338