### PR TITLE
fix(conversation): advance locked phase after own attendance report

### DIFF
--- a/apps/native/app/(tabs)/chats.tsx
+++ b/apps/native/app/(tabs)/chats.tsx
@@ -63,6 +63,7 @@ type ChatEntry =
       phase:
         | "scheduled"
         | "awaiting_attendance"
+        | "awaiting_partner_attendance"
         | "awaiting_my_optin"
         | "awaiting_partner_optin"
         | "declined";
@@ -74,6 +75,8 @@ function lockedSubtitle(entry: Extract<ChatEntry, { kind: "locked" }>): string {
       return "unlocks after you first meet up";
     case "awaiting_attendance":
       return "did you meet?";
+    case "awaiting_partner_attendance":
+      return `waiting for ${entry.partner.name.split(" ")[0]} to confirm you met`;
     case "awaiting_my_optin":
       return "tap to keep in touch";
     case "awaiting_partner_optin":

--- a/apps/native/app/chat/locked/[meetupId].tsx
+++ b/apps/native/app/chat/locked/[meetupId].tsx
@@ -9,6 +9,7 @@ import { queryClient, trpc } from "@/utils/trpc";
 type LockedPhase =
   | "scheduled"
   | "awaiting_attendance"
+  | "awaiting_partner_attendance"
   | "awaiting_my_optin"
   | "awaiting_partner_optin"
   | "declined";
@@ -37,6 +38,12 @@ function copyForPhase(phase: LockedPhase, partnerFirstName: string) {
         body: "Confirm attendance to unlock the chat.",
         cta: "Report attendance",
       };
+    case "awaiting_partner_attendance":
+      return {
+        headline: `Waiting for ${partnerFirstName} to confirm you met`,
+        body: "You've confirmed. The chat opens once they confirm too.",
+        cta: "See meetup details",
+      };
     case "awaiting_my_optin":
       return {
         headline: "Would you like to chat and keep in touch?",
@@ -61,6 +68,7 @@ function copyForPhase(phase: LockedPhase, partnerFirstName: string) {
 function headerSubtitle(phase: LockedPhase): string {
   if (phase === "scheduled") return "locked · meet first";
   if (phase === "awaiting_attendance") return "locked · awaiting attendance";
+  if (phase === "awaiting_partner_attendance") return "locked · waiting on partner";
   if (phase === "awaiting_my_optin") return "locked · rate to unlock";
   if (phase === "awaiting_partner_optin") return "locked · waiting to enable chatting";
   return "won't open";

--- a/packages/api/src/contexts/conversation/__tests__/locked-phase.test.ts
+++ b/packages/api/src/contexts/conversation/__tests__/locked-phase.test.ts
@@ -38,6 +38,25 @@ describe("deriveLockedPhase", () => {
     ).toBe("awaiting_attendance");
   });
 
+  it("returns 'awaiting_partner_attendance' when current student already reported but meetup is still confirmed", () => {
+    // #398 — A confirmed meetup only becomes `completed` once BOTH participants
+    // report attendance. While the current student has reported but the partner
+    // has not, the status stays `confirmed`. We must NOT re-prompt attendance
+    // (the server rejects a duplicate report) nor advance to `awaiting_my_optin`
+    // (the opt-in handler rejects non-completed meetups). Surface a dedicated
+    // waiting phase instead.
+    const phase = deriveLockedPhase({
+      meetupStatus: "confirmed",
+      meetupAt: past,
+      now,
+      hasMyAttendanceReport: true,
+      myOptIn: null,
+      partnerOptIn: null,
+    });
+    expect(phase).not.toBe("awaiting_attendance");
+    expect(phase).toBe("awaiting_partner_attendance");
+  });
+
   it("returns 'awaiting_my_optin' for completed meetups when current student has not responded", () => {
     expect(
       deriveLockedPhase({

--- a/packages/api/src/contexts/conversation/chat.ts
+++ b/packages/api/src/contexts/conversation/chat.ts
@@ -435,9 +435,10 @@ export const chatRouter = router({
     const phaseRank: Record<string, number> = {
       scheduled: 0,
       awaiting_attendance: 1,
-      awaiting_my_optin: 2,
-      awaiting_partner_optin: 3,
-      declined: 4,
+      awaiting_partner_attendance: 2,
+      awaiting_my_optin: 3,
+      awaiting_partner_optin: 4,
+      declined: 5,
     };
     const sortedLocked = lockedEntries.filter(keepEntry).sort((a, b) => {
       const r = (phaseRank[a.phase] ?? 99) - (phaseRank[b.phase] ?? 99);

--- a/packages/api/src/contexts/conversation/messaging-utils.ts
+++ b/packages/api/src/contexts/conversation/messaging-utils.ts
@@ -130,6 +130,10 @@ export function keptEntryKeysByPartner(
  * Phase a locked chat teaser is in. Drives copy + CTA on the chat list and locked detail screen.
  * - `scheduled`            — meetup confirmed, datetime in the future ("unlocks Friday at 10:30")
  * - `awaiting_attendance`  — meetup datetime passed, current student hasn't filed an attendance report
+ * - `awaiting_partner_attendance` — current student reported attendance, but the meetup is still
+ *   `confirmed` because the partner hasn't reported yet. A meetup only becomes `completed` once
+ *   BOTH report (see #398). This is a non-interactive waiting state: re-prompting attendance is
+ *   rejected as a duplicate, and the messaging opt-in handler rejects non-completed meetups.
  * - `awaiting_my_optin`    — meetup completed, current student hasn't responded to messaging opt-in
  * - `awaiting_partner_optin` — current student opted in, partner hasn't responded yet
  * - `declined`             — outcome already decided against opening (one declined, or `not_attended`)
@@ -137,6 +141,7 @@ export function keptEntryKeysByPartner(
 export type LockedPhase =
   | "scheduled"
   | "awaiting_attendance"
+  | "awaiting_partner_attendance"
   | "awaiting_my_optin"
   | "awaiting_partner_optin"
   | "declined";
@@ -153,7 +158,10 @@ export function deriveLockedPhase(args: {
   if (args.meetupStatus === "confirmed") {
     if (args.meetupAt > args.now) return "scheduled";
     if (!args.hasMyAttendanceReport) return "awaiting_attendance";
-    return "awaiting_attendance";
+    // #398 — I've reported but the meetup is still `confirmed`, so the partner
+    // hasn't reported yet. Don't re-prompt attendance (the server rejects the
+    // duplicate) and don't advance to opt-in (rejected for non-completed meetups).
+    return "awaiting_partner_attendance";
   }
   // completed
   if (args.myOptIn === "decline" || args.partnerOptIn === "decline") return "declined";


### PR DESCRIPTION
Fixes the Chats locked prompt looping on "did you meet?" after a student already reported attendance.

## Root cause
`deriveLockedPhase` (`packages/api/src/contexts/conversation/messaging-utils.ts`) returned `awaiting_attendance` from BOTH branches when `meetupStatus === "confirmed"` and the datetime had passed, ignoring `hasMyAttendanceReport`. A meetup only becomes `completed` once BOTH participants report (`meetup-aggregate.ts`), so while a student has reported but their partner has not, the status stays `confirmed` and the chat kept re-prompting attendance — which the server then rejects as a duplicate.

## Phase decision: new `awaiting_partner_attendance` phase (not `awaiting_my_optin`)
The reporter suggested advancing to `awaiting_my_optin` ("tap to keep in touch"). I verified the opt-in handler `respondToOptIn` (`messaging.ts:54`) **hard-rejects non-completed meetups** (`"Messaging opt-in is only available for completed meetups"`). Advancing to `awaiting_my_optin` while the meetup is still `confirmed` would re-create the exact same dead-end (a CTA the server rejects).

So I introduced a dedicated, **non-interactive waiting phase** `awaiting_partner_attendance`: current student has reported, partner has not. It surfaces "waiting for {partner} to confirm you met" with no attendance-report or opt-in CTA, wired through both native screens. Once the partner reports, the meetup flips to `completed` and the existing `awaiting_my_optin` flow takes over.

## Changes
- `messaging-utils.ts` — add `awaiting_partner_attendance` to `LockedPhase`; return it when `confirmed` + passed + `hasMyAttendanceReport`.
- `chat.ts` — slot the new phase into `phaseRank` (after `awaiting_attendance`).
- `apps/native/app/(tabs)/chats.tsx` — subtitle copy + union type.
- `apps/native/app/chat/locked/[meetupId].tsx` — copy, header subtitle, union type (falls through to non-interactive CTA).
- `locked-phase.test.ts` — new case asserting the phase is NOT `awaiting_attendance`.

## Tests
- `packages/api`: 160 pass, 0 fail
- `bun run check-types`: pass
- native chat jest suites: 3 pass, 0 fail

Closes #398