### PR TITLE
fix(native): stop leaking meetup time/location on locked chat

### DIFF
--- a/apps/native/__tests__/locked-chat-no-meetup-leak.test.tsx
+++ b/apps/native/__tests__/locked-chat-no-meetup-leak.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * Regression test for bug #361 — Locked chat detail must not leak meetup
+ * location / weekday / countdown / time, and the header subtitle must NOT
+ * claim a time-based unlock for the `scheduled` phase.
+ *
+ * Real unlock rule: both partners rate and opt in via "Keep in touch."
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react-native";
+import React from "react";
+
+jest.mock("expo-router", () => ({
+  useLocalSearchParams: () => ({ meetupId: "m-1" }),
+  useRouter: () => ({ push: jest.fn(), back: jest.fn() }),
+}));
+
+jest.mock("@expo/vector-icons", () => ({
+  Ionicons: () => null,
+}));
+
+const mockListEntries = jest.fn();
+
+jest.mock("@/utils/trpc", () => ({
+  trpc: {
+    chat: {
+      listEntries: {
+        queryOptions: () => ({
+          queryKey: ["chat.listEntries"],
+          queryFn: mockListEntries,
+        }),
+      },
+    },
+    messaging: {
+      respondToOptIn: {
+        mutationOptions: () => ({ mutationFn: jest.fn() }),
+      },
+    },
+    meetup: {
+      getConfirmed: {
+        queryOptions: () => ({ queryKey: ["meetup.getConfirmed"] }),
+      },
+    },
+  },
+  queryClient: { invalidateQueries: jest.fn() },
+}));
+
+import LockedChatScreen from "../app/chat/locked/[meetupId]";
+
+function renderScreen() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <LockedChatScreen />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  mockListEntries.mockReset();
+});
+
+describe("#361 — locked chat detail does not leak meetup info", () => {
+  it("does not render meetup-strip in scheduled phase", async () => {
+    const future = new Date(Date.now() + 1000 * 60 * 60 * 26).toISOString();
+    mockListEntries.mockResolvedValue([
+      {
+        kind: "locked",
+        id: "m-1",
+        meetupId: "m-1",
+        partner: { id: "p", name: "Anna", image: null },
+        venue: { id: "v", name: "Café Foo", photoUrl: null },
+        meetupAt: future,
+        phase: "scheduled",
+      },
+    ]);
+
+    renderScreen();
+
+    await screen.findByTestId("locked-card");
+    expect(screen.queryByTestId("meetup-strip")).toBeNull();
+    expect(screen.queryByText(/Café Foo/i)).toBeNull();
+    expect(screen.queryByText(/CAFÉ FOO/i)).toBeNull();
+  });
+
+  it("header subtitle stays neutral — no unlocks-today / time / weekday leak", async () => {
+    const future = new Date(Date.now() + 1000 * 60 * 60 * 3).toISOString();
+    mockListEntries.mockResolvedValue([
+      {
+        kind: "locked",
+        id: "m-1",
+        meetupId: "m-1",
+        partner: { id: "p", name: "Anna", image: null },
+        venue: { id: "v", name: "Café Foo", photoUrl: null },
+        meetupAt: future,
+        phase: "scheduled",
+      },
+    ]);
+
+    renderScreen();
+
+    const status = await screen.findByTestId("locked-status");
+    expect(status.props.children).toBe("locked · meet first");
+  });
+
+  it("body copy matches real unlock rule (no check-in claim)", async () => {
+    const future = new Date(Date.now() + 1000 * 60 * 60 * 24).toISOString();
+    mockListEntries.mockResolvedValue([
+      {
+        kind: "locked",
+        id: "m-1",
+        meetupId: "m-1",
+        partner: { id: "p", name: "Anna", image: null },
+        venue: { id: "v", name: "Café Foo", photoUrl: null },
+        meetupAt: future,
+        phase: "scheduled",
+      },
+    ]);
+
+    renderScreen();
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText(/check in at the café/i),
+      ).toBeNull();
+      expect(
+        screen.getByText(/meet and choose to keep in touch/i),
+      ).toBeTruthy();
+    });
+  });
+});

--- a/apps/native/app/chat/locked/[meetupId].tsx
+++ b/apps/native/app/chat/locked/[meetupId].tsx
@@ -28,7 +28,7 @@ function copyForPhase(phase: LockedPhase, partnerFirstName: string) {
     case "scheduled":
       return {
         headline: "Meet first. Message after.",
-        body: "Chat opens when you both check in at the café.",
+        body: "Chat opens after you both meet and choose to keep in touch.",
         cta: "See meetup details",
       };
     case "awaiting_attendance":
@@ -58,42 +58,8 @@ function copyForPhase(phase: LockedPhase, partnerFirstName: string) {
   }
 }
 
