### PR TITLE
fix: foreground push notification banners suppressed (#348)

### DIFF
--- a/apps/native/app/_layout.tsx
+++ b/apps/native/app/_layout.tsx
@@ -37,8 +37,21 @@ import { OnboardingModal } from "@/components/onboarding-modal"; // edge-case: c
 
 SplashScreen.preventAutoHideAsync();
 
+const CUSTOM_MODAL_TYPES = new Set(["match_accepted", "meetup_confirmed"]);
+
 function useNotificationCategories() {
   useEffect(() => {
+    Notifications.setNotificationHandler({
+      handleNotification: async (notification) => {
+        const type = notification.request.content.data?.type;
+        const hasCustomModal = typeof type === "string" && CUSTOM_MODAL_TYPES.has(type);
+        return {
+          shouldShowAlert: !hasCustomModal,
+          shouldPlaySound: !hasCustomModal,
+          shouldSetBadge: true,
+        };
+      },
+    });
     void Notifications.setNotificationCategoryAsync("match_accepted", [
       { identifier: "connect_now", buttonTitle: "Connect Now" },
     ]);

--- a/apps/native/lib/notifications.ts
+++ b/apps/native/lib/notifications.ts
@@ -11,8 +11,15 @@ type NotificationReceived = {
   request: { content: { data?: Record<string, unknown> | null; body?: string | null } };
 };
 
+type NotificationHandlerResponse = {
+  shouldShowAlert: boolean;
+  shouldPlaySound: boolean;
+  shouldSetBadge: boolean;
+};
+
 type NotificationsApi = {
   setNotificationCategoryAsync: (id: string, actions: Array<{ identifier: string; buttonTitle: string }>) => Promise<unknown>;
+  setNotificationHandler: (handler: { handleNotification: (n: NotificationReceived) => Promise<NotificationHandlerResponse> } | null) => void;
   requestPermissionsAsync: () => Promise<{ status: string }>;
   getExpoPushTokenAsync: (opts?: { projectId?: string }) => Promise<{ data: string }>;
   addNotificationReceivedListener: (cb: (n: NotificationReceived) => void) => Subscription;
@@ -26,6 +33,7 @@ const noopSubscription: Subscription = { remove: () => {} };
 
 const stub: NotificationsApi = {
   setNotificationCategoryAsync: async () => undefined,
+  setNotificationHandler: () => {},
   requestPermissionsAsync: async () => ({ status: "denied" }),
   getExpoPushTokenAsync: async () => {
     throw new Error("Push notifications unavailable in Expo Go on Android");
@@ -41,6 +49,7 @@ const impl: NotificationsApi = isExpoGoAndroid
 
 export const {
   setNotificationCategoryAsync,
+  setNotificationHandler,
   requestPermissionsAsync,
   getExpoPushTokenAsync,
   addNotificationReceivedListener,


### PR DESCRIPTION
Expo suppresses notification banners when the app is in the foreground if no `setNotificationHandler` is configured. The wrapper `lib/notifications.ts` didn't expose it, so there was no way to configure it.

Changes:
- Added `setNotificationHandler` to `NotificationsApi` type + stub in `lib/notifications.ts`
- Configured it in `_layout.tsx` to show banners for all notification types
- For `match_accepted` and `meetup_confirmed`, suppresses the OS banner (`shouldShowAlert: false`) since those types already trigger custom in-app modals via `addNotificationReceivedListener`

Closes #348