### PR TITLE
fix(native): hydrate profile modal after onboarding completes

### DIFF
--- a/apps/native/__tests__/profile-modal-hydration.test.tsx
+++ b/apps/native/__tests__/profile-modal-hydration.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * Regression test for bug #360 — Profile modal does not hydrate after
+ * onboarding completes in the same session.
+ *
+ * Race: profileQuery resolves first with null name/surname (pre-onboarding),
+ * then refetches with populated identity after `setIdentityProfile` writes.
+ * Local input state must be seeded from the refetch.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, render, screen, waitFor } from "@testing-library/react-native";
+import React from "react";
+
+jest.mock("expo-updates", () => ({
+  checkForUpdateAsync: jest.fn().mockResolvedValue({ isAvailable: false }),
+  fetchUpdateAsync: jest.fn(),
+  reloadAsync: jest.fn(),
+  updateId: null,
+}));
+
+jest.mock("expo-constants", () => ({
+  default: { expoConfig: { version: "0.0.0" } },
+}));
+
+jest.mock("heroui-native", () => ({
+  useToast: () => ({ toast: { show: jest.fn() } }),
+}));
+
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock("@/lib/auth-client", () => ({
+  authClient: {
+    useSession: () => ({ data: null }),
+    signOut: jest.fn(),
+  },
+}));
+
+jest.mock("@/utils/profile-picture", () => ({
+  pickAndEncodeProfilePicture: jest.fn(),
+}));
+
+jest.mock("@/components/language-picker-modal", () => ({
+  LanguagePickerModal: () => null,
+}));
+
+const mockSetIdentityMutate = jest.fn();
+const mockProfileQueryFn = jest.fn();
+
+jest.mock("@/utils/trpc", () => ({
+  trpc: {
+    profile: {
+      getMyProfile: {
+        queryOptions: () => ({
+          queryKey: ["profile.getMyProfile"],
+          queryFn: mockProfileQueryFn,
+        }),
+      },
+      setIdentityProfile: {
+        mutationOptions: () => ({
+          mutationFn: (vars: unknown) => {
+            mockSetIdentityMutate(vars);
+            return Promise.resolve({ ok: true });
+          },
+        }),
+      },
+      upsertLanguage: {
+        mutationOptions: () => ({ mutationFn: jest.fn() }),
+      },
+      removeLanguage: {
+        mutationOptions: () => ({ mutationFn: jest.fn() }),
+      },
+      toggleInterest: {
+        mutationOptions: () => ({ mutationFn: jest.fn() }),
+      },
+    },
+  },
+  queryClient: { invalidateQueries: jest.fn(), clear: jest.fn() },
+}));
+
+import { ProfileModal } from "../components/profile-modal";
+
+function renderModal(client: QueryClient) {
+  return render(
+    <QueryClientProvider client={client}>
+      <ProfileModal visible={true} onDismiss={() => {}} />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  mockSetIdentityMutate.mockReset();
+  mockProfileQueryFn.mockReset();
+});
+
+describe("#360 — profile modal hydration after onboarding", () => {
+  it("seeds name + surname + image when identity arrives in a later refetch", async () => {
+    mockProfileQueryFn.mockResolvedValueOnce({
+      identity: { name: null, surname: null, image: null, email: "a@b.c" },
+      profile: null,
+      languages: [],
+      interests: [],
+    });
+
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    renderModal(client);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("Anna").props.value).toBe("");
+      expect(screen.getByPlaceholderText("de Vries").props.value).toBe("");
+    });
+
+    mockProfileQueryFn.mockResolvedValueOnce({
+      identity: {
+        name: "Anna",
+        surname: "Smith",
+        image: "data:image/jpeg;base64,xyz",
+        email: "a@b.c",
+      },
+      profile: null,
+      languages: [],
+      interests: [],
+    });
+
+    await act(async () => {
+      await client.invalidateQueries({ queryKey: ["profile.getMyProfile"] });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("Anna").props.value).toBe("Anna");
+      expect(screen.getByPlaceholderText("de Vries").props.value).toBe("Smith");
+    });
+  });
+});

