### PR TITLE
feat(native): gate conversation starters on profile languages

### DIFF
--- a/apps/native/__tests__/conversation-starters-gate.test.tsx
+++ b/apps/native/__tests__/conversation-starters-gate.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * Tests for task #381 — Gate the Conversation Starters screen on the buddy's
+ * profile languages.
+ *
+ * The screen reads the buddy's spoken + learning languages via the existing
+ * `trpc.profile.getMyProfile` query and branches its render:
+ *   - loading  → a loading state (never the empty state)
+ *   - error    → a sensible fallback, not a false empty state
+ *   - empty    → no spoken/learning languages → "add a language" empty state
+ *                with a CTA that navigates to the profile/onboarding screen
+ *   - ready    → ≥1 language → the cards entry-point container that later
+ *                Features (#377 picker, #378 deck) fill in
+ *
+ * Scenario 1: Buddy with no profile languages sees the empty state.
+ * Scenario 2: Buddy with at least one language reaches the cards entry point.
+ * Scenario 3: Profile is still loading → loading state.
+ * Edge: profile query errors → fallback, not a false empty state.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react-native";
+import React from "react";
+
+const mockPush = jest.fn();
+
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock("@/components/container", () => {
+  const { View } = require("react-native");
+  return {
+    Container: ({ children }: { children: React.ReactNode }) => (
+      <View>{children}</View>
+    ),
+  };
+});
+
+const mockGetMyProfile = jest.fn();
+
+jest.mock("@/utils/trpc", () => ({
+  trpc: {
+    profile: {
+      getMyProfile: {
+        queryOptions: () => ({
+          queryKey: ["profile.getMyProfile"],
+          queryFn: mockGetMyProfile,
+        }),
+      },
+    },
+  },
+}));
+
+// eslint-disable-next-line import/first
+import ConversationStartersScreen from "../app/(tabs)/conversation-starters";
+
+const ENTRY_POINT_TEST_ID = "conversation-starters-entry-point";
+const EMPTY_TEST_ID = "conversation-starters-empty";
+const LOADING_TEST_ID = "conversation-starters-loading";
+
+function renderScreen() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <ConversationStartersScreen />
+    </QueryClientProvider>,
+  );
+}
+
+const profileWith = (
+  languages: { language: string; type: "spoken" | "learning" }[],
+) => ({
+  identity: { name: "Anna", surname: "de Vries", image: null, email: "a@b.nl" },
+  profile: null,
+  languages,
+  interests: [],
+});
+
+describe("#381 — Gate Conversation Starters on profile languages", () => {
+  beforeEach(() => {
+    mockGetMyProfile.mockReset();
+    mockPush.mockReset();
+  });
+
+  describe("Scenario: Buddy with no profile languages sees the empty state", () => {
+    it("shows the empty state with a CTA to the profile/onboarding screen", async () => {
+      mockGetMyProfile.mockResolvedValue(profileWith([]));
+
+      renderScreen();
+
+      await waitFor(() => {
+        expect(screen.getByTestId(EMPTY_TEST_ID)).toBeTruthy();
+      });
+
+      // Empty state explains that languages must be added.
+      expect(screen.getByText(/add a language/i)).toBeTruthy();
+      // Entry point is NOT rendered while there are no languages.
+      expect(screen.queryByTestId(ENTRY_POINT_TEST_ID)).toBeNull();
+
+      // CTA navigates to the profile/onboarding screen.
+      fireEvent.press(screen.getByTestId("conversation-starters-empty-cta"));
+      expect(mockPush).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("Scenario: Buddy with at least one language reaches the cards entry point", () => {
+    it("renders the entry point for a spoken language", async () => {
+      mockGetMyProfile.mockResolvedValue(
+        profileWith([{ language: "es", type: "spoken" }]),
+      );
+
+      renderScreen();
+
+      await waitFor(() => {
+        expect(screen.getByTestId(ENTRY_POINT_TEST_ID)).toBeTruthy();
+      });
+      expect(screen.queryByTestId(EMPTY_TEST_ID)).toBeNull();
+    });
+
+    it("renders the entry point for a learning-only language", async () => {
+      mockGetMyProfile.mockResolvedValue(
+        profileWith([{ language: "fr", type: "learning" }]),
+      );
+
+      renderScreen();
+
+      await waitFor(() => {
+        expect(screen.getByTestId(ENTRY_POINT_TEST_ID)).toBeTruthy();
+      });
+      expect(screen.queryByTestId(EMPTY_TEST_ID)).toBeNull();
+    });
+  });
+
+  describe("Scenario: Profile is still loading", () => {
+    it("shows the loading state, not the empty state", async () => {
+      // A promise that never resolves keeps the query pending.
+      mockGetMyProfile.mockReturnValue(new Promise(() => {}));
+
+      renderScreen();
+
+      expect(screen.getByTestId(LOADING_TEST_ID)).toBeTruthy();
+      expect(screen.queryByTestId(EMPTY_TEST_ID)).toBeNull();
+      expect(screen.queryByTestId(ENTRY_POINT_TEST_ID)).toBeNull();
+    });
+  });
+
+  describe("Edge: profile query errors", () => {
+    it("shows a fallback rather than a false empty state", async () => {
+      mockGetMyProfile.mockRejectedValue(new Error("network"));
+
+      renderScreen();
+
+      await waitFor(() => {
+        expect(screen.getByTestId("conversation-starters-error")).toBeTruthy();
+      });
+      // Must NOT misrepresent an error as "no languages".
+      expect(screen.queryByTestId(EMPTY_TEST_ID)).toBeNull();
+    });
+  });
+});

--- a/apps/native/__tests__/conversation-starters-tab.test.tsx
+++ b/apps/native/__tests__/conversation-starters-tab.test.tsx
@@ -31,7 +31,7 @@ jest.mock("expo-router", () => {
     registeredScreens.push({ name, options });
     return null;
   };
-  return { Tabs };
+  return { Tabs, useRouter: () => ({ push: jest.fn() }) };
 });
 
 jest.mock("@expo/vector-icons", () => {
@@ -45,9 +45,17 @@ jest.mock("uniwind", () => ({
   withUniwind: (Component: unknown) => Component,
 }));
 
-jest.mock("@tanstack/react-query", () => ({
-  useQuery: () => ({ data: [] }),
-}));
+jest.mock("@tanstack/react-query", () => {
+  // The layout's badge queries read `.data.length` / `.data.filter(...)` (an
+  // array), while the Conversation Starters screen reads `.data.languages`.
+  // An array carrying a `languages` property satisfies both: the badges see an
+  // empty array, and the screen sees one language → ready entry point.
+  const data: unknown[] & { languages?: unknown } = [];
+  data.languages = [{ language: "es", type: "spoken" }];
+  return {
+    useQuery: () => ({ data, isPending: false, isError: false }),
+  };
+});
 
 const makeQueryable = () => ({ queryOptions: () => ({}) });
 jest.mock("@/utils/trpc", () => ({
@@ -55,6 +63,7 @@ jest.mock("@/utils/trpc", () => ({
     matching: { getIncomingRequests: makeQueryable() },
     meetup: { list: makeQueryable(), getConfirmed: makeQueryable() },
     chat: { listEntries: makeQueryable() },
+    profile: { getMyProfile: makeQueryable() },
   },
 }));
 

--- a/apps/native/app/(tabs)/conversation-starters.tsx
+++ b/apps/native/app/(tabs)/conversation-starters.tsx
@@ -1,11 +1,107 @@
-import { Text, View } from "react-native";
+import { useQuery } from "@tanstack/react-query";
+import { useRouter } from "expo-router";
+import { Pressable, Text, View } from "react-native";
 
 import { Container } from "@/components/container";
+import { trpc } from "@/utils/trpc";
 
+/**
+ * Conversation Starters entry point, gated on the buddy's profile languages.
+ *
+ * A buddy with no spoken or learning languages has nothing to practice, so the
+ * screen guides them to add languages first. Everyone with at least one
+ * language reaches the ready-state container that later Features (#377 picker,
+ * #378 deck) fill in.
+ */
 export default function ConversationStartersScreen() {
+  const router = useRouter();
+  const profileQuery = useQuery(trpc.profile.getMyProfile.queryOptions());
+
+  if (profileQuery.isPending) {
+    return <LoadingState />;
+  }
+
+  if (profileQuery.isError) {
+    return <ErrorState />;
+  }
+
+  const languages = profileQuery.data?.languages ?? [];
+  const hasLanguages = languages.length > 0;
+
+  if (!hasLanguages) {
+    return <EmptyState onAddLanguages={() => router.push("/(tabs)/home")} />;
+  }
+
+  return <ReadyState />;
+}
+
+function Centered({ children }: { children: React.ReactNode }) {
   return (
     <Container>
-      <View className="flex-1 items-center justify-center p-6">
+      <View className="flex-1 items-center justify-center p-6">{children}</View>
+    </Container>
+  );
+}
+
+function LoadingState() {
+  return (
+    <Centered>
+      <Text
+        testID="conversation-starters-loading"
+        className="text-center text-sm text-muted-foreground"
+      >
+        Loading your languages…
+      </Text>
+    </Centered>
+  );
+}
+
+function ErrorState() {
+  return (
+    <Centered>
+      <Text
+        testID="conversation-starters-error"
+        className="text-center text-lg font-semibold text-foreground"
+      >
+        Something went wrong
+      </Text>
+      <Text className="mt-2 text-center text-sm text-muted-foreground">
+        We couldn't load your languages. Please try again.
+      </Text>
+    </Centered>
+  );
+}
+
+function EmptyState({ onAddLanguages }: { onAddLanguages: () => void }) {
+  return (
+    <Centered>
+      <View testID="conversation-starters-empty" className="items-center">
+        <Text className="text-center text-lg font-semibold text-foreground">
+          No languages yet
+        </Text>
+        <Text className="mt-2 text-center text-sm text-muted-foreground">
+          Add the languages you speak or want to learn to your profile to start
+          practising with conversation starters.
+        </Text>
+        <Pressable
+          testID="conversation-starters-empty-cta"
+          accessibilityRole="button"
+          onPress={onAddLanguages}
+          className="mt-6 rounded-full bg-primary px-6 py-3"
+        >
+          <Text className="text-center text-sm font-semibold text-primary-foreground">
+            Add a language
+          </Text>
+        </Pressable>
+      </View>
+    </Centered>
+  );
+}
+
+function ReadyState() {
+  return (
+    <Centered>
+      <View testID="conversation-starters-entry-point" className="items-center">
         <Text className="text-center text-lg font-semibold text-foreground">
           Conversation Starters
         </Text>
@@ -13,6 +109,6 @@ export default function ConversationStartersScreen() {
           Your practice cards will appear here.
         </Text>
       </View>
-    </Container>
+    </Centered>
   );
 }


### PR DESCRIPTION
## Summary

A buddy with no languages on their profile has nothing to practice. Rather than show a blank or broken
deck, the Conversation Starters screen (Task #381, Feature #376, Epic #375) now reads the buddy's
profile languages and gates the experience: it guides language-less buddies to add languages first, and
lets everyone else through to the cards entry point that later Features (#377 picker, #378 deck) build on.

## Changes

- `apps/native/app/(tabs)/conversation-starters.tsx` (built on the #380 placeholder) now reads the
  buddy's spoken + learning languages via the existing read-only `trpc.profile.getMyProfile` query and
  branches the render:
  - **loading** → loading state (never the empty state),
  - **error** → a sensible fallback (not a false "no languages" message),
  - **empty** (zero spoken/learning languages) → an "add a language" empty state with a CTA that
    navigates to the profile/onboarding flow (`/(tabs)/home`, which hosts the profile modal),
  - **ready** (≥1 language) → the cards entry-point container later Features fill.
- Small presentational sub-components keep each function under 40 lines; stable testIDs added for each
  state.
- Updated the #380 screen-render test to mock the screen's new `useRouter` / `trpc.profile` /
  query-state dependencies (its render assertion is preserved).
- No backend/API/DB changes — reuses the existing profile query; no writes.

## Test plan

`apps/native/__tests__/conversation-starters-gate.test.tsx` — 5 passing tests:

- [x] Buddy with no profile languages sees the empty state (copy + CTA navigates)
- [x] Buddy with at least one language reaches the cards entry point (spoken-only and learning-only)
- [x] Profile is still loading → loading state, not the empty state
- [x] Edge: profile query errors → fallback, not a false empty state
- [x] `bun run check-types` passes; full native suite green when run serially (`--runInBand`)

## Related

Closes #381
