### PR TITLE
fix: warm palette for partner profile, respond-meetup, and counter-propose UI (#343 #344 #345)

### DIFF
--- a/apps/native/app/(tabs)/profile.tsx
+++ b/apps/native/app/(tabs)/profile.tsx
@@ -17,25 +17,13 @@ import { authClient } from "@/lib/auth-client";
 import { queryClient, trpc } from "@/utils/trpc";
 import { pickAndEncodeProfilePicture } from "@/utils/profile-picture";
 import { INTERESTS, interestLabel } from "@/utils/interest-labels";
+import { getLanguageFlag } from "@/utils/language-flags";
 
 const GOLD = "#F2C94C";
 const BORDER = "#D9C9BC";
 const MIN_INTERESTS = 3;
 const MAX_INTERESTS = 7;
 
-const LANGUAGE_FLAGS: Record<string, string> = {
-  Afrikaans: "🇿🇦", Arabic: "🇸🇦", Bengali: "🇧🇩", Bulgarian: "🇧🇬",
-  Catalan: "🏳️", Chinese: "🇨🇳", Croatian: "🇭🇷", Czech: "🇨🇿",
-  Danish: "🇩🇰", Dutch: "🇳🇱", English: "🇬🇧", Estonian: "🇪🇪",
-  Finnish: "🇫🇮", French: "🇫🇷", German: "🇩🇪", Greek: "🇬🇷",
-  Hebrew: "🇮🇱", Hindi: "🇮🇳", Hungarian: "🇭🇺", Indonesian: "🇮🇩",
-  Italian: "🇮🇹", Japanese: "🇯🇵", Korean: "🇰🇷", Latvian: "🇱🇻",
-  Lithuanian: "🇱🇹", Malay: "🇲🇾", Norwegian: "🇳🇴", Persian: "🇮🇷",
-  Polish: "🇵🇱", Portuguese: "🇵🇹", Romanian: "🇷🇴", Russian: "🇷🇺",
-  Serbian: "🇷🇸", Slovak: "🇸🇰", Slovenian: "🇸🇮", Spanish: "🇪🇸",
-  Swedish: "🇸🇪", Thai: "🇹🇭", Turkish: "🇹🇷", Ukrainian: "🇺🇦",
-  Vietnamese: "🇻🇳",
-};
 
 const LEVEL_BLOCKS = [
   { value: "beginner" as const, label: "A1–A2", sub: "Beginner" },
@@ -282,7 +270,7 @@ export default function ProfileScreen() {
                   <View className="flex-row items-center justify-between">
                     <View className="flex-row items-center gap-2.5">
                       <Text style={{ fontSize: 24 }}>
-                        {LANGUAGE_FLAGS[sl.language] ?? "🌐"}
+                        {getLanguageFlag(sl.language)}
                       </Text>
                       <Text className="font-manrope-bold text-[15px] text-foreground">
                         {sl.language}
@@ -375,7 +363,7 @@ export default function ProfileScreen() {
                   <View className="flex-row items-center justify-between">
                     <View className="flex-row items-center gap-2.5">
                       <Text style={{ fontSize: 24 }}>
-                        {LANGUAGE_FLAGS[ll.language] ?? "🌐"}
+                        {getLanguageFlag(ll.language)}
                       </Text>
                       <Text className="font-manrope-bold text-[15px] text-foreground">
                         {ll.language}

--- a/apps/native/app/partner/[id].tsx
+++ b/apps/native/app/partner/[id].tsx
@@ -9,6 +9,34 @@ import { MatchCelebrationModal } from "@/components/match-celebration-modal";
 import { queryClient, trpc } from "@/utils/trpc";
 import { interestLabel } from "@/utils/interest-labels";
 
+const GOLD = "#F2C94C";
+const BORDER = "#D9C9BC";
+
+const LANGUAGE_FLAGS: Record<string, string> = {
+  Afrikaans: "🇿🇦", Arabic: "🇸🇦", Bengali: "🇧🇩", Bulgarian: "🇧🇬",
+  Catalan: "🏳️", Chinese: "🇨🇳", Croatian: "🇭🇷", Czech: "🇨🇿",
+  Danish: "🇩🇰", Dutch: "🇳🇱", English: "🇬🇧", Estonian: "🇪🇪",
+  Finnish: "🇫🇮", French: "🇫🇷", German: "🇩🇪", Greek: "🇬🇷",
+  Hebrew: "🇮🇱", Hindi: "🇮🇳", Hungarian: "🇭🇺", Indonesian: "🇮🇩",
+  Italian: "🇮🇹", Japanese: "🇯🇵", Korean: "🇰🇷", Latvian: "🇱🇻",
+  Lithuanian: "🇱🇹", Malay: "🇲🇾", Norwegian: "🇳🇴", Persian: "🇮🇷",
+  Polish: "🇵🇱", Portuguese: "🇵🇹", Romanian: "🇷🇴", Russian: "🇷🇺",
+  Serbian: "🇷🇸", Slovak: "🇸🇰", Slovenian: "🇸🇮", Spanish: "🇪🇸",
+  Swedish: "🇸🇪", Thai: "🇹🇭", Turkish: "🇹🇷", Ukrainian: "🇺🇦",
+  Vietnamese: "🇻🇳",
+};
+
+function SectionLabel({ children }: { children: string }) {
+  return (
+    <Text
+      className="font-manrope-semi text-[11px] tracking-[2px] uppercase mb-2"
+      style={{ color: "#8A7570" }}
+    >
+      {children}
+    </Text>
+  );
+}
+
 export default function PartnerProfileScreen() {
   const { id, matchRequestId } = useLocalSearchParams<{ id: string; matchRequestId?: string }>();
   const router = useRouter();
@@ -107,22 +135,26 @@ export default function PartnerProfileScreen() {
       <ScrollView contentContainerStyle={{ padding: 16 }}>
         {/* Header: photo + name */}
         <View className="items-center mb-6">
-          {profile.image ? (
-            <Image
-              testID="profile-photo"
-              source={{ uri: profile.image }}
-              className="w-24 h-24 rounded-full mb-3"
-            />
-          ) : (
-            <View
-              testID="profile-photo-placeholder"
-              className="w-24 h-24 rounded-full bg-muted items-center justify-center mb-3"
-            >
-              <Text className="text-muted-foreground text-3xl font-semibold">
-                {profile.name.charAt(0).toUpperCase()}
-              </Text>
-            </View>
-          )}
+          <View
+            style={{ borderWidth: 2.5, borderColor: GOLD, borderRadius: 52, padding: 2, marginBottom: 12 }}
+          >
+            {profile.image ? (
+              <Image
+                testID="profile-photo"
+                source={{ uri: profile.image }}
+                style={{ width: 96, height: 96, borderRadius: 48 }}
+              />
+            ) : (
+              <View
+                testID="profile-photo-placeholder"
+                style={{ width: 96, height: 96, borderRadius: 48, backgroundColor: "#E2C5BD", alignItems: "center", justifyContent: "center" }}
+              >
+                <Text className="text-3xl font-jakarta" style={{ color: "#2C1810" }}>
+                  {profile.name.charAt(0).toUpperCase()}
+                </Text>
+              </View>
+            )}
+          </View>
           <Text testID="profile-name" className="text-foreground text-2xl font-manrope-bold mt-1">
             {profile.name}
           </Text>
@@ -138,20 +170,20 @@ export default function PartnerProfileScreen() {
         {/* Bio / Introduction */}
         {profile.bio && (
           <View className="mb-4">
-            <Text className="font-manrope-semi text-[11px] tracking-[2px] uppercase mb-2" style={{ color: "#8A7570" }}>Introduction</Text>
-            <Text className="text-muted-foreground font-manrope">{profile.bio}</Text>
+            <SectionLabel>Introduction</SectionLabel>
+            <Text className="font-manrope" style={{ color: "#8A7570" }}>{profile.bio}</Text>
           </View>
         )}
 
         {/* Spoken languages */}
         {profile.spokenLanguages.length > 0 && (
           <View className="mb-4">
-            <Text className="font-manrope-semi text-[11px] tracking-[2px] uppercase mb-2" style={{ color: "#8A7570" }}>Speaks</Text>
+            <SectionLabel>Speaks</SectionLabel>
             <View className="flex-row flex-wrap gap-2" testID="profile-offered-languages">
               {profile.spokenLanguages.map((l) => (
-                <View key={l.language} className="bg-primary/10 px-3 py-1 rounded-full">
-                  <Text className="text-primary text-xs font-manrope-semi">
-                    {l.language}{l.proficiency ? ` · ${l.proficiency}` : ""}
+                <View key={l.language} className="px-3 py-1 rounded-full" style={{ borderWidth: 1, borderColor: GOLD, backgroundColor: "#FFF9EC" }}>
+                  <Text className="text-xs font-manrope-semi" style={{ color: "#2C1810" }}>
+                    {LANGUAGE_FLAGS[l.language] ?? ""} {l.language}{l.proficiency ? ` · ${l.proficiency}` : ""}
                   </Text>
                 </View>
               ))}
@@ -162,11 +194,13 @@ export default function PartnerProfileScreen() {
         {/* Learning languages */}
         {profile.learningLanguages.length > 0 && (
           <View className="mb-4">
-            <Text className="font-manrope-semi text-[11px] tracking-[2px] uppercase mb-2" style={{ color: "#8A7570" }}>Learning</Text>
+            <SectionLabel>Learning</SectionLabel>
             <View className="flex-row flex-wrap gap-2" testID="profile-targeted-languages">
               {profile.learningLanguages.map((lang) => (
-                <View key={lang} className="bg-secondary/10 px-3 py-1 rounded-full">
-                  <Text className="text-secondary-foreground text-xs font-manrope-semi">{lang}</Text>
+                <View key={lang} className="px-3 py-1 rounded-full" style={{ borderWidth: 1, borderColor: BORDER }}>
+                  <Text className="text-xs font-manrope-semi" style={{ color: "#8A7570" }}>
+                    {LANGUAGE_FLAGS[lang] ?? ""} {lang}
+                  </Text>
                 </View>
               ))}
             </View>
@@ -176,11 +210,11 @@ export default function PartnerProfileScreen() {
         {/* Interests / Topics */}
         {profile.interests.length > 0 && (
           <View className="mb-4">
-            <Text className="font-manrope-semi text-[11px] tracking-[2px] uppercase mb-2" style={{ color: "#8A7570" }}>Topics</Text>
+            <SectionLabel>Topics</SectionLabel>
             <View className="flex-row flex-wrap gap-2" testID="profile-topics">
               {profile.interests.map((topic) => (
-                <View key={topic} className="bg-muted px-3 py-1 rounded-full">
-                  <Text className="text-muted-foreground text-xs font-manrope">{interestLabel(topic)}</Text>
+                <View key={topic} className="px-3 py-1 rounded-full" style={{ borderWidth: 1, borderColor: BORDER, backgroundColor: "#F5EFE8" }}>
+                  <Text className="text-xs font-manrope" style={{ color: "#8A7570" }}>{interestLabel(topic)}</Text>
                 </View>
               ))}
             </View>

--- a/apps/native/app/partner/[id].tsx
+++ b/apps/native/app/partner/[id].tsx
@@ -8,23 +8,10 @@ import { Container } from "@/components/container";
 import { MatchCelebrationModal } from "@/components/match-celebration-modal";
 import { queryClient, trpc } from "@/utils/trpc";
 import { interestLabel } from "@/utils/interest-labels";
+import { getLanguageFlag } from "@/utils/language-flags";
 
 const GOLD = "#F2C94C";
 const BORDER = "#D9C9BC";
-
-const LANGUAGE_FLAGS: Record<string, string> = {
-  Afrikaans: "🇿🇦", Arabic: "🇸🇦", Bengali: "🇧🇩", Bulgarian: "🇧🇬",
-  Catalan: "🏳️", Chinese: "🇨🇳", Croatian: "🇭🇷", Czech: "🇨🇿",
-  Danish: "🇩🇰", Dutch: "🇳🇱", English: "🇬🇧", Estonian: "🇪🇪",
-  Finnish: "🇫🇮", French: "🇫🇷", German: "🇩🇪", Greek: "🇬🇷",
-  Hebrew: "🇮🇱", Hindi: "🇮🇳", Hungarian: "🇭🇺", Indonesian: "🇮🇩",
-  Italian: "🇮🇹", Japanese: "🇯🇵", Korean: "🇰🇷", Latvian: "🇱🇻",
-  Lithuanian: "🇱🇹", Malay: "🇲🇾", Norwegian: "🇳🇴", Persian: "🇮🇷",
-  Polish: "🇵🇱", Portuguese: "🇵🇹", Romanian: "🇷🇴", Russian: "🇷🇺",
-  Serbian: "🇷🇸", Slovak: "🇸🇰", Slovenian: "🇸🇮", Spanish: "🇪🇸",
-  Swedish: "🇸🇪", Thai: "🇹🇭", Turkish: "🇹🇷", Ukrainian: "🇺🇦",
-  Vietnamese: "🇻🇳",
-};
 
 function SectionLabel({ children }: { children: string }) {
   return (
@@ -183,7 +170,7 @@ export default function PartnerProfileScreen() {
               {profile.spokenLanguages.map((l) => (
                 <View key={l.language} className="px-3 py-1 rounded-full" style={{ borderWidth: 1, borderColor: GOLD, backgroundColor: "#FFF9EC" }}>
                   <Text className="text-xs font-manrope-semi" style={{ color: "#2C1810" }}>
-                    {LANGUAGE_FLAGS[l.language] ?? ""} {l.language}{l.proficiency ? ` · ${l.proficiency}` : ""}
+                    {getLanguageFlag(l.language)} {l.language}{l.proficiency ? ` · ${l.proficiency}` : ""}
                   </Text>
                 </View>
               ))}
@@ -199,7 +186,7 @@ export default function PartnerProfileScreen() {
               {profile.learningLanguages.map((lang) => (
                 <View key={lang} className="px-3 py-1 rounded-full" style={{ borderWidth: 1, borderColor: BORDER }}>
                   <Text className="text-xs font-manrope-semi" style={{ color: "#8A7570" }}>
-                    {LANGUAGE_FLAGS[lang] ?? ""} {lang}
+                    {getLanguageFlag(lang)} {lang}
                   </Text>
                 </View>
               ))}

--- a/apps/native/app/respond-meetup.tsx
+++ b/apps/native/app/respond-meetup.tsx
@@ -165,9 +165,14 @@ export default function RespondMeetupScreen() {
                   key={v.id}
                   testID="venue-option"
                   onPress={() => setSelectedVenueId(v.id)}
-                  className={`border rounded-xl p-3 ${selectedVenueId === v.id ? "border-primary bg-primary/10" : "border-border bg-card"}`}
+                  className="rounded-xl p-3"
+                  style={{
+                    borderWidth: 1.5,
+                    borderColor: selectedVenueId === v.id ? "#F2C94C" : "#D9C9BC",
+                    backgroundColor: selectedVenueId === v.id ? "#FFF9EC" : "#F5EFE8",
+                  }}
                 >
-                  <Text className={`font-manrope-semi ${selectedVenueId === v.id ? "text-primary" : "text-foreground"}`}>
+                  <Text className="font-manrope-semi" style={{ color: selectedVenueId === v.id ? "#2C1810" : "#8A7570" }}>
                     {v.name}
                   </Text>
                 </TouchableOpacity>
@@ -213,9 +218,14 @@ export default function RespondMeetupScreen() {
                   key={slot}
                   testID="time-slot"
                   onPress={() => setTime(slot)}
-                  className={`border rounded-lg px-3 py-1.5 ${time === slot ? "border-primary bg-primary/10" : "border-border bg-card"}`}
+                  className="rounded-lg px-3 py-1.5"
+                  style={{
+                    borderWidth: 1.5,
+                    borderColor: time === slot ? "#F2C94C" : "#D9C9BC",
+                    backgroundColor: time === slot ? "#FFF9EC" : "transparent",
+                  }}
                 >
-                  <Text className={`font-manrope ${time === slot ? "text-primary font-manrope-semi" : "text-foreground"}`}>{slot}</Text>
+                  <Text className={`font-manrope${time === slot ? "-semi" : ""}`} style={{ color: time === slot ? "#2C1810" : "#8A7570" }}>{slot}</Text>
                 </TouchableOpacity>
               ))}
             </View>


### PR DESCRIPTION
Visual consistency fixes using the warm brand palette:

- **#343** — `partner/[id].tsx`: gold ring on avatar (`borderWidth: 2.5, borderColor: #F2C94C`), language flag emojis via `LANGUAGE_FLAGS` map, warm-palette chips replacing `bg-primary/10`/`bg-muted`, shared `SectionLabel` component
- **#344/#345** — `respond-meetup.tsx` counter-propose view: venue and time-slot selection now uses gold/warm colors (`#F2C94C` border, `#FFF9EC` background when selected) instead of `bg-primary/10`

Closes #343
Closes #344
Closes #345