### PR TITLE
fix(native): Home keep-in-touch tile routes to locked chat

### DIFF
--- a/apps/native/app/(tabs)/home.tsx
+++ b/apps/native/app/(tabs)/home.tsx
@@ -92,6 +92,9 @@ export default function HomeScreen() {
             onOpenChat={(conversationId) =>
               router.push(`/chat/${conversationId}` as never)
             }
+            onOpenLocked={(meetupId) =>
+              router.push(`/chat/locked/${meetupId}` as never)
+            }
             onReschedule={() =>
               setMeetupModal({
                 type: "propose",

--- a/apps/native/components/home/hero-post.tsx
+++ b/apps/native/components/home/hero-post.tsx
@@ -19,23 +19,18 @@ const EMOJIS: { rating: 1 | 2 | 3 | 4 | 5; glyph: string }[] = [
 type Props = {
   meetup: ConfirmedMeetup;
   onOpenChat: (conversationId: string) => void;
+  // #371 — route the locked keep-in-touch tile to the locked chat screen,
+  // which owns the opt-in (accept/decline) prompt (see #370).
+  onOpenLocked: (meetupId: string) => void;
   // #27 — re-open the propose flow after a "didn't meet" report.
   onReschedule: () => void;
 };
 
-export function HeroPost({ meetup, onOpenChat, onReschedule }: Props) {
+export function HeroPost({ meetup, onOpenChat, onOpenLocked, onReschedule }: Props) {
   const [selectedRating, setSelectedRating] = useState<number | null>(null);
 
   const reportMutation = useMutation(
     trpc.meetup.reportAttendance.mutationOptions({
-      onSuccess: () => {
-        void queryClient.invalidateQueries(trpc.meetup.getConfirmed.queryOptions());
-      },
-    }),
-  );
-
-  const optInMutation = useMutation(
-    trpc.messaging.respondToOptIn.mutationOptions({
       onSuccess: () => {
         void queryClient.invalidateQueries(trpc.meetup.getConfirmed.queryOptions());
       },
@@ -100,10 +95,7 @@ export function HeroPost({ meetup, onOpenChat, onReschedule }: Props) {
       return (
         <Pressable
           testID="opt-in-cta"
-          onPress={() =>
-            optInMutation.mutate({ meetupId: meetup.meetupId, response: "accept" })
-          }
-          disabled={optInMutation.isPending}
+          onPress={() => onOpenLocked(meetup.meetupId)}
           className="rounded-2xl mt-5 flex-row items-center justify-between p-4"
           style={{ backgroundColor: "#FFFFFF" }}
         >


### PR DESCRIPTION
## Bug
On Home, the locked "Stay in touch? / Chat with {partner} 🔒" tile fired the opt-in mutation **inline** (silently accepting) instead of routing to the chat like the Chats-tab locked rows do.

## Fix
- `hero-post.tsx`: the `opt-in-cta` press now calls a new `onOpenLocked(meetupId)` prop instead of mutating. Only the `mine === null` CTA branch changed; UNLOCKED (`onOpenChat`) and WAITING states are untouched.
- `home.tsx`: wires `onOpenLocked` to `router.push('/chat/locked/${meetupId}')`, matching `chats.tsx`.
- The now-unused `optInMutation` is removed (no remaining references). Accept/decline lives solely on the locked chat screen (see #370), keeping a single opt-in surface.

## Tests
`apps/native` home suite — **21 pass / 0 fail**. No new type errors in touched source.

Closes #371

🤖 Generated with [Claude Code](https://claude.com/claude-code)