### PR TITLE
fix(native): locked-chat teaser explains how it unlocks

### DIFF
--- a/apps/native/app/(tabs)/chats.tsx
+++ b/apps/native/app/(tabs)/chats.tsx
@@ -3,7 +3,7 @@ import { useRouter } from "expo-router";
 import { useQuery } from "@tanstack/react-query";
 import { Ionicons } from "@expo/vector-icons";
 
-import { formatChatTimestamp, formatUnlockMoment } from "@/lib/dates";
+import { formatChatTimestamp } from "@/lib/dates";
 import { trpc } from "@/utils/trpc";
 import { Container } from "@/components/container";
 import { CARD, GOLD } from "@/components/home/tokens";
@@ -71,7 +71,7 @@ type ChatEntry =
 function lockedSubtitle(entry: Extract<ChatEntry, { kind: "locked" }>): string {
   switch (entry.phase) {
     case "scheduled":
-      return `unlocks ${formatUnlockMoment(entry.meetupAt)}`;
+      return "unlocks after you first meet up";
     case "awaiting_attendance":
       return "did you meet?";
     case "awaiting_my_optin":

--- a/apps/native/lib/dates.ts
+++ b/apps/native/lib/dates.ts
@@ -102,18 +102,6 @@ export function formatChatSectionLabel(input: DateInput, now: Date = new Date())
   return safeFormat(d, "MMM d").toUpperCase();
 }
 
-/** Lock-expiry phrase: "today HH:mm" / "tomorrow HH:mm" / "EEEE HH:mm" / "MMM d". */
-export function formatUnlockMoment(input: DateInput, now: Date = new Date()): string {
-  const at = toDate(input);
-  if (!at) return "";
-  const days = differenceInCalendarDays(at, now);
-  const time = safeFormat(at, "HH:mm");
-  if (days <= 0) return `today ${time}`;
-  if (days === 1) return `tomorrow ${time}`;
-  if (days < 7) return `${safeFormat(at, "EEEE")} ${time}`;
-  return safeFormat(at, "MMM d");
-}
-
 /** Absolute calendar-day distance between two dates. Returns 0 on invalid input. */
 export function daysBetween(a: DateInput, b: DateInput): number {
   const da = toDate(a);


### PR DESCRIPTION
## Summary

In the Chats tab, a not-yet-unlocked (`scheduled`) chat showed an unlock **countdown** ("unlocks Friday at 10:30"). But unlock is **phase-based with no time buffer** — `deriveLockedPhase` gates `scheduled` purely on `meetupAt > now`, so there is no moment to count down to. The countdown was misleading.

This replaces the countdown with static copy that explains *how* the chat unlocks.

## Changes

- `apps/native/app/(tabs)/chats.tsx` — `scheduled` case of `lockedSubtitle` now returns `"unlocks after you first meet up"` (tightened to fit the single-line italic row) instead of `` `unlocks ${formatUnlockMoment(entry.meetupAt)}` ``. Removed the now-unused `formatUnlockMoment` import.
- `apps/native/lib/dates.ts` — removed the now-unused `formatUnlockMoment` helper (only referenced from chats.tsx; no tests reference it).

## Not changed

- Other locked phases (`awaiting_attendance`, `awaiting_my_optin`, `awaiting_partner_optin`, `declined`) and the #370 "waiting for {partner} to enable chatting" copy are untouched.
- The locked detail screen (`chat/locked/[meetupId].tsx`) already uses phase-based framing ("Meet first. Message after." / "Chat opens after you both meet and choose to keep in touch.") with no countdown — no change needed.
- `deriveLockedPhase` and phase gating are unchanged — no grace buffer.

## Verification

- `cd apps/native && bunx jest --no-coverage locked-chat-no-meetup-leak dates` → 1 suite, 3 tests pass.
- `cd packages/api && bun test locked-phase.test.ts` → 8 pass, 0 fail (stays green).

Closes #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)