### PR TITLE
fix(conversation): keep open chat unlocked over future meet-up card

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ coverage
 .cache
 tmp
 temp
+
+.claude/worktrees/

--- a/packages/api/src/contexts/conversation/__tests__/chat-list-dedupe.test.ts
+++ b/packages/api/src/contexts/conversation/__tests__/chat-list-dedupe.test.ts
@@ -3,8 +3,10 @@
  *
  * Covers `keptEntryKeysByPartner`:
  *   - Multiple open conversations with the same partner collapse to the most recent.
- *   - Open chats and locked meetup cards dedupe together (cross-kind), most recent wins.
+ *   - An open chat always wins over a locked meetup card for the same partner, even when the
+ *     locked card is future-dated (a newly scheduled meet-up must not re-lock an open chat).
  *   - A stale locked card never hides a more recently active chat with the same partner.
+ *   - Pre-meet locked cards for partners with no open chat still surface as locked.
  *   - Distinct partners are all kept.
  *   - Entries with an unknown partner are always kept (never collapsed into each other).
  */
@@ -25,13 +27,34 @@ describe("keptEntryKeysByPartner", () => {
     expect(kept.size).toBe(1);
   });
 
-  it("dedupes a locked meetup card and an open chat with the same partner (most recent wins)", () => {
+  it("keeps the open chat over a future-dated locked meetup card with the same partner", () => {
+    // A newly scheduled meet-up (future sortAt) must not re-lock an already-open chat.
     const kept = keptEntryKeysByPartner([
       { kind: "locked", id: "meetupUpcoming", partner: { id: "bob" }, sortAt: at("2026-03-01T10:00:00Z") },
       { kind: "open", id: "convStale", partner: { id: "bob" }, sortAt: at("2026-01-15T10:00:00Z") },
     ]);
-    expect(kept.has("locked-meetupUpcoming")).toBe(true);
-    expect(kept.has("open-convStale")).toBe(false);
+    expect(kept.has("open-convStale")).toBe(true);
+    expect(kept.has("locked-meetupUpcoming")).toBe(false);
+    expect(kept.size).toBe(1);
+  });
+
+  it("keeps the open chat when a brand-new future meet-up is scheduled (order-independent)", () => {
+    // Same as above but with the open chat listed first — open must win regardless of order.
+    const now = at("2026-06-13T10:00:00Z");
+    const kept = keptEntryKeysByPartner([
+      { kind: "open", id: "convOpen", partner: { id: "bob" }, sortAt: at("2026-06-01T10:00:00Z") },
+      { kind: "locked", id: "newMeetup", partner: { id: "bob" }, sortAt: new Date(now.getTime() + 86_400_000) },
+    ]);
+    expect(kept.has("open-convOpen")).toBe(true);
+    expect(kept.has("locked-newMeetup")).toBe(false);
+    expect(kept.size).toBe(1);
+  });
+
+  it("still surfaces a pre-meet locked card for a partner with no open chat", () => {
+    const kept = keptEntryKeysByPartner([
+      { kind: "locked", id: "meetupSoon", partner: { id: "carol" }, sortAt: at("2026-07-01T10:00:00Z") },
+    ]);
+    expect(kept.has("locked-meetupSoon")).toBe(true);
     expect(kept.size).toBe(1);
   });
 

--- a/packages/api/src/contexts/conversation/messaging-utils.ts
+++ b/packages/api/src/contexts/conversation/messaging-utils.ts
@@ -73,9 +73,17 @@ export function checkReadAccess(
 
 /**
  * Collapses chat-list entries to one row per partner. A user met more than once would otherwise
- * surface once per meetup/conversation; the most recently active entry (highest `sortAt`) wins,
- * comparing open chats and locked meetup cards together. Entries with an unknown partner
- * (`partner === null`) are always kept — there is nothing to dedupe them against.
+ * surface once per meetup/conversation. Precedence rules:
+ *   - An `open` conversation always outranks a `locked` meetup card for the same partner,
+ *     regardless of `sortAt`. Once a chat is unlocked it is a terminal state and must never be
+ *     re-hidden behind a future-dated locked teaser (a new meet-up's `sortAt` is in the future).
+ *   - When both entries are the same kind (two open chats, or two locked cards with no open chat),
+ *     the most recently active entry (highest `sortAt`) wins.
+ * Pre-meet locked cards for partners with NO open chat are unaffected — they still win against
+ * other locked cards by `sortAt` and surface as locked.
+ *
+ * Entries with an unknown partner (`partner === null`) are always kept — there is nothing to
+ * dedupe them against.
  *
  * Returns the set of kept entry keys, where a key is `${kind}-${id}` (matching the frontend's
  * list key). Callers filter their entries with `keptKeys.has(`${kind}-${id}`)`.
@@ -88,7 +96,7 @@ export function keptEntryKeysByPartner(
     sortAt: Date;
   }>,
 ): Set<string> {
-  const bestByPartner = new Map<string, { key: string; sortAt: Date }>();
+  const bestByPartner = new Map<string, { kind: "open" | "locked"; key: string; sortAt: Date }>();
   const keptKeys = new Set<string>();
   for (const entry of entries) {
     const key = `${entry.kind}-${entry.id}`;
@@ -98,8 +106,20 @@ export function keptEntryKeysByPartner(
       continue;
     }
     const current = bestByPartner.get(partnerId);
-    if (!current || entry.sortAt.getTime() > current.sortAt.getTime()) {
-      bestByPartner.set(partnerId, { key, sortAt: entry.sortAt });
+    if (!current) {
+      bestByPartner.set(partnerId, { kind: entry.kind, key, sortAt: entry.sortAt });
+      continue;
+    }
+    // Open always beats locked for the same partner, regardless of sortAt.
+    if (entry.kind !== current.kind) {
+      if (entry.kind === "open") {
+        bestByPartner.set(partnerId, { kind: entry.kind, key, sortAt: entry.sortAt });
+      }
+      continue; // incoming is locked and current is open — keep current
+    }
+    // Same kind — fall back to most-recent-activity comparison.
+    if (entry.sortAt.getTime() > current.sortAt.getTime()) {
+      bestByPartner.set(partnerId, { kind: entry.kind, key, sortAt: entry.sortAt });
     }
   }
   for (const { key } of bestByPartner.values()) keptKeys.add(key);


### PR DESCRIPTION
## Bug
Chat re-locks every time a new meet-up is scheduled. An already-open conversation disappeared behind a locked teaser when a new future meet-up was confirmed with the same partner, because `keptEntryKeysByPartner` ranked strictly by `sortAt` (a future-dated locked card outranked the open chat).

## Fix
`keptEntryKeysByPartner` (`messaging-utils.ts`) now gives an **open** conversation precedence over any **locked** meet-up card for the same partner, regardless of `sortAt`. Same-kind entries still fall back to most-recent-activity. Pre-meet locked cards for partners with no open chat are unaffected.

## Tests
`chat-list-dedupe.test.ts` updated: the case that asserted the buggy "future locked card wins" now asserts the open chat is kept; added order-independent + pre-meet-locked cases. **159 pass / 0 fail** in `packages/api`.

Closes #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)