### PR TITLE
fix: partner disappears and confirmation popup auto-dismisses in respond-meetup (#334 #335)

### DIFF
--- a/apps/native/app/respond-meetup.tsx
+++ b/apps/native/app/respond-meetup.tsx
@@ -39,6 +39,7 @@ export default function RespondMeetupScreen() {
     void queryClient.invalidateQueries(trpc.meetup.getPendingIncoming.queryOptions());
     void queryClient.invalidateQueries(trpc.meetup.list.queryOptions({ status: "pending" }));
     void queryClient.invalidateQueries(trpc.meetup.pendingCount.queryOptions());
+    void queryClient.invalidateQueries(trpc.matching.getMyMatches.queryOptions());
   }
 
   const acceptMutation = useMutation(
@@ -92,6 +93,18 @@ export default function RespondMeetupScreen() {
           <Spinner />
         </View>
       </Container>
+    );
+  }
+
+  if (confirmed) {
+    return (
+      <MeetupConfirmedModal
+        visible
+        venueName={confirmed.venueName}
+        date={confirmed.date}
+        time={confirmed.time}
+        onDismiss={() => { setConfirmed(null); router.back(); }}
+      />
     );
   }
 
@@ -251,16 +264,6 @@ export default function RespondMeetupScreen() {
   }
 
   return (
-    <>
-      {confirmed && (
-        <MeetupConfirmedModal
-          visible
-          venueName={confirmed.venueName}
-          date={confirmed.date}
-          time={confirmed.time}
-          onDismiss={() => { setConfirmed(null); router.back(); }}
-        />
-      )}
     <Container>
       <ScrollView contentContainerStyle={{ padding: 16 }}>
         <Text className="text-foreground text-2xl font-manrope-bold mb-1">Meetup proposal</Text>
@@ -340,6 +343,5 @@ export default function RespondMeetupScreen() {
         </View>
       </ScrollView>
     </Container>
-    </>
   );
 }


### PR DESCRIPTION
Two logic bugs in `respond-meetup.tsx`:

- **#334** — After all 5 counter-proposal rounds are exhausted and the final proposal is declined, `getMyMatches` was not invalidated. The partner vanished from the home screen because the cached matches still excluded them (active meetup filter). Added `getMyMatches` to `invalidateQueries()`.
- **#335** — Accepting a proposal showed the `MeetupConfirmedModal` briefly then dismissed it. Root cause: `invalidateQueries()` caused `proposalQuery` to refetch and return null, hitting the `!proposal` early-return guard before the user could see the modal. Fixed by adding a `confirmed` check before the proposal guard — the modal now renders via early return and stays visible until the user taps Okay.

Closes #334
Closes #335