### PR TITLE
test(native): retarget partner-profile match-request suite to current architecture

### DIFF
--- a/apps/native/__tests__/match-request-actions.test.tsx
+++ b/apps/native/__tests__/match-request-actions.test.tsx
@@ -1,0 +1,357 @@
+/**
+ * Retargeted match-request coverage.
+ *
+ * The send / accept / decline flow used to live on the partner profile screen
+ * (`app/partner/[id].tsx`) and was exercised by `partner-profile.test.tsx`.
+ * It has since been refactored OUT of that screen into:
+ *
+ *   - `components/candidate-card.tsx` — the "Send Request" quick action on a
+ *     suggestion card, with success + conflict feedback.
+ *   - `app/(tabs)/matches.tsx` — the "Invitations received" section where a
+ *     receiver accepts or declines an incoming request inline.
+ *
+ * These tests preserve the ORIGINAL product intent of scenarios
+ * #120 / #122 / #123 / #124 (send) and #127 / #128 / #129 (accept / decline),
+ * asserting against the components that now own each behavior.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react-native";
+import React from "react";
+
+// ───────────────────────────────────────────────────────────────────────────
+// Shared mocks
+// ───────────────────────────────────────────────────────────────────────────
+
+const mockPush = jest.fn();
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock("@/components/container", () => {
+  const { View } = require("react-native");
+  return {
+    Container: ({ children }: { children: React.ReactNode }) => <View>{children}</View>,
+  };
+});
+
+jest.mock("@/lib/dates", () => ({
+  epochMs: (s: string) => new Date(s).getTime(),
+}));
+
+jest.mock("@/utils/language-flags", () => ({
+  getLanguageFlag: () => "🏳",
+  getLanguageCode: (l: string) => l,
+  getNativeName: (l: string) => l,
+}));
+
+jest.mock("@/utils/interest-labels", () => ({
+  interestLabel: (t: string) => t,
+}));
+
+const mockSendMatchRequest = jest.fn();
+const mockAccept = jest.fn();
+const mockDecline = jest.fn();
+const mockGetMyMatches = jest.fn();
+const mockGetIncoming = jest.fn();
+const mockGetOutgoing = jest.fn();
+const mockInvalidate = jest.fn();
+
+jest.mock("@/utils/trpc", () => ({
+  queryClient: { invalidateQueries: (...a: unknown[]) => mockInvalidate(...a) },
+  trpc: {
+    matching: {
+      sendMatchRequest: {
+        mutationOptions: () => ({ mutationFn: mockSendMatchRequest }),
+      },
+      getMyMatches: {
+        queryOptions: (i?: unknown) => ({
+          queryKey: ["matching.getMyMatches", i ?? null],
+          queryFn: () => mockGetMyMatches(),
+        }),
+      },
+      getIncomingRequests: {
+        queryOptions: () => ({
+          queryKey: ["matching.getIncomingRequests"],
+          queryFn: () => mockGetIncoming(),
+        }),
+      },
+      getOutgoingRequests: {
+        queryOptions: () => ({
+          queryKey: ["matching.getOutgoingRequests"],
+          queryFn: () => mockGetOutgoing(),
+        }),
+      },
+      acceptMatchRequest: {
+        mutationOptions: (o?: Record<string, unknown>) => ({ mutationFn: mockAccept, ...(o ?? {}) }),
+      },
+      declineMatchRequest: {
+        mutationOptions: (o?: Record<string, unknown>) => ({ mutationFn: mockDecline, ...(o ?? {}) }),
+      },
+      withdrawMatchRequest: {
+        mutationOptions: (o?: Record<string, unknown>) => ({ mutationFn: jest.fn(), ...(o ?? {}) }),
+      },
+    },
+  },
+}));
+
+function makeClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+}
+
+// Import components after the mocks are registered.
+// eslint-disable-next-line import/first
+import { CandidateCard } from "../components/candidate-card";
+// eslint-disable-next-line import/first
+import MatchesScreen from "../app/(tabs)/matches";
+
+const candidateProps = {
+  userId: "candidate-123",
+  name: "Alice",
+  image: null,
+  spokenLanguages: [{ language: "Dutch", proficiency: "native" as const }],
+  learningLanguages: ["English"],
+  interests: ["tech_coding"],
+};
+
+function renderCard() {
+  const client = makeClient();
+  return render(
+    <QueryClientProvider client={client}>
+      <CandidateCard {...candidateProps} />
+    </QueryClientProvider>,
+  );
+}
+
+function renderMatches() {
+  const client = makeClient();
+  return render(
+    <QueryClientProvider client={client}>
+      <MatchesScreen />
+    </QueryClientProvider>,
+  );
+}
+
+const incoming = (id: string, name: string) => ({
+  matchRequestId: id,
+  requesterId: `req-${id}`,
+  requesterName: name,
+  requesterPhotoUrl: null,
+  requesterOfferedLanguages: ["Spanish"],
+  requesterTargetedLanguages: ["English"],
+  createdAt: "2026-06-01T00:00:00.000Z",
+});
+
+beforeEach(() => {
+  mockPush.mockClear();
+  mockSendMatchRequest.mockReset().mockResolvedValue({ matchRequestId: "req-1", status: "pending" });
+  mockAccept.mockClear().mockResolvedValue({ status: "accepted", matchedWithUserId: "requester-1" });
+  mockDecline.mockClear().mockResolvedValue({ status: "declined" });
+  mockInvalidate.mockClear();
+  mockGetMyMatches.mockReset().mockResolvedValue([]);
+  mockGetIncoming.mockReset().mockResolvedValue([]);
+  mockGetOutgoing.mockReset().mockResolvedValue([]);
+});
+
+// ─── #122 / #120: Send Request action (relocated to CandidateCard) ──────────
+//
+// The "Send Request" action and its contextual states now live on the
+// suggestion card. There is no per-candidate status query on the card any
+// more — the button is always rendered initially and flips to a "Request Sent"
+// confirmation state from the mutation result, which is the surviving form of
+// scenario #120's "contextual based on match status".
+
+describe("#122 / #120 — Send Request action (CandidateCard)", () => {
+  it("renders a Send Request button when no request has been sent yet", () => {
+    renderCard();
+    expect(screen.getByTestId("send-request-button")).toBeTruthy();
+    expect(screen.queryByText("Request Sent")).toBeNull();
+  });
+
+  it("calls sendMatchRequest with the candidate's userId when tapped", async () => {
+    renderCard();
+
+    fireEvent.press(screen.getByTestId("send-request-button"));
+
+    await waitFor(() => {
+      expect(mockSendMatchRequest).toHaveBeenCalledTimes(1);
+    });
+    expect(mockSendMatchRequest.mock.calls[0][0]).toEqual({ receiverId: "candidate-123" });
+  });
+
+  it("flips to a 'Request Sent' state after the request succeeds", async () => {
+    renderCard();
+
+    fireEvent.press(screen.getByTestId("send-request-button"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Request Sent")).toBeTruthy();
+    });
+  });
+});
+
+// ─── #124: Confirmation feedback after sending (relocated to CandidateCard) ──
+
+describe("#124 — Confirmation feedback after sending (CandidateCard)", () => {
+  it("shows a confirmation message after successfully sending a request", async () => {
+    renderCard();
+
+    fireEvent.press(screen.getByTestId("send-request-button"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("confirmation-message")).toBeTruthy();
+    });
+  });
+
+  it("disables the Send Request button after a successful send (no double-send)", async () => {
+    renderCard();
+
+    fireEvent.press(screen.getByTestId("send-request-button"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("confirmation-message")).toBeTruthy();
+    });
+
+    // A second tap must not fire another mutation.
+    fireEvent.press(screen.getByTestId("send-request-button"));
+    expect(mockSendMatchRequest).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ─── #123: Duplicate-request prevention (relocated to CandidateCard) ────────
+//
+// Server-side CONFLICT (a request already exists) surfaces an inline error on
+// the card. The original "show Send Request again after a decline" sub-case
+// relied on a per-candidate status query that no longer exists on the card,
+// so that specific assertion is dropped (see report).
+
+describe("#123 — Duplicate match-request prevention (CandidateCard)", () => {
+  it("shows a conflict error message when the server reports CONFLICT", async () => {
+    const conflictError = Object.assign(new Error("Conflict"), {
+      data: { code: "CONFLICT" },
+    });
+    mockSendMatchRequest.mockRejectedValue(conflictError);
+
+    renderCard();
+
+    fireEvent.press(screen.getByTestId("send-request-button"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("conflict-error-message")).toBeTruthy();
+    });
+  });
+});
+
+// ─── #127: Receiver sees Accept/Decline on the incoming request ─────────────
+//
+// The accept/decline action bar now lives in the "Invitations received"
+// section of the Matches tab, per incoming request. The receiver can still
+// open the requester's profile from there before deciding.
+
+describe("#127 — Accept/Decline actions on an incoming request (Matches tab)", () => {
+  it("renders Accept and Decline actions for an incoming request", async () => {
+    mockGetIncoming.mockResolvedValue([incoming("req-abc", "Cara")]);
+
+    renderMatches();
+
+    await waitFor(() => expect(screen.getByTestId("incoming-request-card")).toBeTruthy());
+    expect(screen.getByTestId("accept-match-request")).toBeTruthy();
+    expect(screen.getByTestId("decline-match-request")).toBeTruthy();
+  });
+
+  it("lets the receiver open the requester's profile before deciding", async () => {
+    mockGetIncoming.mockResolvedValue([incoming("req-abc", "Cara")]);
+
+    renderMatches();
+
+    await waitFor(() => expect(screen.getByText("Cara")).toBeTruthy());
+
+    fireEvent.press(screen.getByText("Cara"));
+
+    expect(mockPush).toHaveBeenCalledWith(
+      "/partner/req-req-abc?matchRequestId=req-abc",
+    );
+  });
+
+  it("does not render Accept/Decline actions when there are no incoming requests", async () => {
+    mockGetIncoming.mockResolvedValue([]);
+
+    renderMatches();
+
+    await waitFor(() => expect(screen.getByText(/No matches yet/i)).toBeTruthy());
+    expect(screen.queryByTestId("incoming-request-card")).toBeNull();
+    expect(screen.queryByTestId("accept-match-request")).toBeNull();
+  });
+});
+
+// ─── #128: Accept action transitions both Students to Matched ───────────────
+
+describe("#128 — Accept action transitioning both Students to Matched (Matches tab)", () => {
+  it("calls acceptMatchRequest with the request id when Accept is tapped", async () => {
+    mockGetIncoming.mockResolvedValue([incoming("req-abc", "Cara")]);
+
+    renderMatches();
+
+    await waitFor(() => expect(screen.getByTestId("accept-match-request")).toBeTruthy());
+    fireEvent.press(screen.getByTestId("accept-match-request"));
+
+    await waitFor(() => {
+      expect(mockAccept).toHaveBeenCalledTimes(1);
+    });
+    // TanStack Query v5 calls mutationFn(variables, context) — assert variables only.
+    expect(mockAccept.mock.calls[0]?.[0]).toEqual({ matchRequestId: "req-abc" });
+  });
+
+  it("invalidates the incoming requests query after accepting", async () => {
+    mockGetIncoming.mockResolvedValue([incoming("req-abc", "Cara")]);
+
+    renderMatches();
+
+    await waitFor(() => expect(screen.getByTestId("accept-match-request")).toBeTruthy());
+    fireEvent.press(screen.getByTestId("accept-match-request"));
+
+    await waitFor(() => {
+      expect(mockInvalidate).toHaveBeenCalledWith(
+        expect.objectContaining({ queryKey: ["matching.getIncomingRequests"] }),
+      );
+    });
+  });
+});
+
+// ─── #129: Decline action removes the request ───────────────────────────────
+//
+// Decline no longer "navigates back" (that was the partner-screen flow); the
+// action happens inline on the Matches tab and the declined request is removed
+// from the list via query invalidation.
+
+describe("#129 — Decline action removing the request (Matches tab)", () => {
+  it("calls declineMatchRequest with the request id when Decline is tapped", async () => {
+    mockGetIncoming.mockResolvedValue([incoming("req-abc", "Cara")]);
+
+    renderMatches();
+
+    await waitFor(() => expect(screen.getByTestId("decline-match-request")).toBeTruthy());
+    fireEvent.press(screen.getByTestId("decline-match-request"));
+
+    await waitFor(() => {
+      expect(mockDecline).toHaveBeenCalledTimes(1);
+    });
+    expect(mockDecline.mock.calls[0]?.[0]).toEqual({ matchRequestId: "req-abc" });
+  });
+
+  it("invalidates the incoming requests query after declining (removes the request)", async () => {
+    mockGetIncoming.mockResolvedValue([incoming("req-abc", "Cara")]);
+
+    renderMatches();
+
+    await waitFor(() => expect(screen.getByTestId("decline-match-request")).toBeTruthy());
+    fireEvent.press(screen.getByTestId("decline-match-request"));
+
+    await waitFor(() => {
+      expect(mockInvalidate).toHaveBeenCalledWith(
+        expect.objectContaining({ queryKey: ["matching.getIncomingRequests"] }),
+      );
+    });
+  });
+});

--- a/apps/native/__tests__/partner-profile.test.tsx
+++ b/apps/native/__tests__/partner-profile.test.tsx
@@ -1,12 +1,13 @@
 /**
- * Tests for tasks:
+ * Tests for the partner profile screen (`app/partner/[id].tsx`):
  *   #119 — Display comments section on candidate profile
- *   #120 — Surface "Send Request" action contextually based on match status
  *   #121 — Handle removed/unavailable candidate profile gracefully
- *   #122 — Send Request button on candidate profile screen
- *   #127 — Allow receiver to open requester's profile before deciding
- *   #128 — Accept action transitioning both Students to Matched state
- *   #129 — Decline action removing the request and navigating back
+ *   #10  — Matched buddy actions (Propose a meet-up + Unmatch)
+ *
+ * The match-request send / accept / decline flow that USED to live on this
+ * screen (scenarios #120, #122, #123, #124, #127, #128, #129) has been
+ * refactored into the suggestion card and the Matches tab. That coverage now
+ * lives in `match-request-actions.test.tsx`.
  */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react-native";
