### PR TITLE
fix(native): home hero carousel + chat screen redesign

### DIFF
--- a/apps/native/__tests__/compose-ui.test.tsx
+++ b/apps/native/__tests__/compose-ui.test.tsx
@@ -12,9 +12,24 @@ import React from "react";
 
 // ── Router mock ───────────────────────────────────────────────────────────────
 
-jest.mock("expo-router", () => ({
-  useLocalSearchParams: () => ({ conversationId: "conv-1" }),
-  useRouter: () => ({ back: jest.fn() }),
+jest.mock("expo-router", () => {
+  const { useEffect } = require("react");
+  return {
+    useLocalSearchParams: () => ({ conversationId: "conv-1" }),
+    useRouter: () => ({ back: jest.fn() }),
+    useFocusEffect: (cb: () => void | (() => void)) => {
+      useEffect(() => {
+        const cleanup = cb();
+        return typeof cleanup === "function" ? cleanup : undefined;
+      }, []); // eslint-disable-line react-hooks/exhaustive-deps
+    },
+  };
+});
+
+jest.mock("@/lib/auth-client", () => ({
+  authClient: {
+    useSession: () => ({ data: { user: { id: "alice" } } }),
+  },
 }));
 
 // ── tRPC / query mock ─────────────────────────────────────────────────────────
@@ -29,6 +44,12 @@ jest.mock("@/utils/trpc", () => ({
         queryOptions: (_input: unknown, _opts: unknown) => ({
           queryKey: ["chat.getMessages"],
           queryFn: async () => ({ messages: [] }),
+        }),
+      },
+      listEntries: {
+        queryOptions: () => ({
+          queryKey: ["chat.listEntries"],
+          queryFn: async () => [],
         }),
       },
       markRead: {

--- a/apps/native/__tests__/conversation-history.test.tsx
+++ b/apps/native/__tests__/conversation-history.test.tsx
@@ -66,6 +66,12 @@ jest.mock("@/utils/trpc", () => ({
           queryFn: async () => ({ messages: mockMessages }),
         }),
       },
+      listEntries: {
+        queryOptions: () => ({
+          queryKey: ["chat.listEntries"],
+          queryFn: async () => [],
+        }),
+      },
       markRead: {
         mutationOptions: () => ({ mutationFn: jest.fn().mockResolvedValue({}) }),
       },

--- a/apps/native/__tests__/empty-conversation-state.test.tsx
+++ b/apps/native/__tests__/empty-conversation-state.test.tsx
@@ -62,6 +62,12 @@ jest.mock("@/utils/trpc", () => ({
           queryFn: async () => ({ messages: [] }),
         }),
       },
+      listEntries: {
+        queryOptions: () => ({
+          queryKey: ["chat.listEntries"],
+          queryFn: async () => [],
+        }),
+      },
       markRead: {
         mutationOptions: () => ({ mutationFn: jest.fn().mockResolvedValue({}) }),
       },

--- a/apps/native/__tests__/home-state.test.ts
+++ b/apps/native/__tests__/home-state.test.ts
@@ -1,4 +1,5 @@
 import {
+  needsAction,
   resolveHomeState,
   type ConfirmedMeetup,
   type PendingProposal,
@@ -50,93 +51,164 @@ function match(partial: Partial<MyMatch>): MyMatch {
 
 const empty = { confirmed: [], pending: [], matches: [], discover: [] };
 
-describe("resolveHomeState cascade", () => {
+describe("resolveHomeState carousel", () => {
   it("falls back to nomeetup when nothing else applies", () => {
-    const { hero, secondaries } = resolveHomeState(empty);
-    expect(hero.kind).toBe("nomeetup");
+    const { heros, secondaries } = resolveHomeState(empty);
+    expect(heros).toHaveLength(1);
+    expect(heros[0]?.kind).toBe("nomeetup");
     expect(secondaries).toEqual([]);
   });
 
   it("nomeetup carries discover count + partners", () => {
     const partners = [{ spokenLanguages: [{ language: "Italian", proficiency: "native" }] }];
-    const { hero } = resolveHomeState({ ...empty, discover: partners });
-    expect(hero).toMatchObject({ kind: "nomeetup", matchCount: 1 });
+    const { heros } = resolveHomeState({ ...empty, discover: partners });
+    expect(heros[0]).toMatchObject({ kind: "nomeetup", matchCount: 1 });
   });
 
-  it("matchfound wins over nomeetup", () => {
-    const { hero } = resolveHomeState({ ...empty, matches: [match({})] });
-    expect(hero.kind).toBe("matchfound");
+  it("matchfound beats nomeetup", () => {
+    const { heros } = resolveHomeState({ ...empty, matches: [match({})] });
+    expect(heros[0]?.kind).toBe("matchfound");
   });
 
-  it("waiting wins over matchfound", () => {
-    const { hero } = resolveHomeState({
+  it("waiting beats matchfound", () => {
+    const { heros, secondaries } = resolveHomeState({
       ...empty,
       pending: [pending({})],
       matches: [match({})],
     });
-    expect(hero.kind).toBe("waiting");
+    expect(heros[0]?.kind).toBe("waiting");
+    expect(secondaries[0]?.kind).toBe("matchfound");
   });
 
-  it("confirmed wins over waiting", () => {
-    const { hero } = resolveHomeState({
+  it("confirmed meetup becomes hero; waiting demoted to secondary", () => {
+    const { heros, secondaries } = resolveHomeState({
       ...empty,
       confirmed: [confirmed({})],
       pending: [pending({})],
     });
-    expect(hero.kind).toBe("confirmed");
+    expect(heros).toHaveLength(1);
+    expect(heros[0]?.kind).toBe("confirmed");
+    expect(secondaries[0]?.kind).toBe("waiting");
   });
 
-  it("post wins over confirmed", () => {
+  it("post entries lead heros before upcoming confirmed", () => {
     const past = confirmed({ meetupId: "past", isPast: true, hasReported: false });
     const future = confirmed({ meetupId: "future", isPast: false });
-    const { hero } = resolveHomeState({ ...empty, confirmed: [past, future] });
-    expect(hero.kind).toBe("post");
-    if (hero.kind === "post") expect(hero.meetup.meetupId).toBe("past");
+    const { heros } = resolveHomeState({ ...empty, confirmed: [past, future] });
+    expect(heros.map((h) => h.kind)).toEqual(["post", "confirmed"]);
   });
 
-  it("filters out reported past meetups from post", () => {
+  it("filters out reported past meetups", () => {
     const reported = confirmed({ isPast: true, hasReported: true });
-    const { hero } = resolveHomeState({ ...empty, confirmed: [reported] });
-    expect(hero.kind).toBe("nomeetup");
+    const { heros } = resolveHomeState({ ...empty, confirmed: [reported] });
+    expect(heros[0]?.kind).toBe("nomeetup");
   });
 
-  it("confirmed picks soonest future", () => {
-    const a = confirmed({ meetupId: "a", date: "2099-06-01", time: "10:00" });
-    const b = confirmed({ meetupId: "b", date: "2099-01-01", time: "10:00" });
-    const { hero } = resolveHomeState({ ...empty, confirmed: [a, b] });
-    if (hero.kind === "confirmed") expect(hero.meetup.meetupId).toBe("b");
+  it("upcoming confirmed are ordered chronologically", () => {
+    const a = confirmed({ meetupId: "later", date: "2099-06-01", time: "10:00" });
+    const b = confirmed({ meetupId: "sooner", date: "2099-01-01", time: "10:00" });
+    const { heros } = resolveHomeState({ ...empty, confirmed: [a, b] });
+    const ids = heros.map((h) => (h.kind === "confirmed" ? h.meetup.meetupId : null));
+    expect(ids).toEqual(["sooner", "later"]);
   });
 
-  it("waiting picks oldest pending", () => {
+  it("partner-proposed reschedule jumps to front of upcoming carousel", () => {
+    const earlier = confirmed({
+      meetupId: "earlier",
+      date: "2099-01-01",
+      time: "09:00",
+    });
+    const laterWithAction = confirmed({
+      meetupId: "later",
+      date: "2099-01-01",
+      time: "10:00",
+      reschedulePending: true,
+      rescheduleIsFromMe: false,
+    });
+    const { heros } = resolveHomeState({
+      ...empty,
+      confirmed: [earlier, laterWithAction],
+    });
+    const ids = heros.map((h) => (h.kind === "confirmed" ? h.meetup.meetupId : null));
+    expect(ids).toEqual(["later", "earlier"]);
+  });
+
+  it("self-initiated reschedule does not jump the queue", () => {
+    const earlier = confirmed({ meetupId: "earlier", date: "2099-01-01", time: "09:00" });
+    const laterMine = confirmed({
+      meetupId: "later",
+      date: "2099-01-01",
+      time: "10:00",
+      reschedulePending: true,
+      rescheduleIsFromMe: true,
+    });
+    const { heros } = resolveHomeState({
+      ...empty,
+      confirmed: [earlier, laterMine],
+    });
+    const ids = heros.map((h) => (h.kind === "confirmed" ? h.meetup.meetupId : null));
+    expect(ids).toEqual(["earlier", "later"]);
+  });
+
+  it("waiting heros are ordered oldest pending first", () => {
     const a = pending({ id: "newer", createdAt: "2026-04-28T12:00:00Z" });
     const b = pending({ id: "older", createdAt: "2026-04-28T08:00:00Z" });
-    const { hero } = resolveHomeState({ ...empty, pending: [a, b] });
-    if (hero.kind === "waiting") expect(hero.proposal.id).toBe("older");
+    const { heros } = resolveHomeState({ ...empty, pending: [a, b] });
+    const ids = heros.map((h) => (h.kind === "waiting" ? h.proposal.id : null));
+    expect(ids).toEqual(["older", "newer"]);
   });
 
   it("matchfound picks newest match", () => {
     const a = match({ matchId: "older", matchedAt: "2026-04-20T10:00:00Z" });
     const b = match({ matchId: "newer", matchedAt: "2026-04-28T10:00:00Z" });
-    const { hero } = resolveHomeState({ ...empty, matches: [a, b] });
-    if (hero.kind === "matchfound") expect(hero.match.matchId).toBe("newer");
+    const { heros } = resolveHomeState({ ...empty, matches: [a, b] });
+    expect(heros[0]).toMatchObject({ kind: "matchfound" });
+    if (heros[0]?.kind === "matchfound") expect(heros[0].match.matchId).toBe("newer");
   });
 
-  it("returns up to 2 secondaries below the hero", () => {
-    const { hero, secondaries } = resolveHomeState({
-      confirmed: [confirmed({ isPast: true, hasReported: false })], // post
-      pending: [pending({})], // waiting
-      matches: [match({})], // matchfound
-      discover: [{ spokenLanguages: [] }], // nomeetup
+  it("returns up to 2 secondaries below the meetup carousel", () => {
+    const { heros, secondaries } = resolveHomeState({
+      confirmed: [confirmed({ isPast: true, hasReported: false })],
+      pending: [pending({})],
+      matches: [match({})],
+      discover: [{ spokenLanguages: [] }],
     });
-    expect(hero.kind).toBe("post");
+    expect(heros[0]?.kind).toBe("post");
     expect(secondaries.map((s) => s.kind)).toEqual(["waiting", "matchfound"]);
   });
+});
 
-  it("includes confirmed as secondary when post is hero", () => {
-    const past = confirmed({ meetupId: "past", isPast: true, hasReported: false });
-    const future = confirmed({ meetupId: "future", isPast: false, status: "confirmed" });
-    const { hero, secondaries } = resolveHomeState({ ...empty, confirmed: [past, future] });
-    expect(hero.kind).toBe("post");
-    expect(secondaries[0]?.kind).toBe("confirmed");
+describe("needsAction", () => {
+  it("flags post (rating needed)", () => {
+    expect(
+      needsAction({ kind: "post", meetup: confirmed({ isPast: true }) }),
+    ).toBe(true);
+  });
+
+  it("flags confirmed with partner-proposed reschedule", () => {
+    const state = {
+      kind: "confirmed" as const,
+      meetup: confirmed({ reschedulePending: true, rescheduleIsFromMe: false }),
+    };
+    expect(needsAction(state)).toBe(true);
+  });
+
+  it("does not flag confirmed without reschedule", () => {
+    const state = { kind: "confirmed" as const, meetup: confirmed({}) };
+    expect(needsAction(state)).toBe(false);
+  });
+
+  it("flags waiting that needs my reply", () => {
+    const state = { kind: "waiting" as const, proposal: pending({ isProposer: false }) };
+    expect(needsAction(state)).toBe(true);
+  });
+
+  it("does not flag waiting where I am the proposer", () => {
+    const state = { kind: "waiting" as const, proposal: pending({ isProposer: true }) };
+    expect(needsAction(state)).toBe(false);
+  });
+
+  it("does not flag nomeetup", () => {
+    expect(needsAction({ kind: "nomeetup", matchCount: 0, partners: [] })).toBe(false);
   });
 });

--- a/apps/native/__tests__/mark-messages-as-read.test.tsx
+++ b/apps/native/__tests__/mark-messages-as-read.test.tsx
@@ -70,6 +70,12 @@ jest.mock("@/utils/trpc", () => ({
           queryFn: async () => ({ messages: [] }),
         }),
       },
+      listEntries: {
+        queryOptions: () => ({
+          queryKey: ["chat.listEntries"],
+          queryFn: async () => [],
+        }),
+      },
       markRead: {
         mutationOptions: () => ({
           mutationFn: mockMarkRead,

--- a/apps/native/__tests__/push-suppression-presence.test.tsx
+++ b/apps/native/__tests__/push-suppression-presence.test.tsx
@@ -76,6 +76,12 @@ jest.mock("@/utils/trpc", () => ({
           queryFn: async () => ({ messages: [] }),
         }),
       },
+      listEntries: {
+        queryOptions: () => ({
+          queryKey: ["chat.listEntries"],
+          queryFn: async () => [],
+        }),
+      },
       markRead: {
         mutationOptions: () => ({
           mutationFn: mockMarkRead,

--- a/apps/native/__tests__/read-unread-indicators.test.tsx
+++ b/apps/native/__tests__/read-unread-indicators.test.tsx
@@ -65,6 +65,12 @@ jest.mock("@/utils/trpc", () => ({
           }),
         }),
       },
+      listEntries: {
+        queryOptions: () => ({
+          queryKey: ["chat.listEntries"],
+          queryFn: async () => [],
+        }),
+      },
       markRead: {
         mutationOptions: () => ({ mutationFn: jest.fn().mockResolvedValue({}) }),
       },

--- a/apps/native/app/(tabs)/home.tsx
+++ b/apps/native/app/(tabs)/home.tsx
@@ -13,6 +13,7 @@ import { HeroWaiting } from "@/components/home/hero-waiting";
 import { HeroConfirmed } from "@/components/home/hero-confirmed";
 import { HeroPost } from "@/components/home/hero-post";
 import { SecondaryCard } from "@/components/home/secondary-card";
+import { HeroCarousel } from "@/components/home/hero-carousel";
 import { resolveHomeState, type HomeState } from "@/components/home/home-state";
 import { GOLD } from "@/components/home/tokens";
 
@@ -42,7 +43,7 @@ export default function HomeScreen() {
     },
   }));
 
-  const { hero, secondaries } = resolveHomeState({
+  const { heros, secondaries } = resolveHomeState({
     confirmed: confirmedQuery.data ?? [],
     pending: (pendingQuery.data ?? []).map((p) => ({
       id: p.id,
@@ -83,7 +84,7 @@ export default function HomeScreen() {
     }
   }
 
-  function renderHero() {
+  function renderHero(hero: HomeState) {
     switch (hero.kind) {
       case "post":
         return (
@@ -188,7 +189,7 @@ export default function HomeScreen() {
           </Pressable>
         </View>
 
-        {renderHero()}
+        <HeroCarousel heros={heros} renderHero={renderHero} />
 
         {secondaries.length > 0 && (
           <View className="mt-8">

--- a/apps/native/app/chat/[conversationId].tsx
+++ b/apps/native/app/chat/[conversationId].tsx
@@ -1,11 +1,22 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { useLocalSearchParams } from "expo-router";
+import { useLocalSearchParams, useRouter } from "expo-router";
 import { useFocusEffect } from "expo-router";
-import { useCallback, useEffect, useRef, useState } from "react";
-import { AppState, FlatList, Text, TextInput, TouchableOpacity, View } from "react-native";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  AppState,
+  FlatList,
+  Image,
+  KeyboardAvoidingView,
+  Platform,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { authClient } from "@/lib/auth-client";
-import { Container } from "@/components/container";
 import { trpc } from "@/utils/trpc";
 
 function formatTime(date: Date | string): string {
@@ -13,7 +24,56 @@ function formatTime(date: Date | string): string {
   return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
 }
 
+function startOfDay(d: Date): number {
+  const x = new Date(d);
+  x.setHours(0, 0, 0, 0);
+  return x.getTime();
+}
+
+function formatDayLabel(date: Date): string {
+  const today = startOfDay(new Date());
+  const day = startOfDay(date);
+  const diffDays = Math.round((today - day) / (1000 * 60 * 60 * 24));
+  if (diffDays === 0) return "TODAY";
+  if (diffDays === 1) return "YESTERDAY";
+  if (diffDays < 7)
+    return date.toLocaleDateString([], { weekday: "long" }).toUpperCase();
+  return date
+    .toLocaleDateString([], { month: "short", day: "numeric" })
+    .toUpperCase();
+}
+
+type Message = {
+  id: string;
+  conversationId: string;
+  senderId: string;
+  content: string;
+  createdAt: Date | string;
+  isUnread: boolean;
+};
+
+type Row =
+  | { kind: "divider"; id: string; label: string }
+  | { kind: "message"; id: string; message: Message };
+
+function buildRows(messages: Message[]): Row[] {
+  const rows: Row[] = [];
+  let lastDay: number | null = null;
+  for (const m of messages) {
+    const d = typeof m.createdAt === "string" ? new Date(m.createdAt) : m.createdAt;
+    const day = startOfDay(d);
+    if (day !== lastDay) {
+      rows.push({ kind: "divider", id: `div-${day}`, label: formatDayLabel(d) });
+      lastDay = day;
+    }
+    rows.push({ kind: "message", id: m.id, message: m });
+  }
+  return rows;
+}
+
 export default function ChatScreen() {
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
   const { conversationId } = useLocalSearchParams<{ conversationId: string }>();
   const { data: session } = authClient.useSession();
   const currentUserId = session?.user.id;
@@ -24,13 +84,8 @@ export default function ChatScreen() {
   const listRef = useRef<FlatList>(null);
   const queryClient = useQueryClient();
 
-  const markRead = useMutation(
-    trpc.chat.markRead.mutationOptions(),
-  );
-
-  const setPresence = useMutation(
-    trpc.messaging.setPresence.mutationOptions(),
-  );
+  const markRead = useMutation(trpc.chat.markRead.mutationOptions());
+  const setPresence = useMutation(trpc.messaging.setPresence.mutationOptions());
 
   useFocusEffect(
     useCallback(() => {
@@ -38,13 +93,11 @@ export default function ChatScreen() {
         { conversationId },
         {
           onSuccess: () => {
-            // Invalidate getMessages so isUnread indicators refresh
             void queryClient.invalidateQueries({ queryKey: ["chat.getMessages"] });
           },
         },
       );
 
-      // #153 — Signal active presence so push notifications are suppressed while viewing
       setPresence.mutate({ conversationId, active: true });
 
       const appStateSub = AppState.addEventListener("change", (nextState) => {
@@ -69,7 +122,17 @@ export default function ChatScreen() {
     ),
   );
 
-  const messages = data?.messages ?? [];
+  const { data: entries } = useQuery(trpc.chat.listEntries.queryOptions());
+  const partner = useMemo(() => {
+    const entry = entries?.find(
+      (e) => e.kind === "open" && e.id === conversationId,
+    );
+    if (entry && entry.kind === "open") return entry.partner;
+    return null;
+  }, [entries, conversationId]);
+
+  const messages = (data?.messages ?? []) as Message[];
+  const rows = useMemo(() => buildRows(messages), [messages]);
 
   useEffect(() => {
     if (messages.length > 0) {
@@ -103,90 +166,169 @@ export default function ChatScreen() {
   }
 
   const isPending = sendMessage.isPending;
+  const partnerInitial = (partner?.name?.trim()?.[0] ?? "?").toUpperCase();
 
   return (
-    <Container isScrollable={false}>
-      <FlatList
-        ref={listRef}
-        testID="message-list"
-        data={messages}
-        keyExtractor={(item) => item.id}
-        onContentSizeChange={() => listRef.current?.scrollToEnd({ animated: false })}
-        ListEmptyComponent={
-          <View testID="empty-conversation-state" className="flex-1 items-center justify-center py-16 px-8">
-            <Text className="text-muted-foreground text-center text-base">
-              No messages yet. Say hi to start the conversation!
+    <View className="flex-1 bg-brand-background" style={{ paddingTop: insets.top }}>
+      <View className="flex-row items-center px-4 py-3 gap-3">
+        <TouchableOpacity
+          testID="chat-back-btn"
+          accessibilityLabel="Back"
+          onPress={() => router.back()}
+          hitSlop={12}
+        >
+          <Ionicons name="arrow-back" size={24} color="#2C1810" />
+        </TouchableOpacity>
+        <View className="w-11 h-11 rounded-full bg-brand-muted items-center justify-center overflow-hidden">
+          {partner?.image ? (
+            <Image
+              source={{ uri: partner.image }}
+              className="w-11 h-11 rounded-full"
+            />
+          ) : (
+            <Text className="text-brand-foreground font-manrope-bold text-lg">
+              {partnerInitial}
+            </Text>
+          )}
+        </View>
+        <View className="flex-1">
+          <Text className="text-brand-foreground font-manrope-bold text-base">
+            {partner?.name ?? "Chat"}
+          </Text>
+          <View className="flex-row items-center gap-1.5 mt-0.5">
+            <View className="w-1.5 h-1.5 rounded-full bg-brand-green" />
+            <Text className="text-brand-muted-foreground font-manrope text-xs">
+              open chat
             </Text>
           </View>
-        }
-        renderItem={({ item }) => {
-          const isMine = item.senderId === currentUserId;
-          return (
+        </View>
+        <TouchableOpacity
+          testID="chat-info-btn"
+          accessibilityLabel="Conversation info"
+          hitSlop={12}
+        >
+          <Ionicons name="information-circle-outline" size={24} color="#6F605B" />
+        </TouchableOpacity>
+      </View>
+
+      <KeyboardAvoidingView
+        className="flex-1"
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+        keyboardVerticalOffset={Platform.OS === "ios" ? insets.top + 8 : 0}
+      >
+        <FlatList
+          ref={listRef}
+          testID="message-list"
+          data={rows}
+          keyExtractor={(item) => item.id}
+          contentContainerStyle={{ paddingVertical: 8 }}
+          onContentSizeChange={() =>
+            listRef.current?.scrollToEnd({ animated: false })
+          }
+          ListEmptyComponent={
             <View
-              testID="message-bubble"
-              className={`mx-4 my-1 max-w-[80%] rounded-2xl px-3 py-2 ${isMine ? "self-end bg-primary" : item.isUnread ? "self-start bg-muted border-l-2 border-primary" : "self-start bg-muted"}`}
+              testID="empty-conversation-state"
+              className="flex-1 items-center justify-center py-16 px-8"
             >
-              {!isMine && (
-                <Text testID="message-sender" className="text-xs text-muted-foreground mb-1">
-                  Match
-                </Text>
-              )}
-              <Text
-                className={`${isMine ? "text-primary-foreground" : "text-foreground"} ${item.isUnread && !isMine ? "font-semibold" : ""}`}
-              >
-                {item.content}
+              <Text className="text-brand-muted-foreground font-manrope text-center text-base">
+                No messages yet. Say hi to start the conversation!
               </Text>
-              <View className="flex-row items-center justify-end gap-1 mt-1">
-                {item.isUnread && !isMine && (
-                  <View
-                    testID="unread-indicator"
-                    className="w-2 h-2 rounded-full bg-primary"
-                  />
+            </View>
+          }
+          renderItem={({ item }) => {
+            if (item.kind === "divider") {
+              return (
+                <View className="items-center my-3">
+                  <Text className="text-brand-muted-foreground font-manrope-semi tracking-widest text-[11px]">
+                    {item.label}
+                  </Text>
+                </View>
+              );
+            }
+            const msg = item.message;
+            const isMine = msg.senderId === currentUserId;
+            return (
+              <View
+                testID="message-bubble"
+                className={`mx-4 my-1 max-w-[78%] rounded-3xl px-4 py-2.5 ${
+                  isMine
+                    ? "self-end bg-brand-gold"
+                    : "self-start bg-brand-muted"
+                }`}
+              >
+                {!isMine && (
+                  <Text
+                    testID="message-sender"
+                    className="text-brand-muted-foreground font-manrope text-[11px] mb-0.5"
+                  >
+                    {partner?.name ?? "Match"}
+                  </Text>
                 )}
                 <Text
-                  testID="message-timestamp"
-                  className={`text-xs ${isMine ? "text-primary-foreground/70" : "text-muted-foreground"}`}
+                  className={`font-manrope text-brand-foreground ${
+                    msg.isUnread && !isMine ? "font-manrope-semi" : ""
+                  }`}
                 >
-                  {formatTime(item.createdAt)}
+                  {msg.content}
                 </Text>
+                <View className="flex-row items-center justify-end gap-1 mt-0.5">
+                  {msg.isUnread && !isMine && (
+                    <View
+                      testID="unread-indicator"
+                      className="w-1.5 h-1.5 rounded-full bg-brand-primary"
+                    />
+                  )}
+                  <Text
+                    testID="message-timestamp"
+                    className="text-brand-foreground/50 font-manrope text-[10px]"
+                  >
+                    {formatTime(msg.createdAt)}
+                  </Text>
+                </View>
               </View>
-            </View>
-          );
-        }}
-      />
+            );
+          }}
+        />
 
-      <View className="border-t border-border px-4 py-3 gap-2">
-        {showEmptyHint && (
-          <Text testID="empty-hint" className="text-danger text-sm">
-            Message cannot be empty.
-          </Text>
-        )}
-        {sendError && (
-          <Text className="text-danger text-sm">{sendError}</Text>
-        )}
-        <View className="flex-row items-end gap-2">
-          <TextInput
-            testID="message-input"
-            className="flex-1 border border-border rounded-xl px-3 py-2 text-foreground bg-background"
-            placeholder="Type a message…"
-            placeholderTextColor="gray"
-            multiline
-            value={content}
-            onChangeText={handleChangeText}
-            editable={!isPending}
-            accessibilityLabel="Message input"
-          />
-          <TouchableOpacity
-            testID="send-btn"
-            onPress={handleSend}
-            disabled={isPending}
-            accessibilityState={{ disabled: isPending }}
-            className="bg-primary rounded-xl px-4 py-2 justify-center"
-          >
-            <Text className="text-primary-foreground font-semibold">Send</Text>
-          </TouchableOpacity>
+        <View
+          className="px-4 pt-2 gap-2"
+          style={{ paddingBottom: insets.bottom + 8 }}
+        >
+          {showEmptyHint && (
+            <Text testID="empty-hint" className="text-red-500 font-manrope text-sm">
+              Message cannot be empty.
+            </Text>
+          )}
+          {sendError && (
+            <Text className="text-red-500 font-manrope text-sm">{sendError}</Text>
+          )}
+          <View className="flex-row items-center gap-2">
+            <View className="flex-1 rounded-full bg-white border border-brand-border px-5 py-1">
+              <TextInput
+                testID="message-input"
+                className="text-brand-foreground font-manrope text-base py-2"
+                placeholder="Type a message…"
+                placeholderTextColor="#6F605B"
+                multiline
+                value={content}
+                onChangeText={handleChangeText}
+                editable={!isPending}
+                accessibilityLabel="Message input"
+              />
+            </View>
+            <TouchableOpacity
+              testID="send-btn"
+              onPress={handleSend}
+              disabled={isPending}
+              accessibilityState={{ disabled: isPending }}
+              accessibilityLabel="Send message"
+              className="w-12 h-12 rounded-full bg-brand-gold items-center justify-center"
+            >
+              <Ionicons name="arrow-up" size={22} color="#2C1810" />
+            </TouchableOpacity>
+          </View>
         </View>
-      </View>
-    </Container>
+      </KeyboardAvoidingView>
+    </View>
   );
 }

--- a/apps/native/components/home/hero-carousel.tsx
+++ b/apps/native/components/home/hero-carousel.tsx
@@ -1,0 +1,121 @@
+import { useCallback, useRef, useState } from "react";
+import {
+  FlatList,
+  type LayoutChangeEvent,
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
+  Pressable,
+  View,
+} from "react-native";
+
+import { needsAction, type HomeState } from "./home-state";
+import { GOLD } from "./tokens";
+
+type Props = {
+  heros: HomeState[];
+  renderHero: (state: HomeState) => React.ReactNode;
+};
+
+const DOT_SIZE = 6;
+const DOT_GAP = 6;
+
+export function HeroCarousel({ heros, renderHero }: Props) {
+  const [width, setWidth] = useState(0);
+  const [index, setIndex] = useState(0);
+  const listRef = useRef<FlatList<HomeState>>(null);
+
+  const handleLayout = useCallback((e: LayoutChangeEvent) => {
+    setWidth(e.nativeEvent.layout.width);
+  }, []);
+
+  const handleScroll = useCallback(
+    (e: NativeSyntheticEvent<NativeScrollEvent>) => {
+      if (width === 0) return;
+      const next = Math.round(e.nativeEvent.contentOffset.x / width);
+      if (next !== index) setIndex(next);
+    },
+    [width, index],
+  );
+
+  const jumpTo = useCallback(
+    (i: number) => {
+      if (width === 0) return;
+      listRef.current?.scrollToOffset({ offset: i * width, animated: true });
+      setIndex(i);
+    },
+    [width],
+  );
+
+  if (heros.length === 0) return null;
+  if (heros.length === 1) {
+    return <View testID="hero-carousel">{renderHero(heros[0]!)}</View>;
+  }
+
+  return (
+    <View testID="hero-carousel" onLayout={handleLayout}>
+      {width > 0 && (
+        <FlatList
+          ref={listRef}
+          data={heros}
+          horizontal
+          pagingEnabled
+          showsHorizontalScrollIndicator={false}
+          keyExtractor={heroKey}
+          onScroll={handleScroll}
+          scrollEventThrottle={16}
+          renderItem={({ item }) => (
+            <View style={{ width }}>{renderHero(item)}</View>
+          )}
+        />
+      )}
+      <View
+        testID="hero-carousel-dots"
+        className="flex-row items-center justify-center mt-3"
+        style={{ gap: DOT_GAP }}
+      >
+        {heros.map((state, i) => {
+          const active = i === index;
+          const action = i !== index && needsAction(state);
+          return (
+            <Pressable
+              key={heroKey(state, i)}
+              testID={
+                action
+                  ? `hero-carousel-dot-action-${i}`
+                  : `hero-carousel-dot-${i}`
+              }
+              onPress={() => jumpTo(i)}
+              hitSlop={8}
+              style={{
+                width: active ? DOT_SIZE * 2 : DOT_SIZE,
+                height: DOT_SIZE,
+                borderRadius: DOT_SIZE / 2,
+                backgroundColor: active
+                  ? GOLD
+                  : action
+                    ? GOLD
+                    : "rgba(0,0,0,0.18)",
+                opacity: active ? 1 : action ? 0.85 : 1,
+              }}
+            />
+          );
+        })}
+      </View>
+    </View>
+  );
+}
+
+function heroKey(state: HomeState, fallback?: number): string {
+  switch (state.kind) {
+    case "post":
+      return `post-${state.meetup.meetupId}`;
+    case "confirmed":
+      return `confirmed-${state.meetup.meetupId}`;
+    case "waiting":
+      return `waiting-${state.proposal.id}`;
+    case "matchfound":
+      return `match-${state.match.matchId}`;
+    case "nomeetup":
+      return `nomeetup-${fallback ?? 0}`;
+  }
+}

--- a/apps/native/components/home/home-state.ts
+++ b/apps/native/components/home/home-state.ts
@@ -54,25 +54,44 @@ type Inputs = {
   discover: DiscoverPartner[];
 };
 
-const PRIORITY: HomeState["kind"][] = ["post", "confirmed", "waiting", "matchfound", "nomeetup"];
-
-function pickPost(confirmed: ConfirmedMeetup[]): ConfirmedMeetup | null {
-  const candidates = confirmed.filter((m) => m.isPast && !m.hasReported);
-  if (candidates.length === 0) return null;
-  return [...candidates].sort((a, b) => `${b.date}T${b.time}`.localeCompare(`${a.date}T${a.time}`))[0]!;
+function needsAction(state: HomeState): boolean {
+  switch (state.kind) {
+    case "post":
+      return true;
+    case "confirmed":
+      return state.meetup.reschedulePending && !state.meetup.rescheduleIsFromMe;
+    case "waiting":
+      return !state.proposal.isProposer;
+    case "matchfound":
+      return true;
+    case "nomeetup":
+      return false;
+  }
 }
 
-function pickConfirmed(confirmed: ConfirmedMeetup[]): ConfirmedMeetup | null {
-  const candidates = confirmed.filter((m) => !m.isPast && m.status === "confirmed");
-  if (candidates.length === 0) return null;
-  return [...candidates].sort((a, b) => `${a.date}T${a.time}`.localeCompare(`${b.date}T${b.time}`))[0]!;
+function buildPostList(confirmed: ConfirmedMeetup[]): HomeState[] {
+  return confirmed
+    .filter((m) => m.isPast && !m.hasReported)
+    .sort((a, b) => `${b.date}T${b.time}`.localeCompare(`${a.date}T${a.time}`))
+    .map((m) => ({ kind: "post", meetup: m }));
 }
 
-function pickWaiting(pending: PendingProposal[]): PendingProposal | null {
-  if (pending.length === 0) return null;
-  return [...pending].sort(
-    (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
-  )[0]!;
+function buildConfirmedList(confirmed: ConfirmedMeetup[]): HomeState[] {
+  return confirmed
+    .filter((m) => !m.isPast && m.status === "confirmed")
+    .sort((a, b) => {
+      const aAction = a.reschedulePending && !a.rescheduleIsFromMe ? 1 : 0;
+      const bAction = b.reschedulePending && !b.rescheduleIsFromMe ? 1 : 0;
+      if (aAction !== bAction) return bAction - aAction;
+      return `${a.date}T${a.time}`.localeCompare(`${b.date}T${b.time}`);
+    })
+    .map((m) => ({ kind: "confirmed", meetup: m }));
+}
+
+function buildWaitingList(pending: PendingProposal[]): HomeState[] {
+  return [...pending]
+    .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
+    .map((p) => ({ kind: "waiting", proposal: p }));
 }
 
 function pickMatchfound(matches: MyMatch[]): MyMatch | null {
@@ -82,34 +101,36 @@ function pickMatchfound(matches: MyMatch[]): MyMatch | null {
   )[0]!;
 }
 
-function buildState(kind: HomeState["kind"], inputs: Inputs): HomeState | null {
-  switch (kind) {
-    case "post": {
-      const m = pickPost(inputs.confirmed);
-      return m ? { kind: "post", meetup: m } : null;
-    }
-    case "confirmed": {
-      const m = pickConfirmed(inputs.confirmed);
-      return m ? { kind: "confirmed", meetup: m } : null;
-    }
-    case "waiting": {
-      const p = pickWaiting(inputs.pending);
-      return p ? { kind: "waiting", proposal: p } : null;
-    }
-    case "matchfound": {
-      const m = pickMatchfound(inputs.matches);
-      return m ? { kind: "matchfound", match: m } : null;
-    }
-    case "nomeetup":
-      return { kind: "nomeetup", matchCount: inputs.discover.length, partners: inputs.discover };
-  }
-}
+export function resolveHomeState(inputs: Inputs): { heros: HomeState[]; secondaries: HomeState[] } {
+  const posts = buildPostList(inputs.confirmed);
+  const upcomings = buildConfirmedList(inputs.confirmed);
+  const meetupHeros = [...posts, ...upcomings];
 
-export function resolveHomeState(inputs: Inputs): { hero: HomeState; secondaries: HomeState[] } {
-  const states = PRIORITY.map((k) => buildState(k, inputs)).filter((s): s is HomeState => s !== null);
-  const [hero, ...rest] = states;
+  if (meetupHeros.length > 0) {
+    const secondaries: HomeState[] = [];
+    const waiting = buildWaitingList(inputs.pending)[0];
+    if (waiting) secondaries.push(waiting);
+    const top = pickMatchfound(inputs.matches);
+    if (top) secondaries.push({ kind: "matchfound", match: top });
+    return { heros: meetupHeros, secondaries: secondaries.slice(0, 2) };
+  }
+
+  const waitingList = buildWaitingList(inputs.pending);
+  if (waitingList.length > 0) {
+    const top = pickMatchfound(inputs.matches);
+    return {
+      heros: waitingList,
+      secondaries: top ? [{ kind: "matchfound", match: top }] : [],
+    };
+  }
+
+  const top = pickMatchfound(inputs.matches);
+  if (top) return { heros: [{ kind: "matchfound", match: top }], secondaries: [] };
+
   return {
-    hero: hero ?? { kind: "nomeetup", matchCount: 0, partners: [] },
-    secondaries: rest.slice(0, 2),
+    heros: [{ kind: "nomeetup", matchCount: inputs.discover.length, partners: inputs.discover }],
+    secondaries: [],
   };
 }
+
+export { needsAction };


### PR DESCRIPTION
## Summary
- Swipeable Home hero carousel for upcoming Meet-Ups (#358)
- Redesigned chat screen to match Barista Blend mockup: header with partner avatar/name/status, day dividers, gold/muted bubbles, pill input with circular send button

## Test plan
- [ ] Open Home tab — swipe through upcoming Meet-Ups carousel
- [ ] Open a chat — verify header, day dividers, bubble colors, input/send button match design
- [ ] Send a message — input clears, bubble appears
- [ ] Verify empty conversation state still renders
- [ ] Verify unread indicators still show on unread partner messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)