### PR TITLE
feat(api): serve conversation-starter content per language

### DIFF
--- a/packages/api/src/contexts/conversation-practice/__tests__/starter-content.test.ts
+++ b/packages/api/src/contexts/conversation-practice/__tests__/starter-content.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for:
+ *   #404 — Curate and serve conversation-starter content per language
+ *
+ * Covers the curated content module and its pure lookup helper. The four
+ * Gherkin scenarios from #404 are each named in an `it` block below.
+ */
+import { describe, expect, it } from "bun:test";
+
+import {
+  CURATED_LANGUAGES,
+  STARTER_CARDS,
+  getStartersForLanguage,
+} from "../starter-content";
+
+describe("#404 — curated conversation-starter content", () => {
+  it("Scenario: At least 30 cards per selectable language", () => {
+    expect(CURATED_LANGUAGES.length).toBeGreaterThan(0);
+    for (const language of CURATED_LANGUAGES) {
+      const cards = getStartersForLanguage(language);
+      expect(cards.length).toBeGreaterThanOrEqual(30);
+    }
+  });
+
+  it("Scenario: Each card carries an English translation", () => {
+    for (const language of CURATED_LANGUAGES) {
+      for (const card of getStartersForLanguage(language)) {
+        expect(typeof card.id).toBe("string");
+        expect(card.id.length).toBeGreaterThan(0);
+        expect(typeof card.text).toBe("string");
+        expect(card.text.trim().length).toBeGreaterThan(0);
+        expect(typeof card.translation).toBe("string");
+        expect(card.translation.trim().length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("Scenario: Each card carries an English translation — English maps translation === text", () => {
+    for (const card of getStartersForLanguage("English")) {
+      expect(card.translation).toBe(card.text);
+    }
+  });
+
+  it("Scenario: Uncurated language returns no cards", () => {
+    expect(getStartersForLanguage("Klingon")).toEqual([]);
+    expect(getStartersForLanguage("")).toEqual([]);
+    expect(getStartersForLanguage("dutch")).toEqual([]); // case-sensitive key
+  });
+
+  it("Scenario: Card order is stable", () => {
+    for (const language of CURATED_LANGUAGES) {
+      const first = getStartersForLanguage(language);
+      const second = getStartersForLanguage(language);
+      expect(second.map((c) => c.id)).toEqual(first.map((c) => c.id));
+      expect(second.map((c) => c.text)).toEqual(first.map((c) => c.text));
+    }
+  });
+
+  it("assigns unique, language-prefixed, stable ids within each language", () => {
+    for (const language of CURATED_LANGUAGES) {
+      const ids = getStartersForLanguage(language).map((c) => c.id);
+      expect(new Set(ids).size).toBe(ids.length);
+    }
+    expect(getStartersForLanguage("Dutch")[0]?.id).toBe("nl-001");
+    expect(getStartersForLanguage("English")[0]?.id).toBe("en-001");
+  });
+
+  it("curates English, Dutch, Spanish, German and French", () => {
+    expect(CURATED_LANGUAGES).toEqual(
+      expect.arrayContaining(["English", "Dutch", "Spanish", "German", "French"]),
+    );
+  });
+
+  it("exposes the same number of cards per language (aligned deck positions)", () => {
+    const counts = CURATED_LANGUAGES.map((l) => STARTER_CARDS[l]?.length ?? 0);
+    expect(new Set(counts).size).toBe(1);
+  });
+});

--- a/packages/api/src/contexts/conversation-practice/__tests__/starters.test.ts
+++ b/packages/api/src/contexts/conversation-practice/__tests__/starters.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Integration test for:
+ *   #404 — content.starters.listByLanguage
+ *
+ * Drives the real tRPC caller so the procedure contract (input validation,
+ * protected access, response shape) is verified through the actual router.
+ */
+import "../../../__test-support__/harness";
+
+import { describe, it, expect } from "bun:test";
+
+import { appRouter } from "../../../routers";
+import { buildSessionContext } from "../../../__test-support__/harness";
+
+const USER_ID = "u-starters";
+
+function caller() {
+  return appRouter.createCaller(buildSessionContext(USER_ID));
+}
+
+describe("#404 — content.starters.listByLanguage", () => {
+  it("Scenario: At least 30 cards per selectable language", async () => {
+    const result = await caller().content.starters.listByLanguage({ language: "Dutch" });
+    expect(result.language).toBe("Dutch");
+    expect(result.cards.length).toBeGreaterThanOrEqual(30);
+  });
+
+  it("Scenario: Each card carries an English translation", async () => {
+    const result = await caller().content.starters.listByLanguage({ language: "Dutch" });
+    const card = result.cards[0];
+    expect(card?.text.trim().length).toBeGreaterThan(0);
+    expect(card?.translation.trim().length).toBeGreaterThan(0);
+    expect(card?.text).not.toBe(card?.translation); // Dutch text differs from English
+  });
+
+  it("Scenario: Uncurated language returns no cards", async () => {
+    const result = await caller().content.starters.listByLanguage({ language: "Klingon" });
+    expect(result).toEqual({ language: "Klingon", cards: [] });
+  });
+
+  it("Scenario: Card order is stable", async () => {
+    const a = await caller().content.starters.listByLanguage({ language: "Spanish" });
+    const b = await caller().content.starters.listByLanguage({ language: "Spanish" });
+    expect(b.cards.map((c) => c.id)).toEqual(a.cards.map((c) => c.id));
+  });
+
+  it("echoes the requested language back in the response", async () => {
+    const result = await caller().content.starters.listByLanguage({ language: "French" });
+    expect(result.language).toBe("French");
+    expect(result.cards.length).toBeGreaterThanOrEqual(30);
+  });
+
+  it("requires authentication (protected procedure)", async () => {
+    const anonCaller = appRouter.createCaller({ session: null } as never);
+    await expect(
+      anonCaller.content.starters.listByLanguage({ language: "Dutch" }),
+    ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+  });
+});

--- a/packages/api/src/contexts/conversation-practice/content.ts
+++ b/packages/api/src/contexts/conversation-practice/content.ts
@@ -1,0 +1,10 @@
+import { router } from "../../index";
+import { startersRouter } from "./starters";
+
+/**
+ * Conversation Practice content context. Nests the `starters` sub-router so the
+ * client contract resolves to `content.starters.listByLanguage`.
+ */
+export const contentRouter = router({
+  starters: startersRouter,
+});

--- a/packages/api/src/contexts/conversation-practice/index.ts
+++ b/packages/api/src/contexts/conversation-practice/index.ts
@@ -1,0 +1,7 @@
+export { contentRouter } from "./content";
+export {
+  STARTER_CARDS,
+  CURATED_LANGUAGES,
+  getStartersForLanguage,
+  type StarterCard,
+} from "./starter-content";

--- a/packages/api/src/contexts/conversation-practice/starter-content.ts
+++ b/packages/api/src/contexts/conversation-practice/starter-content.ts
@@ -1,0 +1,229 @@
+/**
+ * Hand-curated conversation-starter content (Task #404, Feature #378, Epic #375).
+ *
+ * Static, version-controlled content — no database table, no migration. Each
+ * selectable language carries at least 30 basic, conversational question cards.
+ * Every card has `text` in that language and a non-empty English `translation`
+ * (for English, `translation === text`). Card order is stable: it is the source
+ * array order, which never changes between requests.
+ */
+
+export interface StarterCard {
+  /** Stable, unique id (language-prefixed, e.g. "nl-001"). */
+  id: string;
+  /** Question text in the card's language. */
+  text: string;
+  /** English translation; non-empty (equals `text` for English). */
+  translation: string;
+}
+
+/**
+ * The 30 basic conversation-starter questions, in English. Every other curated
+ * language is a translation of this same ordered set, so the deck position
+ * indicator lines up across languages.
+ */
+const ENGLISH_STARTERS: readonly string[] = [
+  "How are you today?",
+  "What is your name?",
+  "Where are you from?",
+  "What do you do for work?",
+  "What did you do this weekend?",
+  "Do you have any brothers or sisters?",
+  "What is your favourite food?",
+  "Do you like coffee or tea?",
+  "What music do you like?",
+  "What is your favourite film?",
+  "Do you have any pets?",
+  "What do you like to do in your free time?",
+  "Have you travelled anywhere nice recently?",
+  "What is your favourite season?",
+  "Do you prefer the city or the countryside?",
+  "What languages do you speak?",
+  "Why are you learning this language?",
+  "What is the weather like today?",
+  "What time do you usually wake up?",
+  "Do you play any sports?",
+  "What did you have for breakfast?",
+  "What is your favourite book?",
+  "Do you like to cook?",
+  "What is your dream holiday?",
+  "What makes you happy?",
+  "Do you have any plans for the weekend?",
+  "What is your favourite place in this city?",
+  "How do you usually get to work?",
+  "What is something new you learned recently?",
+  "What are you looking forward to this week?",
+];
+
+/** Localised question text, in the exact same order as `ENGLISH_STARTERS`. */
+const TRANSLATIONS: Record<string, readonly string[]> = {
+  English: ENGLISH_STARTERS,
+  Dutch: [
+    "Hoe gaat het vandaag met je?",
+    "Wat is je naam?",
+    "Waar kom je vandaan?",
+    "Wat voor werk doe je?",
+    "Wat heb je dit weekend gedaan?",
+    "Heb je broers of zussen?",
+    "Wat is je lievelingseten?",
+    "Hou je van koffie of thee?",
+    "Naar welke muziek luister je graag?",
+    "Wat is je favoriete film?",
+    "Heb je huisdieren?",
+    "Wat doe je graag in je vrije tijd?",
+    "Ben je onlangs ergens leuks geweest?",
+    "Wat is je favoriete seizoen?",
+    "Hou je meer van de stad of het platteland?",
+    "Welke talen spreek je?",
+    "Waarom leer je deze taal?",
+    "Wat voor weer is het vandaag?",
+    "Hoe laat sta je meestal op?",
+    "Doe je aan sport?",
+    "Wat heb je als ontbijt gegeten?",
+    "Wat is je favoriete boek?",
+    "Hou je van koken?",
+    "Wat is je droomvakantie?",
+    "Waar word je blij van?",
+    "Heb je plannen voor het weekend?",
+    "Wat is je favoriete plek in deze stad?",
+    "Hoe ga je meestal naar je werk?",
+    "Wat heb je onlangs nieuws geleerd?",
+    "Waar kijk je deze week naar uit?",
+  ],
+  Spanish: [
+    "¿Cómo estás hoy?",
+    "¿Cómo te llamas?",
+    "¿De dónde eres?",
+    "¿A qué te dedicas?",
+    "¿Qué hiciste este fin de semana?",
+    "¿Tienes hermanos o hermanas?",
+    "¿Cuál es tu comida favorita?",
+    "¿Prefieres el café o el té?",
+    "¿Qué música te gusta?",
+    "¿Cuál es tu película favorita?",
+    "¿Tienes mascotas?",
+    "¿Qué te gusta hacer en tu tiempo libre?",
+    "¿Has viajado a algún lugar bonito últimamente?",
+    "¿Cuál es tu estación favorita?",
+    "¿Prefieres la ciudad o el campo?",
+    "¿Qué idiomas hablas?",
+    "¿Por qué estás aprendiendo este idioma?",
+    "¿Qué tiempo hace hoy?",
+    "¿A qué hora te levantas normalmente?",
+    "¿Practicas algún deporte?",
+    "¿Qué desayunaste?",
+    "¿Cuál es tu libro favorito?",
+    "¿Te gusta cocinar?",
+    "¿Cuáles son tus vacaciones soñadas?",
+    "¿Qué te hace feliz?",
+    "¿Tienes planes para el fin de semana?",
+    "¿Cuál es tu lugar favorito de esta ciudad?",
+    "¿Cómo vas normalmente al trabajo?",
+    "¿Qué has aprendido de nuevo últimamente?",
+    "¿Qué esperas con ganas esta semana?",
+  ],
+  German: [
+    "Wie geht es dir heute?",
+    "Wie heißt du?",
+    "Woher kommst du?",
+    "Was machst du beruflich?",
+    "Was hast du dieses Wochenende gemacht?",
+    "Hast du Geschwister?",
+    "Was ist dein Lieblingsessen?",
+    "Magst du lieber Kaffee oder Tee?",
+    "Welche Musik magst du?",
+    "Was ist dein Lieblingsfilm?",
+    "Hast du Haustiere?",
+    "Was machst du gern in deiner Freizeit?",
+    "Warst du in letzter Zeit irgendwo Schönes?",
+    "Was ist deine Lieblingsjahreszeit?",
+    "Magst du lieber die Stadt oder das Land?",
+    "Welche Sprachen sprichst du?",
+    "Warum lernst du diese Sprache?",
+    "Wie ist das Wetter heute?",
+    "Wann stehst du normalerweise auf?",
+    "Treibst du Sport?",
+    "Was hast du zum Frühstück gegessen?",
+    "Was ist dein Lieblingsbuch?",
+    "Kochst du gern?",
+    "Was ist dein Traumurlaub?",
+    "Was macht dich glücklich?",
+    "Hast du Pläne für das Wochenende?",
+    "Was ist dein Lieblingsort in dieser Stadt?",
+    "Wie kommst du normalerweise zur Arbeit?",
+    "Was hast du in letzter Zeit Neues gelernt?",
+    "Worauf freust du dich diese Woche?",
+  ],
+  French: [
+    "Comment vas-tu aujourd'hui ?",
+    "Comment t'appelles-tu ?",
+    "D'où viens-tu ?",
+    "Que fais-tu dans la vie ?",
+    "Qu'as-tu fait ce week-end ?",
+    "As-tu des frères ou des sœurs ?",
+    "Quel est ton plat préféré ?",
+    "Préfères-tu le café ou le thé ?",
+    "Quelle musique aimes-tu ?",
+    "Quel est ton film préféré ?",
+    "As-tu des animaux de compagnie ?",
+    "Qu'aimes-tu faire pendant ton temps libre ?",
+    "As-tu voyagé quelque part de joli récemment ?",
+    "Quelle est ta saison préférée ?",
+    "Préfères-tu la ville ou la campagne ?",
+    "Quelles langues parles-tu ?",
+    "Pourquoi apprends-tu cette langue ?",
+    "Quel temps fait-il aujourd'hui ?",
+    "À quelle heure te lèves-tu d'habitude ?",
+    "Pratiques-tu un sport ?",
+    "Qu'as-tu mangé au petit-déjeuner ?",
+    "Quel est ton livre préféré ?",
+    "Aimes-tu cuisiner ?",
+    "Quelles sont tes vacances de rêve ?",
+    "Qu'est-ce qui te rend heureux ?",
+    "As-tu des projets pour le week-end ?",
+    "Quel est ton endroit préféré dans cette ville ?",
+    "Comment vas-tu au travail d'habitude ?",
+    "Qu'as-tu appris de nouveau récemment ?",
+    "Qu'attends-tu avec impatience cette semaine ?",
+  ],
+};
+
+/** Two-letter id prefix per curated language, matching `language-flags` codes. */
+const ID_PREFIX: Record<string, string> = {
+  English: "en",
+  Dutch: "nl",
+  Spanish: "es",
+  German: "de",
+  French: "fr",
+};
+
+function buildCards(language: string): StarterCard[] {
+  const texts = TRANSLATIONS[language];
+  if (!texts) return [];
+  const prefix = ID_PREFIX[language] ?? language.slice(0, 2).toLowerCase();
+  return texts.map((text, index) => ({
+    id: `${prefix}-${String(index + 1).padStart(3, "0")}`,
+    text,
+    translation: ENGLISH_STARTERS[index] ?? text,
+  }));
+}
+
+/**
+ * Curated cards keyed by language. Built once at module load so the array
+ * identity — and therefore the order — is stable across every request.
+ */
+export const STARTER_CARDS: Readonly<Record<string, readonly StarterCard[]>> =
+  Object.fromEntries(
+    Object.keys(TRANSLATIONS).map((language) => [language, buildCards(language)]),
+  );
+
+/** Languages that currently have curated content. */
+export const CURATED_LANGUAGES: readonly string[] = Object.keys(STARTER_CARDS);
+
+/**
+ * Ordered curated cards for a language, or an empty array when the language has
+ * no curated content yet (so the deck can show a "no cards yet" state).
+ */
+export function getStartersForLanguage(language: string): readonly StarterCard[] {
+  return STARTER_CARDS[language] ?? [];
+}

--- a/packages/api/src/contexts/conversation-practice/starters.ts
+++ b/packages/api/src/contexts/conversation-practice/starters.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+import { protectedProcedure, router } from "../../index";
+import { getStartersForLanguage, type StarterCard } from "./starter-content";
+
+/**
+ * Read-only serving layer for curated conversation-starter content
+ * (Task #404, Feature #378).
+ *
+ * `listByLanguage` returns the ordered cards for the requested language, or an
+ * empty list for an unknown / uncurated language so the deck can render a
+ * "no cards yet" state instead of a blank screen.
+ */
+export const startersRouter = router({
+  listByLanguage: protectedProcedure
+    .input(z.object({ language: z.string() }))
+    .query(({ input }): { language: string; cards: StarterCard[] } => {
+      return {
+        language: input.language,
+        cards: [...getStartersForLanguage(input.language)],
+      };
+    }),
+});

--- a/packages/api/src/routers/index.ts
+++ b/packages/api/src/routers/index.ts
@@ -6,6 +6,7 @@ import { adminVenueRouter } from "../contexts/scheduling/venue-admin";
 import { meetupRouter } from "../contexts/scheduling/meetup";
 import { chatRouter, messagingRouter } from "../contexts/conversation";
 import { moderationRouter } from "../contexts/moderation";
+import { contentRouter } from "../contexts/conversation-practice";
 
 export const appRouter = router({
   healthCheck: publicProcedure.query(() => {
@@ -25,5 +26,6 @@ export const appRouter = router({
   chat: chatRouter,
   messaging: messagingRouter,
   moderation: moderationRouter,
+  content: contentRouter,
 });
 export type AppRouter = typeof appRouter;


### PR DESCRIPTION
## Summary

Buddies need real questions to ask during a meet-up. This adds the foundational content + serving layer for the conversation-starter deck (Feature #378): a hand-curated, static set of basic conversation starters per language, served read-only over tRPC. It unblocks the deck UI task and supplies the translation data later consumed by the tap-to-reveal feature (#379).

No database table or migration — content is static, version-controlled, and colocated with its English translation in a typed module.

## Changes

- New **Conversation Practice content context** at `packages/api/src/contexts/conversation-practice/`:
  - `starter-content.ts` — typed content module. `STARTER_CARDS` keyed by language plus a pure `getStartersForLanguage()` helper. Curates **30 cards each** for **English, Dutch, Spanish, German, French** (150 cards total). Cards are built once at module load so order is stable across requests; ids are language-prefixed (`nl-001`, `en-001`, …). English maps `translation === text`.
  - `starters.ts` — `startersRouter` with the read-only `listByLanguage` query (`protectedProcedure`, matching the dominant sibling convention). Returns `{ language, cards }`, empty `cards` for unknown/uncurated languages.
  - `content.ts` / `index.ts` — `contentRouter` nests `starters` so the contract resolves to `content.starters.listByLanguage`.
- Registered `content: contentRouter` in `packages/api/src/routers/index.ts`.
- Tests in `__tests__/` (content-module unit + router integration via the real tRPC caller).

## Test plan

`bun test` (14 new tests pass; full api suite 186/186, no regressions) and `bun check-types` (clean across all packages).

Per Gherkin scenario:

- **At least 30 cards per selectable language** — asserts ≥30 cards for every curated language, at both module and router level.
- **Each card carries an English translation** — every card has non-empty `text` + `translation`; non-English `text` differs from its translation; English maps `translation === text`.
- **Uncurated language returns no cards** — unknown / empty / wrong-case language → `{ language, cards: [] }`.
- **Card order is stable** — repeated requests return identical id/text order.
- Extra: anonymous caller is rejected (`UNAUTHORIZED`); response echoes the requested language; aligned card counts across languages.

## Related

Closes #404
Part of Feature #378 · Epic #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)
