### PR TITLE
test(native): repair profile-tab-display suite after tabs migration

### DIFF
--- a/apps/native/__tests__/profile-tab-display.test.tsx
+++ b/apps/native/__tests__/profile-tab-display.test.tsx
@@ -1,18 +1,43 @@
 /**
- * Tests for task #281 — Display name, surname, and picture in the profile tab
+ * Tests for task #281 — Display name, surname, and picture in the profile UI.
  *
- * Scenario 1: Student with complete identity profile sees their details
- * Scenario 2: Student without a profile picture sees a placeholder
- * Scenario 3: Profile tab reflects updated values after editing
+ * The standalone `app/profile.tsx` screen was removed during the "added tabs"
+ * migration. The logged-in user's own identity (name / surname / picture) is
+ * now rendered by the `ProfileModal` component (`components/profile-modal.tsx`),
+ * opened from the home tab's profile avatar. These tests assert the #281
+ * scenarios against that component, using its real rendering idioms:
+ *   - name  → the "Anna"     TextInput's `value`
+ *   - surname → the "de Vries" TextInput's `value`
+ *   - picture → an <Image> (no "+" placeholder)
+ *   - placeholder → the "+" placeholder text when image is null
+ *
+ * Scenario 1: Student with complete identity sees name, surname, and picture.
+ * Scenario 2: Student without a profile picture sees the placeholder.
+ * Scenario 3: Identity reflects the latest values from getMyProfile.
+ * Edge: name shows, surname empty when surname is null.
  */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react-native";
+import { render, screen, waitFor } from "@testing-library/react-native";
+import { Image } from "react-native";
 import React from "react";
 
