### PR TITLE
fix: matched partners not rendered on home screen (#339)

### DIFF
--- a/apps/native/app/(tabs)/home.tsx
+++ b/apps/native/app/(tabs)/home.tsx
@@ -192,6 +192,55 @@ export default function HomeScreen() {
           </View>
         )}
 
+        {(matchesQuery.data ?? []).length > 0 && (
+          <View className="mt-8">
+            <Text
+              className="font-manrope-semi tracking-widest text-brand-muted-foreground"
+              style={{ fontSize: 12 }}
+            >
+              MY MATCHES
+            </Text>
+            <View className="flex-row flex-wrap gap-4 mt-3">
+              {(matchesQuery.data ?? []).map((match) => (
+                <Pressable
+                  key={match.matchId}
+                  testID="matched-partner-card"
+                  onPress={() =>
+                    router.push({
+                      pathname: "/partner/[id]",
+                      params: { id: match.partnerId },
+                    })
+                  }
+                  className="items-center active:opacity-70"
+                >
+                  {match.partnerPhotoUrl ? (
+                    <Image
+                      source={{ uri: match.partnerPhotoUrl }}
+                      style={{ width: 56, height: 56, borderRadius: 28, borderWidth: 2, borderColor: "#D9C9BC" }}
+                    />
+                  ) : (
+                    <View
+                      className="items-center justify-center rounded-full"
+                      style={{ width: 56, height: 56, backgroundColor: GOLD, borderWidth: 2, borderColor: "#D9C9BC" }}
+                    >
+                      <Text className="font-manrope-bold" style={{ fontSize: 20 }}>
+                        {(match.partnerName || "?").charAt(0).toUpperCase()}
+                      </Text>
+                    </View>
+                  )}
+                  <Text
+                    className="text-brand-foreground font-manrope-semi mt-1"
+                    style={{ fontSize: 11 }}
+                    numberOfLines={1}
+                  >
+                    {match.partnerName}
+                  </Text>
+                </Pressable>
+              ))}
+            </View>
+          </View>
+        )}
+
         {(incomingRequestsQuery.data ?? []).length > 0 && (
           <View className="mt-8">
             <Text


### PR DESCRIPTION
`matchesQuery` was already fetched on the home screen but its data was never rendered. Added a "MY MATCHES" section below the hero showing avatar + name chips for each matched partner. Tapping navigates to `/partner/[id]`.

Note: `getMyMatches` excludes partners with an active pending/confirmed meetup — this is an existing limitation of the query, documented in the issue.

Closes #339