### PR TITLE
feat(native): add conversation starters tab

### DIFF
--- a/apps/native/__tests__/conversation-starters-tab.test.tsx
+++ b/apps/native/__tests__/conversation-starters-tab.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * Tests for task #380 — Add the Conversation Starters tab and screen to the
+ * bottom navigation.
+ *
+ * Scenario 1: Tab is visible in the bottom navigation.
+ *   The tabs layout registers a "Conversation Starters" <Tabs.Screen> with a
+ *   label (title) and an Ionicons tabBarIcon, alongside the existing tabs.
+ *
+ * Scenario 2: Opening the tab.
+ *   The Conversation Starters screen component renders its own content.
+ *
+ * `expo-router`'s <Tabs> is mocked to capture the registered screens (name +
+ * options) so we can assert registration without a navigation container. The
+ * tRPC badge queries used by the layout are mocked to return empty data.
+ */
+import { render, screen } from "@testing-library/react-native";
+import React from "react";
+
+type ScreenOptions = {
+  title?: string;
+  href?: string | null;
+  tabBarIcon?: (p: { color: string; size: number }) => React.ReactNode;
+};
+
+const registeredScreens: { name: string; options?: ScreenOptions }[] = [];
+
+jest.mock("expo-router", () => {
+  const { View } = require("react-native");
+  const Tabs = ({ children }: { children: React.ReactNode }) => <View>{children}</View>;
+  Tabs.Screen = ({ name, options }: { name: string; options?: ScreenOptions }) => {
+    registeredScreens.push({ name, options });
+    return null;
+  };
+  return { Tabs };
+});
+
+jest.mock("@expo/vector-icons", () => {
+  const { Text } = require("react-native");
+  return {
+    Ionicons: ({ name }: { name: string }) => <Text>{name}</Text>,
+  };
+});
+
+jest.mock("uniwind", () => ({
+  withUniwind: (Component: unknown) => Component,
+}));
+
+jest.mock("@tanstack/react-query", () => ({
+  useQuery: () => ({ data: [] }),
+}));
+
+const makeQueryable = () => ({ queryOptions: () => ({}) });
+jest.mock("@/utils/trpc", () => ({
+  trpc: {
+    matching: { getIncomingRequests: makeQueryable() },
+    meetup: { list: makeQueryable(), getConfirmed: makeQueryable() },
+    chat: { listEntries: makeQueryable() },
+  },
+}));
+
+jest.mock("@/components/container", () => {
+  const { View } = require("react-native");
+  return {
+    Container: ({ children }: { children: React.ReactNode }) => <View>{children}</View>,
+  };
+});
+
+describe("Conversation Starters tab registration", () => {
+  beforeEach(() => {
+    registeredScreens.length = 0;
+  });
+
+  it("registers a Conversation Starters tab with a label and icon", () => {
+    const TabsLayout = require("@/app/(tabs)/_layout").default;
+    render(<TabsLayout />);
+
+    const tab = registeredScreens.find((s) => s.name === "conversation-starters");
+    expect(tab).toBeDefined();
+    expect(tab?.options?.title).toBe("Conversation Starters");
+    // Icon renderer is provided and yields a node (Ionicons element).
+    const iconNode = tab?.options?.tabBarIcon?.({ color: "#000", size: 24 });
+    expect(iconNode).toBeTruthy();
+  });
+
+  it("registers it as a visible tab (not href: null) alongside existing tabs", () => {
+    const TabsLayout = require("@/app/(tabs)/_layout").default;
+    render(<TabsLayout />);
+
+    const names = registeredScreens.map((s) => s.name);
+    expect(names).toEqual(
+      expect.arrayContaining(["home", "matches", "confirmed-meetups", "chats", "conversation-starters"]),
+    );
+
+    const tab = registeredScreens.find((s) => s.name === "conversation-starters");
+    expect(tab?.options?.href).toBeUndefined();
+  });
+});
+
+describe("Conversation Starters screen", () => {
+  it("renders its own content when opened", () => {
+    const ConversationStartersScreen = require("@/app/(tabs)/conversation-starters").default;
+    render(<ConversationStartersScreen />);
+
+    expect(screen.getByText("Conversation Starters")).toBeTruthy();
+  });
+});

--- a/apps/native/app/(tabs)/_layout.tsx
+++ b/apps/native/app/(tabs)/_layout.tsx
@@ -84,6 +84,15 @@ export default function TabsLayout() {
         }}
       />
       <Tabs.Screen
+        name="conversation-starters"
+        options={{
+          title: "Conversation Starters",
+          tabBarIcon: ({ color, size }) => (
+            <StyledIonicons name="chatbox-ellipses-outline" size={size} color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
         name="suggestions"
         options={{ href: null }}
       />

--- a/apps/native/app/(tabs)/conversation-starters.tsx
+++ b/apps/native/app/(tabs)/conversation-starters.tsx
@@ -1,0 +1,18 @@
+import { Text, View } from "react-native";
+
+import { Container } from "@/components/container";
+
+export default function ConversationStartersScreen() {
+  return (
+    <Container>
+      <View className="flex-1 items-center justify-center p-6">
+        <Text className="text-center text-lg font-semibold text-foreground">
+          Conversation Starters
+        </Text>
+        <Text className="mt-2 text-center text-sm text-muted-foreground">
+          Your practice cards will appear here.
+        </Text>
+      </View>
+    </Container>
+  );
+}


### PR DESCRIPTION
## Summary

Gives buddies a visible, dedicated entry point to their conversation-starter cards so they can reach them in one tap during a meet-up (Task #380, serving Feature #376 / Epic #375). This is the first, thin slice of the Feature: it adds the tab + screen scaffold and unblocks the language picker, card deck, and empty-state work in later tasks/features.

## Changes

- **New tab in the bottom navigation** — registers a `conversation-starters` `<Tabs.Screen>` in `apps/native/app/(tabs)/_layout.tsx` with the label "Conversation Starters" and an Ionicons `chatbox-ellipses-outline` icon (distinct from the Chats tab), placed before the hidden `suggestions` screen so it is visible and reachable from any tab.
- **New screen** — `apps/native/app/(tabs)/conversation-starters.tsx`, a placeholder screen wrapping the shared `Container` with a title + subtitle. Real card content arrives in later tasks/features.
- **Tests** — `apps/native/__tests__/conversation-starters-tab.test.tsx` covering tab registration (label + icon + visible alongside existing tabs) and screen rendering.

## Test plan

- [x] Tab is visible in the bottom navigation — automated test asserts title, icon, and visible registration alongside home/matches/confirmed-meetups/chats
- [x] Opening the tab — automated test renders the screen and asserts its placeholder content
- [ ] Manual: confirm on simulator that switching to the tab from another tab preserves the other tabs' navigation state (expo-router default behaviour)

Full native suite green: 34 suites / 161 tests passing (`bun run test`).

## Related

Closes #380