--- a/apps/native/components/profile-modal.tsx
+++ b/apps/native/components/profile-modal.tsx
@@ -59,7 +59,6 @@ export function ProfileModal({ visible, onDismiss }: ProfileModalProps) {
   const [nameInput, setNameInput] = useState("");
   const [surnameInput, setSurnameInput] = useState("");
   const [imageUri, setImageUri] = useState<string | undefined>();
-  const [identityInitialized, setIdentityInitialized] = useState(false);
   const [addingType, setAddingType] = useState<"spoken" | "learning" | null>(
     null,
   );
@@ -67,6 +66,14 @@ export function ProfileModal({ visible, onDismiss }: ProfileModalProps) {
   const [isUpdating, setIsUpdating] = useState(false);
 
   const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingSaveRef = useRef(false);
+  const nameFocusedRef = useRef(false);
+  const surnameFocusedRef = useRef(false);
+  const lastHydratedRef = useRef<{
+    name: string | null;
+    surname: string | null;
+    image: string | null;
+  }>({ name: null, surname: null, image: null });
 
   useEffect(() => {
     if (__DEV__) return;
@@ -90,19 +97,38 @@ export function ProfileModal({ visible, onDismiss }: ProfileModalProps) {
   }
 
   useEffect(() => {
-    if (identityInitialized || !profileQuery.data) return;
+    if (!profileQuery.data) return;
     const identity = profileQuery.data.identity;
-    if (identity?.name || identity?.surname) {
-      setNameInput(identity.name ?? "");
-      setSurnameInput(identity.surname ?? "");
+    const serverName = identity?.name ?? null;
+    const serverSurname = identity?.surname ?? null;
+    const serverImage = identity?.image ?? null;
+    const last = lastHydratedRef.current;
+    const isPending = pendingSaveRef.current;
+
+    if (serverName !== last.name && !nameFocusedRef.current && !isPending) {
+      setNameInput(serverName ?? "");
+      last.name = serverName;
     }
-    setImageUri(identity?.image ?? undefined);
-    setIdentityInitialized(true);
-  }, [profileQuery.data, identityInitialized]);
+    if (
+      serverSurname !== last.surname &&
+      !surnameFocusedRef.current &&
+      !isPending
+    ) {
+      setSurnameInput(serverSurname ?? "");
+      last.surname = serverSurname;
+    }
+    if (serverImage !== last.image && !isPending) {
+      setImageUri(serverImage ?? undefined);
+      last.image = serverImage;
+    }
+  }, [profileQuery.data]);
 
   const setIdentityMutation = useMutation({
     ...trpc.profile.setIdentityProfile.mutationOptions(),
     onSuccess: () => queryClient.invalidateQueries(),
+    onSettled: () => {
+      pendingSaveRef.current = false;
+    },
     onError: (e) => {
       toast.show({
         variant: "danger",
@@ -136,11 +162,18 @@ export function ProfileModal({ visible, onDismiss }: ProfileModalProps) {
     const n = name.trim();
     const s = surname.trim();
     if (!n || !s) return;
+    pendingSaveRef.current = true;
+    lastHydratedRef.current = {
+      name: n,
+      surname: s,
+      image: image ?? null,
+    };
     setIdentityMutation.mutate({ name: n, surname: s, imageUrl: image });
   }
 
   function scheduleIdentitySave(name: string, surname: string) {
     if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current);
+    pendingSaveRef.current = true;
     saveTimeoutRef.current = setTimeout(() => {
       saveIdentity(name, surname, imageUri);
     }, 1200);
@@ -243,9 +276,13 @@ export function ProfileModal({ visible, onDismiss }: ProfileModalProps) {
                       setNameInput(v);
                       scheduleIdentitySave(v, surnameInput);
                     }}
-                    onBlur={() =>
-                      saveIdentity(nameInput, surnameInput, imageUri)
-                    }
+                    onFocus={() => {
+                      nameFocusedRef.current = true;
+                    }}
+                    onBlur={() => {
+                      nameFocusedRef.current = false;
+                      saveIdentity(nameInput, surnameInput, imageUri);
+                    }}
                     placeholder="Anna"
                     placeholderTextColor={BORDER}
                     autoCapitalize="words"
@@ -266,9 +303,13 @@ export function ProfileModal({ visible, onDismiss }: ProfileModalProps) {
                       setSurnameInput(v);
                       scheduleIdentitySave(nameInput, v);
                     }}
-                    onBlur={() =>
-                      saveIdentity(nameInput, surnameInput, imageUri)
-                    }
+                    onFocus={() => {
+                      surnameFocusedRef.current = true;
+                    }}
+                    onBlur={() => {
+                      surnameFocusedRef.current = false;
+                      saveIdentity(nameInput, surnameInput, imageUri);
+                    }}
                     placeholder="de Vries"
                     placeholderTextColor={BORDER}
                     autoCapitalize="words"


### PR DESCRIPTION
## Summary

- Drops one-shot `identityInitialized` flag in `apps/native/components/profile-modal.tsx`; replaces it with a re-seeding effect that mirrors `getMyProfile.identity` into local state whenever the server values change.
- Guards re-seeding with per-field focus refs and a `pendingSaveRef` so we never clobber an in-flight edit or pending debounced save.
- Adds `apps/native/__tests__/profile-modal-hydration.test.tsx` covering the race: first refetch is empty, second resolves with populated identity → inputs become populated.

Closes #360

## Test plan

- [x] `bun run test --testPathPatterns profile-modal-hydration` passes
- [x] Other pre-existing test suite failures verified unrelated (same failures on clean origin/main)
- [ ] Manual: complete onboarding, open Profile from Home — name/surname/avatar populate without app restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)