### PR TITLE
fix(native): 'Schedule a new moment' points to existing matches

### DIFF
--- a/apps/native/__tests__/matches-sections.test.tsx
+++ b/apps/native/__tests__/matches-sections.test.tsx
@@ -153,15 +153,36 @@ describe("#9 — Invitations received section", () => {
 });
 
 describe("#9 — Schedule a new moment", () => {
-  it("shows the action when there are matches and routes to discover", async () => {
+  it("surfaces the existing matches list instead of routing to discover (#373)", async () => {
     mockGetMyMatches.mockResolvedValue([match("m1", "Dee")]);
 
     renderScreen();
 
     await waitFor(() => expect(screen.getByTestId("schedule-new-moment")).toBeTruthy());
 
+    // The existing matches listing is rendered on the same screen.
+    expect(screen.getByTestId("matched-partner-card")).toBeTruthy();
+
     fireEvent.press(screen.getByTestId("schedule-new-moment"));
-    expect(mockPush).toHaveBeenCalledWith("/match");
+
+    // It must NOT route to the discover deck — scheduling is done with an
+    // existing match, opened from the listing below the button.
+    expect(mockPush).not.toHaveBeenCalledWith("/match");
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("opens an existing match's profile to start the propose-meetup flow", async () => {
+    mockGetMyMatches.mockResolvedValue([match("m1", "Dee")]);
+
+    renderScreen();
+
+    await waitFor(() => expect(screen.getByTestId("matched-partner-card")).toBeTruthy());
+
+    fireEvent.press(screen.getByTestId("matched-partner-card"));
+    expect(mockPush).toHaveBeenCalledWith({
+      pathname: "/partner/[id]",
+      params: { id: "p-m1" },
+    });
   });
 
   it("hides the action when there are no matches", async () => {

--- a/apps/native/app/(tabs)/matches.tsx
+++ b/apps/native/app/(tabs)/matches.tsx
@@ -1,6 +1,14 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
-import { Image, Pressable, ScrollView, Text, View } from "react-native";
+import { useRef } from "react";
+import {
+  Image,
+  type LayoutChangeEvent,
+  Pressable,
+  ScrollView,
+  Text,
+  View,
+} from "react-native";
 
 import { Container } from "@/components/container";
 import { epochMs } from "@/lib/dates";
@@ -158,6 +166,16 @@ function SectionLabel({ children }: { children: string }) {
 
 export default function MatchesScreen() {
   const router = useRouter();
+  const scrollRef = useRef<ScrollView>(null);
+  const matchesListY = useRef(0);
+
+  const onMatchesListLayout = (e: LayoutChangeEvent) => {
+    matchesListY.current = e.nativeEvent.layout.y;
+  };
+
+  const scrollToMatchesList = () => {
+    scrollRef.current?.scrollTo({ y: matchesListY.current, animated: true });
+  };
   const matchesQuery = useQuery(
     trpc.matching.getMyMatches.queryOptions({ includeWithActiveMeetup: true }),
   );
@@ -204,6 +222,7 @@ export default function MatchesScreen() {
   return (
     <Container isScrollable={false}>
       <ScrollView
+        ref={scrollRef}
         className="flex-1"
         contentContainerStyle={{ paddingBottom: 32 }}
         showsVerticalScrollIndicator={false}
@@ -481,7 +500,7 @@ export default function MatchesScreen() {
             <Pressable
               testID="schedule-new-moment"
               accessibilityRole="button"
-              onPress={() => router.push("/match")}
+              onPress={scrollToMatchesList}
               style={({ pressed }) => ({
                 height: 52,
                 borderRadius: 26,
@@ -498,44 +517,48 @@ export default function MatchesScreen() {
           </View>
         )}
 
-        {/* New this week */}
-        {newMatches.length > 0 && (
-          <View style={{ paddingHorizontal: 20, marginBottom: 24 }}>
-            <View style={{ paddingHorizontal: 4 }}>
-              <SectionLabel>NEW THIS WEEK</SectionLabel>
+        {/* Existing matches — open a profile to propose a meet-up.
+            The "Schedule a new moment" button above scrolls here. */}
+        <View onLayout={onMatchesListLayout}>
+          {/* New this week */}
+          {newMatches.length > 0 && (
+            <View style={{ paddingHorizontal: 20, marginBottom: 24 }}>
+              <View style={{ paddingHorizontal: 4 }}>
+                <SectionLabel>NEW THIS WEEK</SectionLabel>
+              </View>
+              <View className="flex-row flex-wrap">
+                {newMatches.map((m) => (
+                  <MatchTile
+                    key={m.matchId}
+                    match={m}
+                    isNew
+                    onPress={() => openPartner(m.partnerId)}
+                  />
+                ))}
+              </View>
             </View>
-            <View className="flex-row flex-wrap">
-              {newMatches.map((m) => (
-                <MatchTile
-                  key={m.matchId}
-                  match={m}
-                  isNew
-                  onPress={() => openPartner(m.partnerId)}
-                />
-              ))}
-            </View>
-          </View>
-        )}
+          )}
 
-        {/* Everyone */}
-        {olderMatches.length > 0 && (
-          <View style={{ paddingHorizontal: 20 }}>
-            <View style={{ paddingHorizontal: 4 }}>
-              <SectionLabel>
-                {newMatches.length > 0 ? "EVERYONE" : "MY MATCHES"}
-              </SectionLabel>
+          {/* Everyone */}
+          {olderMatches.length > 0 && (
+            <View style={{ paddingHorizontal: 20 }}>
+              <View style={{ paddingHorizontal: 4 }}>
+                <SectionLabel>
+                  {newMatches.length > 0 ? "EVERYONE" : "MY MATCHES"}
+                </SectionLabel>
+              </View>
+              <View className="flex-row flex-wrap">
+                {olderMatches.map((m) => (
+                  <MatchTile
+                    key={m.matchId}
+                    match={m}
+                    onPress={() => openPartner(m.partnerId)}
+                  />
+                ))}
+              </View>
             </View>
-            <View className="flex-row flex-wrap">
-              {olderMatches.map((m) => (
-                <MatchTile
-                  key={m.matchId}
-                  match={m}
-                  onPress={() => openPartner(m.partnerId)}
-                />
-              ))}
-            </View>
-          </View>
-        )}
+          )}
+        </View>
 
         {/* Empty state */}
         {isEmpty && (


### PR DESCRIPTION
## Problem

The **"Schedule a new moment"** button on the Matches tab (`apps/native/app/(tabs)/matches.tsx`, testID `schedule-new-moment`) called `router.push("/match")` — sending users into the discover deck for **new** people. But scheduling a moment is done with an **existing** match: open a buddy's profile and tap "Propose a meet-up" (`/partner/[id]` → `/propose-meetup`). The existing-matches listing ("NEW THIS WEEK" / "MY MATCHES" → `MatchTile` → `/partner/[id]`) already renders directly below this button on the same screen.

## Fix

The button now scrolls to that existing-matches list instead of navigating to discovery:
- Added a `ScrollView` ref and an `onLayout`-measured anchor `View` wrapping the matches-list sections.
- `onPress` calls `scrollRef.current?.scrollTo(...)` to surface the list.

### Scope / regression safety
- `/match` is untouched as the discovery destination elsewhere (Home discover card, empty state).
- The propose-meetup gating on `/partner/[id]` (matched relationship only) is unchanged.
- `MatchTile` → `openPartner` → `/partner/[id]` path is intact.

## Tests
Updated `apps/native/__tests__/matches-sections.test.tsx`:
- Replaced the old assertion that the button routes to `/match` with assertions that it does **not** navigate (surfaces the on-screen list instead).
- Added a test that pressing a `matched-partner-card` opens `/partner/[id]`.

`apps/native` jest matches suite: 6/6 pass. (Pre-existing, unrelated failures in `partner-profile`, `profile-tab-display`, `reschedule-form`, `suggestions` and a `server` type error in `chat.ts` exist on `main` and are out of scope.)

Closes #373

🤖 Generated with [Claude Code](https://claude.com/claude-code)