-function formatMeetupStrip(meetupAt: Date, venueName: string) {
-  const weekday = meetupAt
-    .toLocaleDateString([], { weekday: "short" })
-    .toUpperCase();
-  const time = meetupAt.toLocaleTimeString([], {
-    hour: "2-digit",
-    minute: "2-digit",
-  });
-  const diffMs = meetupAt.getTime() - Date.now();
-  const totalMin = Math.max(0, Math.round(diffMs / 60_000));
-  const days = Math.floor(totalMin / (60 * 24));
-  const hours = Math.floor((totalMin % (60 * 24)) / 60);
-  const countdown =
-    diffMs <= 0
-      ? "now"
-      : days > 0
-        ? `in ${days}d ${hours}h`
-        : `in ${hours}h`;
-  return { weekday, venueName: venueName.toUpperCase(), countdown, time };
-}
-
-function headerSubtitle(phase: LockedPhase, meetupAt: Date): string {
-  if (phase === "scheduled") {
-    const diffDays = (meetupAt.getTime() - Date.now()) / (1000 * 60 * 60 * 24);
-    const time = meetupAt.toLocaleTimeString([], {
-      hour: "2-digit",
-      minute: "2-digit",
-    });
-    if (diffDays < 1) return `locked · unlocks today ${time}`;
-    if (diffDays < 2) return `locked · unlocks tomorrow ${time}`;
-    if (diffDays < 7) {
-      const wd = meetupAt.toLocaleDateString([], { weekday: "long" });
-      return `locked · unlocks ${wd}`;
-    }
-    return "locked";
-  }
+function headerSubtitle(phase: LockedPhase): string {
+  if (phase === "scheduled") return "locked · meet first";
   if (phase === "awaiting_attendance") return "locked · awaiting attendance";
   if (phase === "awaiting_my_optin") return "locked · rate to unlock";
   if (phase === "awaiting_partner_optin") return "locked · waiting on partner";
@@ -159,11 +125,9 @@ export default function LockedChatScreen() {
     );
   }
 
-  const meetupAt = new Date(entry.meetupAt);
   const partnerFirst = entry.partner.name.split(" ")[0] ?? entry.partner.name;
   const copy = copyForPhase(entry.phase, partnerFirst);
-  const strip = formatMeetupStrip(meetupAt, entry.venue.name);
-  const subtitle = headerSubtitle(entry.phase, meetupAt);
+  const subtitle = headerSubtitle(entry.phase);
 
   function handleCta() {
     if (entry?.phase === "declined") {
@@ -230,25 +194,6 @@ export default function LockedChatScreen() {
             <Text className="text-foreground/80 text-sm mt-1">{copy.body}</Text>
           </View>
         </View>
-
-        {entry.phase !== "declined" && (
-          <View
-            testID="meetup-strip"
-            className="bg-background rounded-2xl px-4 py-3 mb-4 flex-row items-center justify-between"
-          >
-            <View>
-              <Text className="text-muted-foreground text-[10px] font-bold tracking-wider">
-                {strip.weekday} · {strip.venueName}
-              </Text>
-              <Text className="text-foreground text-sm font-semibold mt-0.5">
-                {strip.countdown}
-              </Text>
-            </View>
-            <Text className="text-foreground text-3xl font-bold tracking-tight">
-              {strip.time}
-            </Text>
-          </View>
-        )}
 
         {entry.phase === "awaiting_my_optin" ? (
           <View className="gap-2">


### PR DESCRIPTION
## Summary

- Removes the `meetup-strip` block in `apps/native/app/chat/locked/[meetupId].tsx` for every non-declined phase — venue, weekday, countdown, and time belong on the Confirmed Meetup screen, not on the locked chat surface.
- Drops the time-based unlock claim from `headerSubtitle` for `scheduled`. New copy: `"locked · meet first"`.
- Updates `copyForPhase("scheduled").body` to `"Chat opens after you both meet and choose to keep in touch."` to match the real rule (mutual opt-in, not check-in).
- Deletes the now-unused `formatMeetupStrip()` helper and `meetupAt` local.

Closes #361

## Test plan

- [x] `apps/native/__tests__/locked-chat-no-meetup-leak.test.tsx` — 3 passing scenarios (no strip, neutral header, body copy)
- [ ] Manual: open locked chat from Chats tab pre-meetup — no venue/time leak, header reads `locked · meet first`, body matches mutual opt-in rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)