### PR TITLE
fix(native): make match-card bottom half partner-centric

### DIFF
--- a/apps/native/__tests__/match-request-confirmation.test.tsx
+++ b/apps/native/__tests__/match-request-confirmation.test.tsx
@@ -57,7 +57,6 @@ function renderCard() {
     <QueryClientProvider client={client}>
       <MatchCard
         candidate={candidate}
-        yourLanguage="English"
         onAccept={onAccept}
         onDecline={onDecline}
       />

--- a/apps/native/app/match.tsx
+++ b/apps/native/app/match.tsx
@@ -203,7 +203,6 @@ export default function MatchModalScreen() {
       ) : (
         <MatchCard
           candidate={current}
-          yourLanguage={yourLanguage}
           onAccept={() => setIndex((i) => i + 1)}
           onDecline={() => setIndex((i) => i + 1)}
           onBack={index > 0 ? () => setIndex((i) => Math.max(0, i - 1)) : undefined}

--- a/apps/native/components/match-card.tsx
+++ b/apps/native/components/match-card.tsx
@@ -4,11 +4,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { trpc } from "@/utils/trpc";
 import { interestLabel } from "@/utils/interest-labels";
-import {
-  getLanguageCode,
-  getLanguageFlag,
-  getNativeName,
-} from "@/utils/language-flags";
+import { getLanguageCode, getLanguageFlag } from "@/utils/language-flags";
 
 const GOLD = "#F2C94C";
 const CHIP = "#C8E0E0";
@@ -35,7 +31,6 @@ export interface MatchCardCandidate {
 
 interface MatchCardProps {
   candidate: MatchCardCandidate;
-  yourLanguage: string;
   onAccept: () => void;
   onDecline: () => void;
   onBack?: () => void;
@@ -43,7 +38,6 @@ interface MatchCardProps {
 
 export function MatchCard({
   candidate,
-  yourLanguage,
   onAccept,
   onDecline,
   onBack,
@@ -277,42 +271,57 @@ export function MatchCard({
         </View>
       </View>
 
-      {/* Bottom — you */}
+      {/* Bottom — partner */}
       <View
         className="px-6 pt-6 pb-2"
         style={{ backgroundColor: CREAM, flex: 5 }}
       >
-        <Text
-          className="text-brand-muted-foreground font-manrope-semi tracking-widest"
-          style={{ fontSize: 12 }}
-        >
-          YOU SPEAK
-        </Text>
-        <Text
-          className="text-brand-foreground font-jakarta"
-          style={{ fontSize: 44, lineHeight: 48, marginTop: 4 }}
-        >
-          {getNativeName(yourLanguage)}
-        </Text>
-
-        {candidate.interests.length > 0 && (
-          <View className="flex-row flex-wrap gap-2 mt-4">
-            {candidate.interests.slice(0, 4).map((topic) => (
-              <View
-                key={topic}
-                testID="interest-chip"
-                className="px-3 py-1.5 rounded-full"
-                style={{ backgroundColor: CHIP }}
-              >
-                <Text
-                  className="font-manrope-semi text-brand-foreground"
-                  style={{ fontSize: 13 }}
+        {candidate.interests.length > 0 ? (
+          <>
+            <Text
+              testID="partner-interests-label"
+              className="text-brand-muted-foreground font-manrope-semi tracking-widest"
+              style={{ fontSize: 12 }}
+            >
+              {partnerLabel} IS INTO
+            </Text>
+            <View className="flex-row flex-wrap gap-2 mt-3">
+              {candidate.interests.slice(0, 6).map((topic) => (
+                <View
+                  key={topic}
+                  testID="interest-chip"
+                  className="px-4 py-2 rounded-full"
+                  style={{ backgroundColor: CHIP }}
                 >
-                  {interestLabel(topic)}
-                </Text>
-              </View>
-            ))}
-          </View>
+                  <Text
+                    className="font-manrope-semi text-brand-foreground"
+                    style={{ fontSize: 16 }}
+                  >
+                    {interestLabel(topic)}
+                  </Text>
+                </View>
+              ))}
+            </View>
+          </>
+        ) : (
+          <>
+            <Text
+              testID="partner-interests-empty-label"
+              className="text-brand-muted-foreground font-manrope-semi tracking-widest"
+              style={{ fontSize: 12 }}
+            >
+              ABOUT {partnerLabel}
+            </Text>
+            <Text
+              testID="partner-interests-empty"
+              className="text-brand-foreground font-jakarta"
+              style={{ fontSize: 24, lineHeight: 30, marginTop: 8 }}
+            >
+              {candidate.university
+                ? `Studies at ${candidate.university}.`
+                : `Hasn't shared interests yet — say hoi to find out more.`}
+            </Text>
+          </>
         )}
       </View>
 


### PR DESCRIPTION
## Problem

The match card's dominant bottom half (`flex: 5`) headlined **"YOU SPEAK / {yourLanguage}"** at 44px, surfacing the viewer's own language — something they already know — instead of helping them assess the partner. Partner interests were relegated to small secondary chips.

## Fix

Redesign the bottom half (`apps/native/components/match-card.tsx`) to be partner-centric:

- **Dropped** the `YOU SPEAK / getNativeName(yourLanguage)` headline. Language overlap is already conveyed by the preserved `match-overlap-band`.
- **Promoted** partner interests into the prominent space as larger chips under a `{PARTNER} IS INTO` label (kept `interest-chip` testID; now shows up to 6, 16px text).
- **Empty state**: candidates with no interests fall back to an `ABOUT {PARTNER}` block showing their university, or a "say hoi to find out more" prompt when neither is available.
- **Cleanup**: removed the now-unused `yourLanguage` prop from `MatchCardProps` and its `MatchCard` call sites in `apps/native/app/match.tsx` and the confirmation test. (`yourLanguage` is still used elsewhere in `match.tsx` by `EmptyDeck`, so it stays there.)
- Removed the unused `getNativeName` import.

## Design note (issue flagged "needs design sign-off")

Chose to frame the prominent area around the partner's interests (`{PARTNER} IS INTO`) since that's the most partner-distinguishing content already on the card. University/age remain in the top header; university is reused as the empty-state fallback so the bottom half is never blank.

## Verification

- `apps/native` jest: the two match deck tests (`match-deck-navigation`, `match-request-confirmation`) **pass** (7/7).
- Other failing native suites (`partner-profile`, `profile-tab-display`, `reschedule-form`, `suggestions`) fail **identically on the clean base** — pre-existing, unrelated to this change.
- `tsc` shows **no errors** in `match-card.tsx` or `match.tsx`. The repo-root `check-types` failure is pre-existing in `packages/api/.../conversation/chat.ts` (server, unrelated).

Closes #372

🤖 Generated with [Claude Code](https://claude.com/claude-code)