@@ -31,10 +32,7 @@ jest.mock("@/components/flag-user-modal", () => ({
 // Use mock-prefixed functions so jest.mock() factory can reference them
 const mockProfileFn = jest.fn();
 const mockCommentsFn = jest.fn();
-const mockSendMatchRequest = jest.fn();
 const mockGetMatchRequestStatusFn = jest.fn();
-const mockAcceptMatchRequest = jest.fn();
-const mockDeclineMatchRequest = jest.fn();
 const mockUnmatch = jest.fn();
 const mockInvalidateQueries = jest.fn();
 
@@ -48,20 +46,11 @@ jest.mock("@/utils/trpc", () => ({
           queryFn: () => mockProfileFn(),
         }),
       },
-      sendMatchRequest: {
-        mutationOptions: () => ({ mutationFn: mockSendMatchRequest }),
-      },
       getMatchRequestStatus: {
         queryOptions: () => ({
           queryKey: ["matching.getMatchRequestStatus"],
           queryFn: () => mockGetMatchRequestStatusFn(),
         }),
-      },
-      acceptMatchRequest: {
-        mutationOptions: () => ({ mutationFn: mockAcceptMatchRequest }),
-      },
-      declineMatchRequest: {
-        mutationOptions: () => ({ mutationFn: mockDeclineMatchRequest }),
       },
       getMyMatches: {
         queryOptions: () => ({ queryKey: ["matching.getMyMatches"] }),
@@ -120,9 +109,6 @@ beforeEach(() => {
   mockSearchParams = { id: "candidate-123" };
   mockBack.mockClear();
   mockPush.mockClear();
-  mockSendMatchRequest.mockClear().mockResolvedValue({ matchRequestId: "req-1", status: "pending" });
-  mockAcceptMatchRequest.mockClear().mockResolvedValue({ status: "accepted", matchedWithUserId: "requester-1" });
-  mockDeclineMatchRequest.mockClear().mockResolvedValue({ status: "declined" });
   mockUnmatch.mockClear().mockResolvedValue({ success: true });
   mockInvalidateQueries.mockClear();
   mockProfileFn.mockReset().mockResolvedValue(defaultProfile);
@@ -175,257 +161,6 @@ describe("#121 — Handle removed/unavailable candidate profile gracefully", () 
 
     await waitFor(() => {
       expect(screen.getByText(/no longer available/i)).toBeTruthy();
-    });
-  });
-});
-
-// ─── #124: Confirmation feedback ───────────────────────────────────────────
-
-describe("#124 — Confirmation feedback on candidate profile", () => {
-  it("shows confirmation message after successfully sending a request", async () => {
-    renderScreen();
-
-    await waitFor(() => screen.getByTestId("send-request-button"));
-    fireEvent.press(screen.getByTestId("send-request-button"));
-
-    await waitFor(() => {
-      expect(screen.getByTestId("confirmation-message")).toBeTruthy();
-    });
-  });
-
-  it("shows Request Sent indicator instead of Send Request button after success", async () => {
-    renderScreen();
-
-    await waitFor(() => screen.getByTestId("send-request-button"));
-    fireEvent.press(screen.getByTestId("send-request-button"));
-
-    await waitFor(() => {
-      expect(screen.getByTestId("request-sent-indicator")).toBeTruthy();
-    });
-    expect(screen.queryByTestId("send-request-button")).toBeNull();
-  });
-});
-
-// ─── #122: Send Request on profile screen ──────────────────────────────────
-
-describe("#122 — Send Request on candidate profile screen", () => {
-  it("renders Send Request button", async () => {
-    renderScreen();
-
-    await waitFor(() => {
-      expect(screen.getByTestId("send-request-button")).toBeTruthy();
-    });
-  });
-
-  it("calls sendMatchRequest mutation when tapped and shows confirmation", async () => {
-    renderScreen();
-
-    await waitFor(() => screen.getByTestId("send-request-button"));
-    fireEvent.press(screen.getByTestId("send-request-button"));
-
-    await waitFor(() => {
-      expect(mockSendMatchRequest).toHaveBeenCalledTimes(1);
-    });
-  });
-});
-
-// ─── #120: Contextual Send Request based on match status ───────────────────
-
-describe("#120 — Contextual Send Request action on candidate profile", () => {
-  it("shows Send Request button when no request has been sent", async () => {
-    mockGetMatchRequestStatusFn.mockResolvedValue({ matchRequestStatus: "none", isMatched: false });
-
-    renderScreen();
-
-    await waitFor(() => {
-      expect(screen.getByTestId("send-request-button")).toBeTruthy();
-    });
-    expect(screen.queryByTestId("request-sent-indicator")).toBeNull();
-  });
-
-  it("hides Send Request button and shows Request Sent indicator when a request has already been sent", async () => {
-    mockGetMatchRequestStatusFn.mockResolvedValue({ matchRequestStatus: "pending" });
-
-    renderScreen();
-
-    await waitFor(() => {
-      expect(screen.getByTestId("request-sent-indicator")).toBeTruthy();
-    });
-    expect(screen.queryByTestId("send-request-button")).toBeNull();
-  });
-});
-
-// ─── #123: Duplicate match request prevention ──────────────────────────────
-
-describe("#123 — Duplicate match request prevention on candidate profile", () => {
-  it("shows conflict error message when a second request is attempted", async () => {
-    const conflictError = Object.assign(new Error("Conflict"), {
-      data: { code: "CONFLICT" },
-    });
-    mockSendMatchRequest.mockRejectedValue(conflictError);
-
-    renderScreen();
-
-    await waitFor(() => screen.getByTestId("send-request-button"));
-    fireEvent.press(screen.getByTestId("send-request-button"));
-
-    await waitFor(() => {
-      expect(screen.getByTestId("conflict-error-message")).toBeTruthy();
-    });
-  });
-
-  it("shows Send Request button (not indicator) when previous request was declined", async () => {
-    mockGetMatchRequestStatusFn.mockResolvedValue({ matchRequestStatus: "declined" });
-
-    renderScreen();
-
-    await waitFor(() => {
-      expect(screen.getByTestId("send-request-button")).toBeTruthy();
-    });
-    expect(screen.queryByTestId("request-sent-indicator")).toBeNull();
-  });
-
-  it("allows re-requesting after a decline", async () => {
-    mockGetMatchRequestStatusFn.mockResolvedValue({ matchRequestStatus: "declined" });
-
-    renderScreen();
-
-    await waitFor(() => screen.getByTestId("send-request-button"));
-    fireEvent.press(screen.getByTestId("send-request-button"));
-
-    await waitFor(() => {
-      expect(mockSendMatchRequest).toHaveBeenCalledTimes(1);
-    });
-  });
-});
-
-// ─── #127: Accept/Decline bar when opened from incoming request ────────────
-
-describe("#127 — Accept/Decline action bar on requester profile", () => {
-  it("shows Accept/Decline action bar when opened from incoming request context", async () => {
-    mockSearchParams = { id: "candidate-123", matchRequestId: "req-abc" };
-
-    renderScreen();
-
-    await waitFor(() => {
-      expect(screen.getByTestId("accept-decline-bar")).toBeTruthy();
-    });
-    expect(screen.getByTestId("accept-button")).toBeTruthy();
-    expect(screen.getByTestId("decline-button")).toBeTruthy();
-  });
-
-  it("hides Send Request section when opened from incoming request context", async () => {
-    mockSearchParams = { id: "candidate-123", matchRequestId: "req-abc" };
-
-    renderScreen();
-
-    await waitFor(() => {
-      expect(screen.getByTestId("accept-decline-bar")).toBeTruthy();
-    });
-    expect(screen.queryByTestId("send-request-button")).toBeNull();
-    expect(screen.queryByTestId("request-sent-indicator")).toBeNull();
-  });
-
-  it("shows Send Request section when not opened from incoming request context", async () => {
-    mockSearchParams = { id: "candidate-123" };
-
-    renderScreen();
-
-    await waitFor(() => {
-      expect(screen.getByTestId("send-request-button")).toBeTruthy();
-    });
-    expect(screen.queryByTestId("accept-decline-bar")).toBeNull();
-  });
-});
-
-// ─── #128: Accept action ───────────────────────────────────────────────────
-
-describe("#128 — Accept action transitioning both Students to Matched state", () => {
-  it("calls acceptMatchRequest mutation when Accept is tapped", async () => {
-    mockSearchParams = { id: "candidate-123", matchRequestId: "req-abc" };
-
-    renderScreen();
-
-    await waitFor(() => screen.getByTestId("accept-button"));
-    fireEvent.press(screen.getByTestId("accept-button"));
-
-    await waitFor(() => {
-      expect(mockAcceptMatchRequest).toHaveBeenCalledTimes(1);
-      expect(mockAcceptMatchRequest.mock.calls[0][0]).toEqual({ matchRequestId: "req-abc" });
-    });
-  });
-
-  it("invalidates incoming requests query after accepting", async () => {
-    mockSearchParams = { id: "candidate-123", matchRequestId: "req-abc" };
-
-    renderScreen();
-
-    await waitFor(() => screen.getByTestId("accept-button"));
-    fireEvent.press(screen.getByTestId("accept-button"));
-
-    await waitFor(() => {
-      expect(mockInvalidateQueries).toHaveBeenCalledWith(
-        expect.objectContaining({ queryKey: ["matching.getIncomingRequests"] }),
-      );
-    });
-  });
-
-  it("shows Accepted label and disables Accept button after success", async () => {
-    mockSearchParams = { id: "candidate-123", matchRequestId: "req-abc" };
-
-    renderScreen();
-
-    await waitFor(() => screen.getByTestId("accept-button"));
-    fireEvent.press(screen.getByTestId("accept-button"));
-
-    await waitFor(() => {
-      expect(screen.getByText("Accepted")).toBeTruthy();
-    });
-  });
-});
-
-// ─── #129: Decline action ──────────────────────────────────────────────────
-
-describe("#129 — Decline action removing the request and navigating back", () => {
-  it("calls declineMatchRequest mutation when Decline is tapped", async () => {
-    mockSearchParams = { id: "candidate-123", matchRequestId: "req-abc" };
-
-    renderScreen();
-
-    await waitFor(() => screen.getByTestId("decline-button"));
-    fireEvent.press(screen.getByTestId("decline-button"));
-
-    await waitFor(() => {
-      expect(mockDeclineMatchRequest).toHaveBeenCalledTimes(1);
-      expect(mockDeclineMatchRequest.mock.calls[0][0]).toEqual({ matchRequestId: "req-abc" });
-    });
-  });
-
-  it("navigates back after successful decline", async () => {
-    mockSearchParams = { id: "candidate-123", matchRequestId: "req-abc" };
-
-    renderScreen();
-
-    await waitFor(() => screen.getByTestId("decline-button"));
-    fireEvent.press(screen.getByTestId("decline-button"));
-
-    await waitFor(() => {
-      expect(mockBack).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  it("invalidates incoming requests query after declining", async () => {
-    mockSearchParams = { id: "candidate-123", matchRequestId: "req-abc" };
-
-    renderScreen();
-
-    await waitFor(() => screen.getByTestId("decline-button"));
-    fireEvent.press(screen.getByTestId("decline-button"));
-
-    await waitFor(() => {
-      expect(mockInvalidateQueries).toHaveBeenCalledWith(
-        expect.objectContaining({ queryKey: ["matching.getIncomingRequests"] }),
-      );
     });
   });
 });


### PR DESCRIPTION
## Why

`partner-profile.test.tsx` had drifted from the codebase. 18 tests rendered `app/partner/[id].tsx` and asserted on `send-request-button` / `request-sent-indicator` / `accept-decline-bar` / `accept-button` / `decline-button` — but the match-request **send** and **accept/decline** flows were refactored OUT of the partner screen into card / tab components. The partner screen now owns only the profile, comments (#119), unavailable handling (#121), and matched-buddy actions (#10).

This PR retargets each scenario to the component that now owns the behavior, preserving the original product intent. **No production code changed — test files only.**

## Where the behavior moved

| Behavior | New owner | testIDs |
|---|---|---|
| Send Request + confirmation + conflict | `components/candidate-card.tsx` | `send-request-button`, `confirmation-message`, `conflict-error-message`, "Request Sent" label |
| Accept / Decline an incoming request | `app/(tabs)/matches.tsx` "Invitations received" | `incoming-request-card`, `accept-match-request`, `decline-match-request` |

## Per-scenario disposition

| Scenario | Disposition | Notes |
|---|---|---|
| #119 comments section | **Kept** | Still on partner screen. |
| #121 unavailable profile | **Kept** | Still on partner screen. |
| #10 matched buddy (Propose + Unmatch) | **Kept** | Still on partner screen. |
| #122 Send Request | **Relocated** → CandidateCard | Button + `sendMatchRequest({ receiverId })`. |
| #124 confirmation feedback | **Relocated** → CandidateCard | `confirmation-message` + button disabled after success (no double-send). |
| #120 contextual send action | **Relocated (adapted)** → CandidateCard | Card has no per-candidate status query; the "Request Sent" state derives from the mutation result. The status-driven sub-states were dropped (see below). |
| #123 duplicate-request prevention | **Relocated (partial)** → CandidateCard | CONFLICT inline error kept. |
| #127 accept/decline bar + open profile | **Relocated** → Matches tab | Accept/Decline actions per incoming request; tapping the requester opens their profile with `matchRequestId`. |
| #128 accept transitions to matched | **Relocated** → Matches tab | `acceptMatchRequest({ matchRequestId })` + invalidates `getIncomingRequests`. |
| #129 decline removes request | **Relocated (adapted)** → Matches tab | `declineMatchRequest` + invalidates `getIncomingRequests`. The old "navigate back" assertion was **dropped** — decline is now inline on the Matches tab, not a partner-screen action, so the request is removed via query invalidation instead of navigation. |

## Behavior genuinely removed (not just moved)

- **#123 "re-request after a decline" / #120 status-driven `pending`/`declined` states**: these relied on a per-candidate `getMatchRequestStatus` query on the send surface. The CandidateCard quick-action has no such query (it always renders the button and flips to "Request Sent" from the local mutation), so those specific assertions were dropped rather than asserted against state that no longer exists. The matched-state branch of `getMatchRequestStatus` is still exercised by #10 on the partner screen.
- **#129 "navigate back"**: removed because decline no longer happens on a navigable screen.

## Verification

- `partner-profile` + `match-request-actions`: **22 passed**
- `match-deck-navigation` + `match-request-confirmation` + `candidate-card` + `matches-sections`: **18 passed** (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)