### PR TITLE
fix(scheduling): order meetup.list newest-first

### DIFF
--- a/packages/api/src/contexts/scheduling/meetup.ts
+++ b/packages/api/src/contexts/scheduling/meetup.ts
@@ -1,5 +1,5 @@
 import type { EventEmitter } from "events";
-import { and, eq, or, sql, count, gte, lt, inArray } from "drizzle-orm";
+import { and, eq, or, sql, count, gte, lt, inArray, desc } from "drizzle-orm";
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { db } from "@sip-and-speak/db";
@@ -429,7 +429,7 @@ export const meetupRouter = router({
           sql`receiver.id = ${meetup.receiverId}`,
         )
         .where(and(...conditions))
-        .orderBy(meetup.createdAt);
+        .orderBy(desc(meetup.createdAt));
 
       return rows.map((row) => {
         const isProposer = row.meetup.proposerId === userId;


### PR DESCRIPTION
## Summary

The `meetup.list` tRPC procedure ordered proposals by `createdAt` ascending, so newly created/received proposals appeared at the **bottom** of the Meet-ups tab. This changes the ordering to `desc(meetup.createdAt)` so the most recent proposal is shown first.

## Changes

- `packages/api/src/contexts/scheduling/meetup.ts`
  - Import `desc` from `drizzle-orm`.
  - `list` procedure: `.orderBy(meetup.createdAt)` → `.orderBy(desc(meetup.createdAt))`.

## Not changed (intentional)

- `getConfirmed` — orders by `scheduledAt` asc (upcoming chronological).
- `getPendingIncoming` — `createdAt` asc, `limit(1)`; must stay oldest-first.

## Verification

- Grepped `trpc.meetup.list` consumers (home, confirmed-meetups, _layout, meetup-flow-modal) — all use it for the pending list/count/invalidation; none rely on ascending order.
- `bun test` in `packages/api`: 157 pass, 0 fail.
- `bun run check-types`: the only failures are pre-existing errors in `conversation/chat.ts`, unrelated to this change. `meetup.ts` typechecks clean.

Closes #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)