### PR TITLE
fix(discover): surface compatible languages on candidate cards

### DIFF
--- a/apps/native/components/candidate-card.tsx
+++ b/apps/native/components/candidate-card.tsx
@@ -6,6 +6,9 @@ import { Image, Pressable, Text, View } from "react-native";
 
 import { trpc } from "@/utils/trpc";
 import { interestLabel } from "@/utils/interest-labels";
+import { getLanguageFlag } from "@/utils/language-flags";
+
+const GOLD = "#F2C94C";
 
 interface CandidateCardProps {
   userId: string;
@@ -14,6 +17,7 @@ interface CandidateCardProps {
   spokenLanguages: { language: string; proficiency: string | null }[];
   learningLanguages: string[];
   interests: string[];
+  compatibleLanguages?: string[];
 }
 
 export function CandidateCard({
@@ -23,6 +27,7 @@ export function CandidateCard({
   spokenLanguages,
   learningLanguages,
   interests,
+  compatibleLanguages,
 }: CandidateCardProps) {
   const router = useRouter();
   const [sendConflictError, setSendConflictError] = useState<string | null>(null);
@@ -91,6 +96,23 @@ export function CandidateCard({
             {learningLanguages.map((lang) => (
               <View key={lang} className="bg-secondary/10 px-2 py-0.5 rounded-full">
                 <Text className="text-secondary-foreground text-xs">{lang}</Text>
+              </View>
+            ))}
+          </View>
+        </View>
+      )}
+
+      {(compatibleLanguages ?? []).length > 0 && (
+        <View className="mb-2">
+          <Text className="text-muted-foreground text-xs uppercase font-medium mb-1">
+            In common
+          </Text>
+          <View className="flex-row flex-wrap gap-1" testID="candidate-compatible-languages">
+            {(compatibleLanguages ?? []).map((lang) => (
+              <View key={lang} className="px-2 py-0.5 rounded-full" style={{ backgroundColor: GOLD }}>
+                <Text className="text-xs font-semibold" style={{ color: "#2C1810" }}>
+                  {getLanguageFlag(lang)} {lang}
+                </Text>
               </View>
             ))}
           </View>

--- a/packages/api/src/contexts/matching/matching.ts
+++ b/packages/api/src/contexts/matching/matching.ts
@@ -161,7 +161,14 @@ export const matchingRouter = router({
 
       // Cursor-based pagination (cursor = index offset as string)
       const startIndex = input.cursor ? parseInt(input.cursor, 10) : 0;
-      const page = scored.slice(startIndex, startIndex + input.limit);
+      const page = scored.slice(startIndex, startIndex + input.limit).map((candidate) => {
+        const partnerSpoken = candidate.spokenLanguages.map((l) => l.language);
+        const compatibleLanguages = Array.from(new Set([
+          ...myLearning.filter((lang) => partnerSpoken.includes(lang)),
+          ...mySpoken.filter((lang) => candidate.learningLanguages.includes(lang)),
+        ]));
+        return { ...candidate, compatibleLanguages };
+      });
       const nextCursor =
         startIndex + input.limit < scored.length
           ? String(startIndex + input.limit)


### PR DESCRIPTION
## Summary

- `discover` tRPC procedure now computes `compatibleLanguages` per candidate: the union of languages user can teach the partner and languages partner can teach the user
- `CandidateCard` accepts optional `compatibleLanguages` prop and renders an "In common" section with gold-background chips (`#F2C94C`) when any shared languages exist
- Uses `getLanguageFlag` from the shared utility for emoji flags

## Test plan

- [ ] `discover` API response includes `compatibleLanguages: string[]` per partner
- [ ] When a candidate shares a learning/teaching language with the viewer, "In common" chip row appears on their card
- [ ] No "In common" row when there are no compatible languages
- [ ] Chips display flag emoji + language name with dark text on gold background

Closes #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)