### PR TITLE
fix(native): confirm dialog on 'We met up'

### DIFF
--- a/apps/native/app/(tabs)/confirmed-meetups.tsx
+++ b/apps/native/app/(tabs)/confirmed-meetups.tsx
@@ -451,10 +451,16 @@ export default function ConfirmedMeetupsScreen() {
                           label="We met up"
                           disabled={reportAttendanceMutation.isPending}
                           onPress={() =>
-                            reportAttendanceMutation.mutate({
-                              meetupId: m.meetupId,
-                              attended: true,
-                            })
+                            reportAttendanceMutation.mutate(
+                              { meetupId: m.meetupId, attended: true },
+                              {
+                                onSuccess: () =>
+                                  Alert.alert(
+                                    "Thanks!",
+                                    `You reported attending this meetup — wait for ${m.partner.name} to respond.`,
+                                  ),
+                              },
+                            )
                           }
                           flex
                         />


### PR DESCRIPTION
## Summary

Tapping **"We met up"** on a past meet-up previously fired `reportAttendanceMutation.mutate({ meetupId, attended: true })` with **no `onSuccess` handler**, so the user saw no confirmation — only a static muted label. The "We didn't" path already shows an `Alert`. This adds a matching success dialog.

## Change

`apps/native/app/(tabs)/confirmed-meetups.tsx` — "We met up" now passes an `onSuccess` callback:

```ts
reportAttendanceMutation.mutate(
  { meetupId: m.meetupId, attended: true },
  {
    onSuccess: () =>
      Alert.alert(
        "Thanks!",
        `You reported attending this meetup — wait for ${m.partner.name} to respond.`,
      ),
  },
);
```

- The static `attendance-reported-label` for the already-reported state is unchanged.
- The mutation's own `onSuccess` (query invalidation / card clearing) lives on the `useMutation` definition and is unaffected — both run, so the dialog does not block invalidation.

## Verification

- `apps/native` jest: `locked-chat-no-meetup-leak` passes. `reschedule-form` fails **identically on `main`** (8/8 — `Cannot read properties of undefined (reading 'queryOptions')`, a test-mock gap at `confirmed-meetups.tsx:195`, unrelated to this change).
- `tsc` on the edited file: zero errors. Repo-root `bun run check-types` failures are all pre-existing server-side errors in `packages/api/src/contexts/conversation/chat.ts` (native has no `check-types` script).

Closes #369

🤖 Generated with [Claude Code](https://claude.com/claude-code)