### PR TITLE
fix(native): swipeable Home hero carousel for upcoming Meet-Ups

### DIFF
--- a/apps/native/__tests__/home-state.test.ts
+++ b/apps/native/__tests__/home-state.test.ts
@@ -1,4 +1,5 @@
 import {
+  needsAction,
   resolveHomeState,
   type ConfirmedMeetup,
   type PendingProposal,
@@ -50,93 +51,164 @@ function match(partial: Partial<MyMatch>): MyMatch {
 
 const empty = { confirmed: [], pending: [], matches: [], discover: [] };
 
-describe("resolveHomeState cascade", () => {
+describe("resolveHomeState carousel", () => {
   it("falls back to nomeetup when nothing else applies", () => {
-    const { hero, secondaries } = resolveHomeState(empty);
-    expect(hero.kind).toBe("nomeetup");
+    const { heros, secondaries } = resolveHomeState(empty);
+    expect(heros).toHaveLength(1);
+    expect(heros[0]?.kind).toBe("nomeetup");
     expect(secondaries).toEqual([]);
   });
 
   it("nomeetup carries discover count + partners", () => {
     const partners = [{ spokenLanguages: [{ language: "Italian", proficiency: "native" }] }];
-    const { hero } = resolveHomeState({ ...empty, discover: partners });
-    expect(hero).toMatchObject({ kind: "nomeetup", matchCount: 1 });
+    const { heros } = resolveHomeState({ ...empty, discover: partners });
+    expect(heros[0]).toMatchObject({ kind: "nomeetup", matchCount: 1 });
   });
 
-  it("matchfound wins over nomeetup", () => {
-    const { hero } = resolveHomeState({ ...empty, matches: [match({})] });
-    expect(hero.kind).toBe("matchfound");
+  it("matchfound beats nomeetup", () => {
+    const { heros } = resolveHomeState({ ...empty, matches: [match({})] });
+    expect(heros[0]?.kind).toBe("matchfound");
   });
 
-  it("waiting wins over matchfound", () => {
-    const { hero } = resolveHomeState({
+  it("waiting beats matchfound", () => {
+    const { heros, secondaries } = resolveHomeState({
       ...empty,
       pending: [pending({})],
       matches: [match({})],
     });
-    expect(hero.kind).toBe("waiting");
+    expect(heros[0]?.kind).toBe("waiting");
+    expect(secondaries[0]?.kind).toBe("matchfound");
   });
 
-  it("confirmed wins over waiting", () => {
-    const { hero } = resolveHomeState({
+  it("confirmed meetup becomes hero; waiting demoted to secondary", () => {
+    const { heros, secondaries } = resolveHomeState({
       ...empty,
       confirmed: [confirmed({})],
       pending: [pending({})],
     });
-    expect(hero.kind).toBe("confirmed");
+    expect(heros).toHaveLength(1);
+    expect(heros[0]?.kind).toBe("confirmed");
+    expect(secondaries[0]?.kind).toBe("waiting");
   });
 
-  it("post wins over confirmed", () => {
+  it("post entries lead heros before upcoming confirmed", () => {
     const past = confirmed({ meetupId: "past", isPast: true, hasReported: false });
     const future = confirmed({ meetupId: "future", isPast: false });
-    const { hero } = resolveHomeState({ ...empty, confirmed: [past, future] });
-    expect(hero.kind).toBe("post");
-    if (hero.kind === "post") expect(hero.meetup.meetupId).toBe("past");
+    const { heros } = resolveHomeState({ ...empty, confirmed: [past, future] });
+    expect(heros.map((h) => h.kind)).toEqual(["post", "confirmed"]);
   });
 
-  it("filters out reported past meetups from post", () => {
+  it("filters out reported past meetups", () => {
     const reported = confirmed({ isPast: true, hasReported: true });
-    const { hero } = resolveHomeState({ ...empty, confirmed: [reported] });
-    expect(hero.kind).toBe("nomeetup");
+    const { heros } = resolveHomeState({ ...empty, confirmed: [reported] });
+    expect(heros[0]?.kind).toBe("nomeetup");
   });
 
-  it("confirmed picks soonest future", () => {
-    const a = confirmed({ meetupId: "a", date: "2099-06-01", time: "10:00" });
-    const b = confirmed({ meetupId: "b", date: "2099-01-01", time: "10:00" });
-    const { hero } = resolveHomeState({ ...empty, confirmed: [a, b] });
-    if (hero.kind === "confirmed") expect(hero.meetup.meetupId).toBe("b");
+  it("upcoming confirmed are ordered chronologically", () => {
+    const a = confirmed({ meetupId: "later", date: "2099-06-01", time: "10:00" });
+    const b = confirmed({ meetupId: "sooner", date: "2099-01-01", time: "10:00" });
+    const { heros } = resolveHomeState({ ...empty, confirmed: [a, b] });
+    const ids = heros.map((h) => (h.kind === "confirmed" ? h.meetup.meetupId : null));
+    expect(ids).toEqual(["sooner", "later"]);
   });
 
-  it("waiting picks oldest pending", () => {
+  it("partner-proposed reschedule jumps to front of upcoming carousel", () => {
+    const earlier = confirmed({
+      meetupId: "earlier",
+      date: "2099-01-01",
+      time: "09:00",
+    });
+    const laterWithAction = confirmed({
+      meetupId: "later",
+      date: "2099-01-01",
+      time: "10:00",
+      reschedulePending: true,
+      rescheduleIsFromMe: false,
+    });
+    const { heros } = resolveHomeState({
+      ...empty,
+      confirmed: [earlier, laterWithAction],
+    });
+    const ids = heros.map((h) => (h.kind === "confirmed" ? h.meetup.meetupId : null));
+    expect(ids).toEqual(["later", "earlier"]);
+  });
+
+  it("self-initiated reschedule does not jump the queue", () => {
+    const earlier = confirmed({ meetupId: "earlier", date: "2099-01-01", time: "09:00" });
+    const laterMine = confirmed({
+      meetupId: "later",
+      date: "2099-01-01",
+      time: "10:00",
+      reschedulePending: true,
+      rescheduleIsFromMe: true,
+    });
+    const { heros } = resolveHomeState({
+      ...empty,
+      confirmed: [earlier, laterMine],
+    });
+    const ids = heros.map((h) => (h.kind === "confirmed" ? h.meetup.meetupId : null));
+    expect(ids).toEqual(["earlier", "later"]);
+  });
+
+  it("waiting heros are ordered oldest pending first", () => {
     const a = pending({ id: "newer", createdAt: "2026-04-28T12:00:00Z" });
     const b = pending({ id: "older", createdAt: "2026-04-28T08:00:00Z" });
-    const { hero } = resolveHomeState({ ...empty, pending: [a, b] });
-    if (hero.kind === "waiting") expect(hero.proposal.id).toBe("older");
+    const { heros } = resolveHomeState({ ...empty, pending: [a, b] });
+    const ids = heros.map((h) => (h.kind === "waiting" ? h.proposal.id : null));
+    expect(ids).toEqual(["older", "newer"]);
   });
 
   it("matchfound picks newest match", () => {
     const a = match({ matchId: "older", matchedAt: "2026-04-20T10:00:00Z" });
     const b = match({ matchId: "newer", matchedAt: "2026-04-28T10:00:00Z" });
-    const { hero } = resolveHomeState({ ...empty, matches: [a, b] });
-    if (hero.kind === "matchfound") expect(hero.match.matchId).toBe("newer");
+    const { heros } = resolveHomeState({ ...empty, matches: [a, b] });
+    expect(heros[0]).toMatchObject({ kind: "matchfound" });
+    if (heros[0]?.kind === "matchfound") expect(heros[0].match.matchId).toBe("newer");
   });
 
-  it("returns up to 2 secondaries below the hero", () => {
-    const { hero, secondaries } = resolveHomeState({
-      confirmed: [confirmed({ isPast: true, hasReported: false })], // post
-      pending: [pending({})], // waiting
-      matches: [match({})], // matchfound
-      discover: [{ spokenLanguages: [] }], // nomeetup
+  it("returns up to 2 secondaries below the meetup carousel", () => {
+    const { heros, secondaries } = resolveHomeState({
+      confirmed: [confirmed({ isPast: true, hasReported: false })],
+      pending: [pending({})],
+      matches: [match({})],
+      discover: [{ spokenLanguages: [] }],
     });
-    expect(hero.kind).toBe("post");
+    expect(heros[0]?.kind).toBe("post");
     expect(secondaries.map((s) => s.kind)).toEqual(["waiting", "matchfound"]);
   });
+});
 
-  it("includes confirmed as secondary when post is hero", () => {
-    const past = confirmed({ meetupId: "past", isPast: true, hasReported: false });
-    const future = confirmed({ meetupId: "future", isPast: false, status: "confirmed" });
-    const { hero, secondaries } = resolveHomeState({ ...empty, confirmed: [past, future] });
-    expect(hero.kind).toBe("post");
-    expect(secondaries[0]?.kind).toBe("confirmed");
+describe("needsAction", () => {
+  it("flags post (rating needed)", () => {
+    expect(
+      needsAction({ kind: "post", meetup: confirmed({ isPast: true }) }),
+    ).toBe(true);
+  });
+
+  it("flags confirmed with partner-proposed reschedule", () => {
+    const state = {
+      kind: "confirmed" as const,
+      meetup: confirmed({ reschedulePending: true, rescheduleIsFromMe: false }),
+    };
+    expect(needsAction(state)).toBe(true);
+  });
+
+  it("does not flag confirmed without reschedule", () => {
+    const state = { kind: "confirmed" as const, meetup: confirmed({}) };
+    expect(needsAction(state)).toBe(false);
+  });
+
+  it("flags waiting that needs my reply", () => {
+    const state = { kind: "waiting" as const, proposal: pending({ isProposer: false }) };
+    expect(needsAction(state)).toBe(true);
+  });
+
+  it("does not flag waiting where I am the proposer", () => {
+    const state = { kind: "waiting" as const, proposal: pending({ isProposer: true }) };
+    expect(needsAction(state)).toBe(false);
+  });
+
+  it("does not flag nomeetup", () => {
+    expect(needsAction({ kind: "nomeetup", matchCount: 0, partners: [] })).toBe(false);
   });
 });

--- a/apps/native/app/(tabs)/home.tsx
+++ b/apps/native/app/(tabs)/home.tsx
@@ -13,6 +13,7 @@ import { HeroWaiting } from "@/components/home/hero-waiting";
 import { HeroConfirmed } from "@/components/home/hero-confirmed";
 import { HeroPost } from "@/components/home/hero-post";
 import { SecondaryCard } from "@/components/home/secondary-card";
+import { HeroCarousel } from "@/components/home/hero-carousel";
 import { resolveHomeState, type HomeState } from "@/components/home/home-state";
 import { GOLD } from "@/components/home/tokens";
 
@@ -42,7 +43,7 @@ export default function HomeScreen() {
     },
   }));
 
-  const { hero, secondaries } = resolveHomeState({
+  const { heros, secondaries } = resolveHomeState({
     confirmed: confirmedQuery.data ?? [],
     pending: (pendingQuery.data ?? []).map((p) => ({
       id: p.id,
@@ -83,7 +84,7 @@ export default function HomeScreen() {
     }
   }
 
-  function renderHero() {
+  function renderHero(hero: HomeState) {
     switch (hero.kind) {
       case "post":
         return (
@@ -188,7 +189,7 @@ export default function HomeScreen() {
           </Pressable>
         </View>
 
-        {renderHero()}
+        <HeroCarousel heros={heros} renderHero={renderHero} />
 
         {secondaries.length > 0 && (
           <View className="mt-8">

--- a/apps/native/components/home/hero-carousel.tsx
+++ b/apps/native/components/home/hero-carousel.tsx
@@ -1,0 +1,121 @@
+import { useCallback, useRef, useState } from "react";
+import {
+  FlatList,
+  type LayoutChangeEvent,
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
+  Pressable,
+  View,
+} from "react-native";
+
+import { needsAction, type HomeState } from "./home-state";
+import { GOLD } from "./tokens";
+
+type Props = {
+  heros: HomeState[];
+  renderHero: (state: HomeState) => React.ReactNode;
+};
+
+const DOT_SIZE = 6;
+const DOT_GAP = 6;
+
+export function HeroCarousel({ heros, renderHero }: Props) {
+  const [width, setWidth] = useState(0);
+  const [index, setIndex] = useState(0);
+  const listRef = useRef<FlatList<HomeState>>(null);
+
+  const handleLayout = useCallback((e: LayoutChangeEvent) => {
+    setWidth(e.nativeEvent.layout.width);
+  }, []);
+
+  const handleScroll = useCallback(
+    (e: NativeSyntheticEvent<NativeScrollEvent>) => {
+      if (width === 0) return;
+      const next = Math.round(e.nativeEvent.contentOffset.x / width);
+      if (next !== index) setIndex(next);
+    },
+    [width, index],
+  );
+
+  const jumpTo = useCallback(
+    (i: number) => {
+      if (width === 0) return;
+      listRef.current?.scrollToOffset({ offset: i * width, animated: true });
+      setIndex(i);
+    },
+    [width],
+  );
+
+  if (heros.length === 0) return null;
+  if (heros.length === 1) {
+    return <View testID="hero-carousel">{renderHero(heros[0]!)}</View>;
+  }
+
+  return (
+    <View testID="hero-carousel" onLayout={handleLayout}>
+      {width > 0 && (
+        <FlatList
+          ref={listRef}
+          data={heros}
+          horizontal
+          pagingEnabled
+          showsHorizontalScrollIndicator={false}
+          keyExtractor={heroKey}
+          onScroll={handleScroll}
+          scrollEventThrottle={16}
+          renderItem={({ item }) => (
+            <View style={{ width }}>{renderHero(item)}</View>
+          )}
+        />
+      )}
+      <View
+        testID="hero-carousel-dots"
+        className="flex-row items-center justify-center mt-3"
+        style={{ gap: DOT_GAP }}
+      >
+        {heros.map((state, i) => {
+          const active = i === index;
+          const action = i !== index && needsAction(state);
+          return (
+            <Pressable
+              key={heroKey(state, i)}
+              testID={
+                action
+                  ? `hero-carousel-dot-action-${i}`
+                  : `hero-carousel-dot-${i}`
+              }
+              onPress={() => jumpTo(i)}
+              hitSlop={8}
+              style={{
+                width: active ? DOT_SIZE * 2 : DOT_SIZE,
+                height: DOT_SIZE,
+                borderRadius: DOT_SIZE / 2,
+                backgroundColor: active
+                  ? GOLD
+                  : action
+                    ? GOLD
+                    : "rgba(0,0,0,0.18)",
+                opacity: active ? 1 : action ? 0.85 : 1,
+              }}
+            />
+          );
+        })}
+      </View>
+    </View>
+  );
+}
+
+function heroKey(state: HomeState, fallback?: number): string {
+  switch (state.kind) {
+    case "post":
+      return `post-${state.meetup.meetupId}`;
+    case "confirmed":
+      return `confirmed-${state.meetup.meetupId}`;
+    case "waiting":
+      return `waiting-${state.proposal.id}`;
+    case "matchfound":
+      return `match-${state.match.matchId}`;
+    case "nomeetup":
+      return `nomeetup-${fallback ?? 0}`;
+  }
+}

--- a/apps/native/components/home/home-state.ts
+++ b/apps/native/components/home/home-state.ts
@@ -54,25 +54,44 @@ type Inputs = {
   discover: DiscoverPartner[];
 };
 
-const PRIORITY: HomeState["kind"][] = ["post", "confirmed", "waiting", "matchfound", "nomeetup"];
-
-function pickPost(confirmed: ConfirmedMeetup[]): ConfirmedMeetup | null {
-  const candidates = confirmed.filter((m) => m.isPast && !m.hasReported);
-  if (candidates.length === 0) return null;
-  return [...candidates].sort((a, b) => `${b.date}T${b.time}`.localeCompare(`${a.date}T${a.time}`))[0]!;
+function needsAction(state: HomeState): boolean {
+  switch (state.kind) {
+    case "post":
+      return true;
+    case "confirmed":
+      return state.meetup.reschedulePending && !state.meetup.rescheduleIsFromMe;
+    case "waiting":
+      return !state.proposal.isProposer;
+    case "matchfound":
+      return true;
+    case "nomeetup":
+      return false;
+  }
 }
 
-function pickConfirmed(confirmed: ConfirmedMeetup[]): ConfirmedMeetup | null {
-  const candidates = confirmed.filter((m) => !m.isPast && m.status === "confirmed");
-  if (candidates.length === 0) return null;
-  return [...candidates].sort((a, b) => `${a.date}T${a.time}`.localeCompare(`${b.date}T${b.time}`))[0]!;
+function buildPostList(confirmed: ConfirmedMeetup[]): HomeState[] {
+  return confirmed
+    .filter((m) => m.isPast && !m.hasReported)
+    .sort((a, b) => `${b.date}T${b.time}`.localeCompare(`${a.date}T${a.time}`))
+    .map((m) => ({ kind: "post", meetup: m }));
 }
 
-function pickWaiting(pending: PendingProposal[]): PendingProposal | null {
-  if (pending.length === 0) return null;
-  return [...pending].sort(
-    (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
-  )[0]!;
+function buildConfirmedList(confirmed: ConfirmedMeetup[]): HomeState[] {
+  return confirmed
+    .filter((m) => !m.isPast && m.status === "confirmed")
+    .sort((a, b) => {
+      const aAction = a.reschedulePending && !a.rescheduleIsFromMe ? 1 : 0;
+      const bAction = b.reschedulePending && !b.rescheduleIsFromMe ? 1 : 0;
+      if (aAction !== bAction) return bAction - aAction;
+      return `${a.date}T${a.time}`.localeCompare(`${b.date}T${b.time}`);
+    })
+    .map((m) => ({ kind: "confirmed", meetup: m }));
+}
+
+function buildWaitingList(pending: PendingProposal[]): HomeState[] {
+  return [...pending]
+    .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
+    .map((p) => ({ kind: "waiting", proposal: p }));
 }
 
 function pickMatchfound(matches: MyMatch[]): MyMatch | null {
@@ -82,34 +101,36 @@ function pickMatchfound(matches: MyMatch[]): MyMatch | null {
   )[0]!;
 }
 
-function buildState(kind: HomeState["kind"], inputs: Inputs): HomeState | null {
-  switch (kind) {
-    case "post": {
-      const m = pickPost(inputs.confirmed);
-      return m ? { kind: "post", meetup: m } : null;
-    }
-    case "confirmed": {
-      const m = pickConfirmed(inputs.confirmed);
-      return m ? { kind: "confirmed", meetup: m } : null;
-    }
-    case "waiting": {
-      const p = pickWaiting(inputs.pending);
-      return p ? { kind: "waiting", proposal: p } : null;
-    }
-    case "matchfound": {
-      const m = pickMatchfound(inputs.matches);
-      return m ? { kind: "matchfound", match: m } : null;
-    }
-    case "nomeetup":
-      return { kind: "nomeetup", matchCount: inputs.discover.length, partners: inputs.discover };
-  }
-}
+export function resolveHomeState(inputs: Inputs): { heros: HomeState[]; secondaries: HomeState[] } {
+  const posts = buildPostList(inputs.confirmed);
+  const upcomings = buildConfirmedList(inputs.confirmed);
+  const meetupHeros = [...posts, ...upcomings];
 
-export function resolveHomeState(inputs: Inputs): { hero: HomeState; secondaries: HomeState[] } {
-  const states = PRIORITY.map((k) => buildState(k, inputs)).filter((s): s is HomeState => s !== null);
-  const [hero, ...rest] = states;
+  if (meetupHeros.length > 0) {
+    const secondaries: HomeState[] = [];
+    const waiting = buildWaitingList(inputs.pending)[0];
+    if (waiting) secondaries.push(waiting);
+    const top = pickMatchfound(inputs.matches);
+    if (top) secondaries.push({ kind: "matchfound", match: top });
+    return { heros: meetupHeros, secondaries: secondaries.slice(0, 2) };
+  }
+
+  const waitingList = buildWaitingList(inputs.pending);
+  if (waitingList.length > 0) {
+    const top = pickMatchfound(inputs.matches);
+    return {
+      heros: waitingList,
+      secondaries: top ? [{ kind: "matchfound", match: top }] : [],
+    };
+  }
+
+  const top = pickMatchfound(inputs.matches);
+  if (top) return { heros: [{ kind: "matchfound", match: top }], secondaries: [] };
+
   return {
-    hero: hero ?? { kind: "nomeetup", matchCount: 0, partners: [] },
-    secondaries: rest.slice(0, 2),
+    heros: [{ kind: "nomeetup", matchCount: inputs.discover.length, partners: inputs.discover }],
+    secondaries: [],
   };
 }
+
+export { needsAction };


### PR DESCRIPTION
## Summary
- `resolveHomeState` returns `heros: HomeState[]` (was single `hero`); upcoming Meet-Ups ordered chronologically, partner-proposed Reschedules jump to front, past-unreported posts lead.
- New `HeroCarousel` — horizontally-paged FlatList with dot indicators; off-screen action-needed heros get a gold dot.
- `home-state.test.ts` rewritten (19 tests) covering carousel order, reschedule promotion, secondary fallback chain.

Already shipped to production channel via EAS OTA update [abe2f9c1](https://expo.dev/accounts/xiduzo/projects/sip-and-speak/updates/abe2f9c1-d7e5-4d00-b4c3-098d92e9c9ef).

Closes #358

## Test plan
- [x] `bun run test __tests__/home-state.test.ts` — 19/19 pass
- [x] No new regressions in full native suite (28 pre-existing failures unchanged)
- [x] `tsc --noEmit` clean for changed source files
- [ ] Manual: 2+ upcoming Meet-Ups on same day, one with partner-proposed Reschedule → action-needed card shown first on Home; swipe reveals others