### PR TITLE
feat(scheduling): allow proposer to withdraw a pending meetup proposal

### DIFF
--- a/apps/native/__tests__/reschedule-form.test.tsx
+++ b/apps/native/__tests__/reschedule-form.test.tsx
@@ -38,6 +38,7 @@ jest.mock("expo-router", () => ({
 // ── tRPC / query mock ─────────────────────────────────────────────────────────
 
 const mockCancel = jest.fn().mockResolvedValue({});
+const mockWithdraw = jest.fn().mockResolvedValue({});
 const mockProposeReschedule = jest.fn().mockResolvedValue({});
 const mockReportAttendance = jest.fn().mockResolvedValue({});
 const mockPropose = jest.fn().mockResolvedValue({});
@@ -107,6 +108,7 @@ jest.mock("@/utils/trpc", () => ({
       // mutations
       reportAttendance: mutation(mockReportAttendance),
       cancelMeetup: mutation(mockCancel),
+      withdrawMeetup: mutation(mockWithdraw),
       proposeReschedule: mutation(mockProposeReschedule),
       propose: mutation(mockPropose),
       acceptProposal: mutation(mockAccept),

--- a/apps/native/app/(tabs)/confirmed-meetups.tsx
+++ b/apps/native/app/(tabs)/confirmed-meetups.tsx
@@ -215,6 +215,16 @@ export default function ConfirmedMeetupsScreen() {
     }),
   );
 
+  const withdrawMutation = useMutation(
+    trpc.meetup.withdrawMeetup.mutationOptions({
+      onSuccess: () => {
+        void queryClient.invalidateQueries(trpc.meetup.list.queryOptions({ status: "pending" }));
+        Alert.alert("Proposal withdrawn", "Your proposal has been withdrawn.");
+      },
+      onError: (err) => Alert.alert("Error", err.message),
+    }),
+  );
+
   if (meetupsQuery.isPending || pendingQuery.isPending) {
     return (
       <Container isScrollable={false}>
@@ -267,6 +277,17 @@ export default function ConfirmedMeetupsScreen() {
         text: "Cancel meetup",
         style: "destructive",
         onPress: () => cancelMutation.mutate({ meetupId }),
+      },
+    ]);
+  }
+
+  function handleWithdraw(meetupId: string) {
+    Alert.alert("Withdraw proposal", "Are you sure you want to withdraw this proposal?", [
+      { text: "Keep it", style: "cancel" },
+      {
+        text: "Withdraw",
+        style: "destructive",
+        onPress: () => withdrawMutation.mutate({ meetupId }),
       },
     ]);
   }
@@ -339,13 +360,27 @@ export default function ConfirmedMeetupsScreen() {
                   />
 
                   {isOutgoing ? (
-                    <Text
-                      testID="awaiting-response-label"
-                      className="font-manrope text-center"
-                      style={{ fontSize: 12, color: MUTED, fontStyle: "italic" }}
-                    >
-                      Awaiting response from {p.partner.name}
-                    </Text>
+                    <>
+                      <Text
+                        testID="awaiting-response-label"
+                        className="font-manrope text-center"
+                        style={{
+                          fontSize: 12,
+                          color: MUTED,
+                          fontStyle: "italic",
+                          marginBottom: 12,
+                        }}
+                      >
+                        Awaiting response from {p.partner.name}
+                      </Text>
+                      <SecondaryPill
+                        testID="withdraw-proposal-btn"
+                        label="Withdraw"
+                        onPress={() => handleWithdraw(p.id)}
+                        disabled={withdrawMutation.isPending}
+                        destructive
+                      />
+                    </>
                   ) : (
                     <PrimaryPill
                       testID="respond-to-proposal-btn"

--- a/packages/api/src/__test-support__/harness.ts
+++ b/packages/api/src/__test-support__/harness.ts
@@ -171,6 +171,7 @@ const EVENT_NAMES = [
   "MeetupCounterProposed",
   "MeetupDeclined",
   "MeetupCancelled",
+  "MeetupWithdrawn",
   "MeetupRescheduleProposed",
   "MeetupRescheduled",
   "MeetupRescheduleDeclined",

--- a/packages/api/src/contexts/scheduling/__tests__/meetup-aggregate.test.ts
+++ b/packages/api/src/contexts/scheduling/__tests__/meetup-aggregate.test.ts
@@ -220,6 +220,50 @@ describe("Meetup.cancel", () => {
   });
 });
 
+describe("Meetup.withdraw", () => {
+  it("transitions pending → cancelled for the proposer and emits MeetupWithdrawn", () => {
+    const { state, events } = Meetup.withdraw(pending(), { actorId: "u-A", now: NOW });
+    expect(state.status).toBe("cancelled");
+    expect(events).toHaveLength(1);
+    expect(events[0]!.name).toBe("MeetupWithdrawn");
+    expect(events[0]!.payload.meetupId).toBe("m-1");
+    expect(events[0]!.payload.withdrawnById).toBe("u-A");
+    expect(events[0]!.payload.receiverId).toBe("u-B");
+  });
+
+  it("rejects when the actor is the receiver, not the proposer", () => {
+    expect(() =>
+      Meetup.withdraw(pending(), { actorId: "u-B", now: NOW }),
+    ).toThrow(/proposer/);
+  });
+
+  it("rejects when the actor is not a participant", () => {
+    expect(() =>
+      Meetup.withdraw(pending(), { actorId: "u-X", now: NOW }),
+    ).toThrow(MeetupRuleError);
+  });
+
+  it("rejects withdrawing a confirmed meetup", () => {
+    expect(() =>
+      Meetup.withdraw(confirmed(), { actorId: "u-A", now: NOW }),
+    ).toThrow(/pending/);
+  });
+
+  it("rejects withdrawing a completed meetup", () => {
+    expect(() =>
+      Meetup.withdraw(pending({ status: "completed" }), { actorId: "u-A", now: NOW }),
+    ).toThrow(/pending/);
+  });
+
+  // After a counter-proposal the roles swap; only the *current* proposer may withdraw.
+  it("rejects the original proposer once roles have swapped via counter-proposal", () => {
+    const swapped = pending({ proposerId: "u-B", receiverId: "u-A", round: 2 });
+    expect(() =>
+      Meetup.withdraw(swapped, { actorId: "u-A", now: NOW }),
+    ).toThrow(/proposer/);
+  });
+});
+
 describe("Meetup.proposeReschedule + accept + decline", () => {
   it("proposeReschedule stores reschedule fields and emits event", () => {
     const { state, events } = Meetup.proposeReschedule(confirmed(), {

--- a/packages/api/src/contexts/scheduling/__tests__/meetup-integration.test.ts
+++ b/packages/api/src/contexts/scheduling/__tests__/meetup-integration.test.ts
@@ -166,6 +166,95 @@ describe("meetup integration — accept/decline lifecycle", () => {
   });
 });
 
+describe("meetup integration — withdraw", () => {
+  beforeEach(() => {
+    resetDb();
+  });
+
+  it("withdrawMeetup lets the proposer retract a pending proposal and emits MeetupWithdrawn", async () => {
+    const { a, b, venueId } = await seedMatchedPair();
+    const proposeCaller = appRouter.createCaller(buildSessionContext(a));
+    const created = await proposeCaller.meetup.propose({
+      partnerId: b,
+      venueId,
+      scheduledAt: FUTURE_AT.toISOString(),
+    });
+
+    const capture = captureEvents();
+    const updated = await proposeCaller.meetup.withdrawMeetup({ meetupId: created!.id });
+    capture.stop();
+
+    expect(updated!.status).toBe("cancelled");
+    expect(capture.events.map((e) => e.name)).toContain("MeetupWithdrawn");
+    // A withdrawn never-confirmed proposal must NOT notify the receiver as a cancellation.
+    expect(capture.events.map((e) => e.name)).not.toContain("MeetupCancelled");
+  });
+
+  it("removes the proposal from the proposer's pending list after withdrawal", async () => {
+    const { a, b, venueId } = await seedMatchedPair();
+    const proposeCaller = appRouter.createCaller(buildSessionContext(a));
+    const created = await proposeCaller.meetup.propose({
+      partnerId: b,
+      venueId,
+      scheduledAt: FUTURE_AT.toISOString(),
+    });
+
+    await proposeCaller.meetup.withdrawMeetup({ meetupId: created!.id });
+
+    const pending = await proposeCaller.meetup.list({ status: "pending" });
+    expect(pending.map((m) => m.id)).not.toContain(created!.id);
+  });
+
+  it("does not offer the receiver a response to a withdrawn proposal", async () => {
+    const { a, b, venueId } = await seedMatchedPair();
+    const created = await appRouter
+      .createCaller(buildSessionContext(a))
+      .meetup.propose({ partnerId: b, venueId, scheduledAt: FUTURE_AT.toISOString() });
+
+    await appRouter
+      .createCaller(buildSessionContext(a))
+      .meetup.withdrawMeetup({ meetupId: created!.id });
+
+    const receiverCaller = appRouter.createCaller(buildSessionContext(b));
+    const receiverPending = await receiverCaller.meetup.list({ status: "pending" });
+    expect(receiverPending.map((m) => m.id)).not.toContain(created!.id);
+
+    // Receiver can no longer respond to a withdrawn (now cancelled) proposal.
+    await expect(
+      receiverCaller.meetup.acceptProposal({ meetupId: created!.id }),
+    ).rejects.toThrow();
+  });
+
+  it("rejects the receiver attempting to withdraw the proposer's proposal", async () => {
+    const { a, b, venueId } = await seedMatchedPair();
+    const created = await appRouter
+      .createCaller(buildSessionContext(a))
+      .meetup.propose({ partnerId: b, venueId, scheduledAt: FUTURE_AT.toISOString() });
+
+    await expect(
+      appRouter
+        .createCaller(buildSessionContext(b))
+        .meetup.withdrawMeetup({ meetupId: created!.id }),
+    ).rejects.toThrow(/proposer/);
+  });
+
+  it("rejects withdrawing a confirmed meetup", async () => {
+    const { a, b, venueId } = await seedMatchedPair();
+    const created = await appRouter
+      .createCaller(buildSessionContext(a))
+      .meetup.propose({ partnerId: b, venueId, scheduledAt: FUTURE_AT.toISOString() });
+    await appRouter
+      .createCaller(buildSessionContext(b))
+      .meetup.acceptProposal({ meetupId: created!.id });
+
+    await expect(
+      appRouter
+        .createCaller(buildSessionContext(a))
+        .meetup.withdrawMeetup({ meetupId: created!.id }),
+    ).rejects.toThrow(/pending/);
+  });
+});
+
 describe("meetup integration — counter-propose", () => {
   beforeEach(() => {
     resetDb();

--- a/packages/api/src/contexts/scheduling/meetup-aggregate.ts
+++ b/packages/api/src/contexts/scheduling/meetup-aggregate.ts
@@ -50,6 +50,7 @@ export type MeetupEventName =
   | "MeetupCounterProposed"
   | "MeetupDeclined"
   | "MeetupCancelled"
+  | "MeetupWithdrawn"
   | "MeetupRescheduleProposed"
   | "MeetupRescheduled"
   | "MeetupRescheduleDeclined"
@@ -337,6 +338,48 @@ export const Meetup = {
           cancelledById: args.actorId,
           otherStudentId,
           cancelledAt: args.now,
+        },
+      },
+    ];
+    return { state: next, events };
+  },
+
+  /**
+   * Withdraw a still-pending proposal (proposer-only). Distinct from `cancel`,
+   * which only ever applies to a *confirmed* booking. Keeping the two commands
+   * separate guarantees a confirmed/completed meetup can never be retracted via
+   * the withdraw path, and a never-confirmed proposal never emits the
+   * `MeetupCancelled` event the cancel flow uses (so the receiver is not told a
+   * confirmed booking was cancelled). After a counter-proposal the roles swap,
+   * so only the *current* proposer may withdraw.
+   */
+  withdraw(
+    state: MeetupSnapshot,
+    args: { actorId: string; now: Date },
+  ): { state: MeetupSnapshot; events: DomainEventToEmit[] } {
+    ensureParticipant(state, args.actorId);
+    if (state.proposerId !== args.actorId) {
+      throw new MeetupRuleError(
+        "FORBIDDEN",
+        "Only the proposer can withdraw this proposal",
+      );
+    }
+    if (state.status !== "pending") {
+      throw new MeetupRuleError(
+        "BAD_REQUEST",
+        "Only pending proposals can be withdrawn",
+      );
+    }
+
+    const next: MeetupSnapshot = { ...state, status: "cancelled" };
+    const events: DomainEventToEmit[] = [
+      {
+        name: "MeetupWithdrawn",
+        payload: {
+          meetupId: state.id,
+          withdrawnById: args.actorId,
+          receiverId: state.receiverId,
+          withdrawnAt: args.now,
         },
       },
     ];

--- a/packages/api/src/contexts/scheduling/meetup.ts
+++ b/packages/api/src/contexts/scheduling/meetup.ts
@@ -587,6 +587,35 @@ export const meetupRouter = router({
       return updated;
     }),
 
+  // #399 — Withdraw a still-pending proposal (proposer-only) → cancelled status,
+  // emit MeetupWithdrawn. Separate from cancelMeetup so a confirmed/completed
+  // meetup can never be retracted here, and the receiver is never notified of a
+  // "cancelled meetup" for a proposal that was never confirmed.
+  withdrawMeetup: protectedProcedure
+    .input(z.object({ meetupId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const userId = ctx.session.user.id;
+      const existing = await loadMeetupSnapshot(input.meetupId);
+      if (!existing) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Meetup not found" });
+      }
+
+      let decision;
+      try {
+        decision = Meetup.withdraw(existing, { actorId: userId, now: new Date() });
+      } catch (err) {
+        toTrpcError(err);
+      }
+
+      const [updated] = await db
+        .update(meetup)
+        .set({ status: decision.state.status })
+        .where(eq(meetup.id, existing.id))
+        .returning();
+      emit(decision.events);
+      return updated;
+    }),
+
   // Query confirmed meetups for the current user
   getConfirmed: protectedProcedure.query(async ({ ctx }) => {
     const userId = ctx.session.user.id;

--- a/packages/api/src/domain-events.ts
+++ b/packages/api/src/domain-events.ts
@@ -87,6 +87,19 @@ export interface MeetupCancelledEvent {
   cancelledAt: Date;
 }
 
+/**
+ * Emitted when a proposer retracts a still-pending proposal. Distinct from
+ * `MeetupCancelled` (which applies only to confirmed bookings) so consumers can
+ * treat a withdrawn never-confirmed proposal differently — notably, the
+ * receiver is not notified of a "cancelled meetup".
+ */
+export interface MeetupWithdrawnEvent {
+  meetupId: string;
+  withdrawnById: string;
+  receiverId: string;
+  withdrawnAt: Date;
+}
+
 export interface MeetupRescheduleProposedEvent {
   meetupId: string;
   proposerId: string;
@@ -265,6 +278,7 @@ type DomainEventMap = {
   MeetupCounterProposed: [MeetupCounterProposedEvent];
   MeetupDeclined: [MeetupDeclinedEvent];
   MeetupCancelled: [MeetupCancelledEvent];
+  MeetupWithdrawn: [MeetupWithdrawnEvent];
   MeetupRescheduleProposed: [MeetupRescheduleProposedEvent];
   MeetupRescheduled: [MeetupRescheduledEvent];
   MeetupRescheduleDeclined: [MeetupRescheduleDeclinedEvent];


### PR DESCRIPTION
Adds a withdraw path so a proposer can retract a still-`pending` meetup proposal.

## Approach: dedicated `Meetup.withdraw` command (not a relaxed `cancel`)
Chose a **separate `Meetup.withdraw` aggregate command + `withdrawMeetup` tRPC procedure** rather than overloading `Meetup.cancel`. Rationale:
- `Meetup.cancel` stays strictly `confirmed`-only, so a confirmed/completed meetup can **never** be retracted through the withdraw path, and a `pending` proposal can never go through the confirmed-cancel path. The two lifecycles remain independent — zero regression risk to the existing confirmed-cancel flow.
- `withdraw` is **proposer-only** and **pending-only**: throws `FORBIDDEN` if the actor is the receiver (or not a participant), and `BAD_REQUEST` if status is not `pending`. After a counter-proposal the roles swap, so only the *current* proposer may withdraw.
- Sets status to `cancelled` and emits a new `MeetupWithdrawn` domain event (distinct from `MeetupCancelled`).

## Notification behaviour
`MeetupCancelled` currently has **no subscriber** in the codebase — emitted but only consumed in tests, so cancellation produces no push notification today. `MeetupWithdrawn` is a distinct event with **no subscriber**, so withdrawing a never-confirmed proposal sends **no receiver notification** — the desired behaviour (the receiver is not told a "meetup was cancelled" for a booking that was never confirmed). The new event type is wired into `domain-events.ts` and the test-harness allowlist for future consumers.

## Receiver consistency
A withdrawn proposal becomes `cancelled`, so it drops out of both participants' `meetup.list({ status: "pending" })` and the receiver can no longer `acceptProposal` it (aggregate rejects non-`pending`). `pendingCount` (filtered on `status = "pending"`) decrements automatically.

## Native
Wired a destructive **"Withdraw"** `SecondaryPill` (testID `withdraw-proposal-btn`) into the outgoing pending card under the existing "Awaiting response" label, with a confirm `Alert` and pending-list invalidation on success.

## Past-dated-pending verification (secondary)
Confirmed: no code change needed. `meetup.list` still filters `status: "pending"` rows with `gte(meetup.scheduledAt, new Date())` (#388, `meetup.ts:407-409`), so past-dated pending proposals remain hidden. Left as-is per the issue's "verify only" guidance.

## Tests (all passing)
- API: aggregate unit tests for `Meetup.withdraw` (proposer succeeds + emits `MeetupWithdrawn`; receiver/non-participant/confirmed/completed/role-swapped all rejected) + integration tests for `withdrawMeetup` (proposer withdraws, leaves pending list, receiver not offered response, no `MeetupCancelled`, confirmed rejected). `bun test` → **170 pass / 0 fail**.
- Native: `jest --no-coverage` → **158 pass / 0 fail** (added `withdrawMeetup` to the screen's tRPC mock).
- `turbo check-types` → all green.

Closes #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)