-const mockPush = jest.fn();
-const mockReplace = jest.fn();
-jest.mock("expo-router", () => ({
-  useRouter: () => ({ push: mockPush, replace: mockReplace }),
+jest.mock("expo-updates", () => ({
+  checkForUpdateAsync: jest.fn().mockResolvedValue({ isAvailable: false }),
+  fetchUpdateAsync: jest.fn(),
+  reloadAsync: jest.fn(),
+  updateId: null,
+}));
+
+jest.mock("expo-constants", () => ({
+  default: { expoConfig: { version: "0.0.0" } },
+}));
+
+jest.mock("heroui-native", () => ({
+  useToast: () => ({ toast: { show: jest.fn() } }),
+}));
+
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
 }));
 
 jest.mock("@/lib/auth-client", () => ({
@@ -22,35 +47,62 @@ jest.mock("@/lib/auth-client", () => ({
   },
 }));
 
+jest.mock("@/utils/profile-picture", () => ({
+  pickAndEncodeProfilePicture: jest.fn(),
+}));
+
+jest.mock("@/components/language-picker-modal", () => ({
+  LanguagePickerModal: () => null,
+}));
+
 const mockGetMyProfile = jest.fn();
+
 jest.mock("@/utils/trpc", () => ({
   trpc: {
     profile: {
       getMyProfile: {
-        queryOptions: () => ({ queryKey: ["profile"], queryFn: mockGetMyProfile }),
+        queryOptions: () => ({
+          queryKey: ["profile.getMyProfile"],
+          queryFn: mockGetMyProfile,
+        }),
       },
+      setIdentityProfile: {
+        mutationOptions: () => ({ mutationFn: jest.fn() }),
+      },
+      upsertLanguage: { mutationOptions: () => ({ mutationFn: jest.fn() }) },
+      removeLanguage: { mutationOptions: () => ({ mutationFn: jest.fn() }) },
+      toggleInterest: { mutationOptions: () => ({ mutationFn: jest.fn() }) },
+      deleteAccount: { mutationOptions: () => ({ mutationFn: jest.fn() }) },
     },
   },
+  queryClient: { invalidateQueries: jest.fn(), clear: jest.fn() },
 }));
 
-import ProfileScreen from "../app/profile";
+import { ProfileModal } from "../components/profile-modal";
 
 function renderScreen() {
-  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
   return render(
     <QueryClientProvider client={client}>
-      <ProfileScreen />
+      <ProfileModal visible={true} onDismiss={() => {}} />
     </QueryClientProvider>,
   );
 }
 
-describe("#281 — Profile tab display", () => {
+describe("#281 — Profile identity display", () => {
   beforeEach(() => mockGetMyProfile.mockReset());
 
   describe("Scenario 1: complete identity profile", () => {
-    it("shows full name and profile picture", async () => {
+    it("shows name, surname, and profile picture", async () => {
       mockGetMyProfile.mockResolvedValue({
-        identity: { name: "Sander", surname: "Boer", image: "data:image/jpeg;base64,abc", email: "s.boer@student.tue.nl" },
+        identity: {
+          name: "Sander",
+          surname: "Boer",
+          image: "data:image/jpeg;base64,abc",
+          email: "s.boer@student.tue.nl",
+        },
         profile: null,
         languages: [],
         interests: [],
@@ -58,18 +110,29 @@ describe("#281 — Profile tab display", () => {
 
       renderScreen();
 
-      const fullName = await screen.findByText("Sander Boer");
-      expect(fullName).toBeTruthy();
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText("Anna").props.value).toBe("Sander");
+        expect(screen.getByPlaceholderText("de Vries").props.value).toBe(
+          "Boer",
+        );
+      });
 
-      const picture = await screen.findByLabelText("Profile picture");
-      expect(picture).toBeTruthy();
+      // Picture present: an <Image> renders, and no "+" placeholder is shown.
+      const images = screen.UNSAFE_queryAllByType(Image);
+      expect(images.length).toBeGreaterThan(0);
+      expect(screen.queryByText("+")).toBeNull();
     });
   });
 
   describe("Scenario 2: no profile picture → placeholder", () => {
-    it("shows placeholder avatar when image is null", async () => {
+    it("shows the placeholder when image is null", async () => {
       mockGetMyProfile.mockResolvedValue({
-        identity: { name: "Sander", surname: "Boer", image: null, email: "s.boer@student.tue.nl" },
+        identity: {
+          name: "Sander",
+          surname: "Boer",
+          image: null,
+          email: "s.boer@student.tue.nl",
+        },
         profile: null,
         languages: [],
         interests: [],
@@ -77,18 +140,27 @@ describe("#281 — Profile tab display", () => {
 
       renderScreen();
 
-      const placeholder = await screen.findByLabelText("Profile picture placeholder");
-      expect(placeholder).toBeTruthy();
+      // Wait for identity to hydrate so we assert against the resolved state.
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText("Anna").props.value).toBe("Sander");
+      });
 
-      const fullName = await screen.findByText("Sander Boer");
-      expect(fullName).toBeTruthy();
+      // Identity still shows; only the picture falls back to the placeholder.
+      expect(screen.getByPlaceholderText("de Vries").props.value).toBe("Boer");
+      expect(screen.getByText("+")).toBeTruthy();
+      expect(screen.UNSAFE_queryAllByType(Image).length).toBe(0);
     });
   });
 
   describe("Scenario 3: updated values reflected", () => {
-    it("displays latest name and surname from getMyProfile", async () => {
+    it("displays the latest name and surname from getMyProfile", async () => {
       mockGetMyProfile.mockResolvedValue({
-        identity: { name: "Alex", surname: "Updated", image: null, email: "a.updated@student.tue.nl" },
+        identity: {
+          name: "Alex",
+          surname: "Updated",
+          image: null,
+          email: "a.updated@student.tue.nl",
+        },
         profile: null,
         languages: [],
         interests: [],
@@ -96,15 +168,24 @@ describe("#281 — Profile tab display", () => {
 
       renderScreen();
 
-      const fullName = await screen.findByText("Alex Updated");
-      expect(fullName).toBeTruthy();
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText("Anna").props.value).toBe("Alex");
+        expect(screen.getByPlaceholderText("de Vries").props.value).toBe(
+          "Updated",
+        );
+      });
     });
   });
 
   describe("edge cases", () => {
-    it("shows only name when surname is null", async () => {
+    it("shows the name and leaves surname empty when surname is null", async () => {
       mockGetMyProfile.mockResolvedValue({
-        identity: { name: "Sander", surname: null, image: null, email: "s@student.tue.nl" },
+        identity: {
+          name: "Sander",
+          surname: null,
+          image: null,
+          email: "s@student.tue.nl",
+        },
         profile: null,
         languages: [],
         interests: [],
@@ -112,8 +193,10 @@ describe("#281 — Profile tab display", () => {
 
       renderScreen();
 
-      const nameText = await screen.findByText("Sander");
-      expect(nameText).toBeTruthy();
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText("Anna").props.value).toBe("Sander");
+      });
+      expect(screen.getByPlaceholderText("de Vries").props.value).toBe("");
     });
   });
 });


### PR DESCRIPTION
## Why

The `profile-tab-display` suite (task #281 — own-profile identity display) failed to even load: `Cannot find module '../app/profile'`. The standalone `app/profile.tsx` screen was removed during the "added tabs" migration.

## Where identity now renders

The logged-in user's own identity (name / surname / picture) is now rendered by the **`ProfileModal`** component (`apps/native/components/profile-modal.tsx`), opened from the home tab's profile avatar. It renders:
- name via the "Anna" `TextInput` `value`
- surname via the "de Vries" `TextInput` `value`
- picture via an `<Image>`, falling back to a `+` placeholder `View` when `image` is null
- email as a `<Text>`

There is no standalone profile route and no combined "Full Name" string or `accessibilityLabel="Profile picture"` in the current UI, so the old assertions were retargeted to the component's real idioms (matching the sibling `profile-modal-hydration.test.tsx` mock/render style).

## Per-scenario disposition

- **S1 — complete identity (full name + picture):** kept. Asserts name="Sander"/surname="Boer" via input values, an `<Image>` is present, and no `+` placeholder.
- **S2 — no picture → placeholder:** kept. Waits for identity to hydrate, then asserts the `+` placeholder renders and no `<Image>` is present.
- **S3 — latest values reflected:** kept. Asserts inputs reflect the latest `getMyProfile` name/surname.
- **Edge — name only, surname null:** kept. Asserts name shows and the surname input is empty.

No scenario was dropped — all #281 behaviors still exist, just relocated into `ProfileModal`.

## Verification

`cd apps/native && bunx jest --no-coverage profile-tab-display` → **4 passed, 1 suite passed**.

No production code changed; only the test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)