### PR TITLE
feat(native): add card-language picker to conversation starters

### DIFF
--- a/apps/native/__tests__/card-language-picker.test.tsx
+++ b/apps/native/__tests__/card-language-picker.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * Tests for task #403 — the card-language picker inside the Conversation
+ * Starters screen. These cover the picker component in isolation:
+ *   - shows only the buddy's profile languages (not the full catalogue)
+ *   - de-duplicates a language present in both spoken + learning
+ *   - shows flag + native name per option
+ *   - announces the active option as selected (accessibility)
+ *   - reports the chosen language on press
+ *
+ * Screen-level scenarios (auto-select, collapse, persistence, deck reveal)
+ * live in conversation-starters-picker.test.tsx.
+ */
+import { render, screen, fireEvent } from "@testing-library/react-native";
+import React from "react";
+
+import {
+  CardLanguagePicker,
+  dedupeLanguages,
+  type ProfileLanguage,
+} from "../components/conversation-starters/card-language-picker";
+
+jest.mock("@/components/container", () => {
+  const { View } = require("react-native");
+  return {
+    Container: ({ children }: { children: React.ReactNode }) => (
+      <View>{children}</View>
+    ),
+  };
+});
+
+describe("#403 — dedupeLanguages", () => {
+  it("returns the union of spoken + learning with each language once", () => {
+    const languages: ProfileLanguage[] = [
+      { language: "Dutch", type: "spoken" },
+      { language: "Dutch", type: "learning" },
+      { language: "Spanish", type: "learning" },
+    ];
+    expect(dedupeLanguages(languages)).toEqual(["Dutch", "Spanish"]);
+  });
+
+  it("preserves first-occurrence order", () => {
+    const languages: ProfileLanguage[] = [
+      { language: "Spanish", type: "spoken" },
+      { language: "Dutch", type: "learning" },
+    ];
+    expect(dedupeLanguages(languages)).toEqual(["Spanish", "Dutch"]);
+  });
+});
+
+describe("#403 — CardLanguagePicker", () => {
+  describe("Scenario: Picker shows only profile languages", () => {
+    it("offers only the buddy's languages, each with flag and native name", () => {
+      render(
+        <CardLanguagePicker
+          languages={[
+            { language: "Dutch", type: "learning" },
+            { language: "Spanish", type: "spoken" },
+          ]}
+          activeLanguage={null}
+          onSelect={jest.fn()}
+        />,
+      );
+
+      // Only the two profile languages are offered.
+      expect(screen.getByTestId("card-language-option-Dutch")).toBeTruthy();
+      expect(screen.getByTestId("card-language-option-Spanish")).toBeTruthy();
+      // A language NOT on the profile is never shown (full catalogue excluded).
+      expect(
+        screen.queryByTestId("card-language-option-French"),
+      ).toBeNull();
+
+      // Each shows its flag + native name.
+      expect(screen.getByText("🇳🇱")).toBeTruthy();
+      expect(screen.getByText("Nederlands")).toBeTruthy();
+      expect(screen.getByText("🇪🇸")).toBeTruthy();
+      expect(screen.getByText("Español")).toBeTruthy();
+    });
+  });
+
+  describe("Scenario: Duplicate across spoken and learning is shown once", () => {
+    it("renders a language present in both lists exactly once", () => {
+      render(
+        <CardLanguagePicker
+          languages={[
+            { language: "Dutch", type: "spoken" },
+            { language: "Dutch", type: "learning" },
+          ]}
+          activeLanguage={null}
+          onSelect={jest.fn()}
+        />,
+      );
+
+      expect(screen.getAllByTestId("card-language-option-Dutch")).toHaveLength(
+        1,
+      );
+    });
+  });
+
+  describe("Scenario: Selecting a language activates it", () => {
+    it("reports the chosen language on press", () => {
+      const onSelect = jest.fn();
+      render(
+        <CardLanguagePicker
+          languages={[
+            { language: "Dutch", type: "learning" },
+            { language: "Spanish", type: "spoken" },
+          ]}
+          activeLanguage={null}
+          onSelect={onSelect}
+        />,
+      );
+
+      fireEvent.press(screen.getByTestId("card-language-option-Dutch"));
+      expect(onSelect).toHaveBeenCalledWith("Dutch");
+    });
+  });
+
+  describe("Accessibility: active option is announced as selected", () => {
+    it("marks the active option with accessibilityState selected", () => {
+      render(
+        <CardLanguagePicker
+          languages={[
+            { language: "Dutch", type: "learning" },
+            { language: "Spanish", type: "spoken" },
+          ]}
+          activeLanguage="Dutch"
+          onSelect={jest.fn()}
+        />,
+      );
+
+      expect(
+        screen.getByTestId("card-language-option-Dutch").props
+          .accessibilityState.selected,
+      ).toBe(true);
+      expect(
+        screen.getByTestId("card-language-option-Spanish").props
+          .accessibilityState.selected,
+      ).toBe(false);
+    });
+  });
+});

--- a/apps/native/__tests__/conversation-starters-picker.test.tsx
+++ b/apps/native/__tests__/conversation-starters-picker.test.tsx
@@ -1,0 +1,208 @@
+/**
+ * Tests for task #403 — wiring the card-language picker into the Conversation
+ * Starters screen's ready state (past the #381 gate).
+ *
+ * Screen-level Gherkin scenarios:
+ *   - Selecting a language activates it and reveals the deck area.
+ *   - A single profile language is auto-selected and the picker collapses.
+ *   - The selection persists while the buddy stays on the tab.
+ *
+ * The picker's own option rendering / de-dup is covered in
+ * card-language-picker.test.tsx.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react-native";
+import React from "react";
+
+const mockPush = jest.fn();
+
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock("@/components/container", () => {
+  const { View } = require("react-native");
+  return {
+    Container: ({ children }: { children: React.ReactNode }) => (
+      <View>{children}</View>
+    ),
+  };
+});
+
+const mockGetMyProfile = jest.fn();
+
+jest.mock("@/utils/trpc", () => ({
+  trpc: {
+    profile: {
+      getMyProfile: {
+        queryOptions: () => ({
+          queryKey: ["profile.getMyProfile"],
+          queryFn: mockGetMyProfile,
+        }),
+      },
+    },
+  },
+}));
+
+// eslint-disable-next-line import/first
+import ConversationStartersScreen from "../app/(tabs)/conversation-starters";
+
+const ENTRY_POINT_TEST_ID = "conversation-starters-entry-point";
+const PICKER_TEST_ID = "card-language-picker";
+const DECK_AREA_TEST_ID = "conversation-starters-deck-area";
+
+function renderScreen() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <ConversationStartersScreen />
+    </QueryClientProvider>,
+  );
+}
+
+const profileWith = (
+  languages: { language: string; type: "spoken" | "learning" }[],
+) => ({
+  identity: { name: "Anna", surname: "de Vries", image: null, email: "a@b.nl" },
+  profile: null,
+  languages,
+  interests: [],
+});
+
+describe("#403 — Card-language picker on Conversation Starters", () => {
+  beforeEach(() => {
+    mockGetMyProfile.mockReset();
+    mockPush.mockReset();
+  });
+
+  describe("Scenario: Picker shows only profile languages", () => {
+    it("renders the picker with the buddy's two languages", async () => {
+      mockGetMyProfile.mockResolvedValue(
+        profileWith([
+          { language: "Dutch", type: "spoken" },
+          { language: "Spanish", type: "learning" },
+        ]),
+      );
+
+      renderScreen();
+
+      await waitFor(() => {
+        expect(screen.getByTestId(PICKER_TEST_ID)).toBeTruthy();
+      });
+      expect(screen.getByTestId("card-language-option-Dutch")).toBeTruthy();
+      expect(screen.getByTestId("card-language-option-Spanish")).toBeTruthy();
+    });
+  });
+
+  describe("Scenario: Selecting a language activates it and reveals the deck area", () => {
+    it("activates Dutch and reveals the deck area on press", async () => {
+      mockGetMyProfile.mockResolvedValue(
+        profileWith([
+          { language: "Dutch", type: "spoken" },
+          { language: "Spanish", type: "learning" },
+        ]),
+      );
+
+      renderScreen();
+
+      await waitFor(() => {
+        expect(screen.getByTestId(PICKER_TEST_ID)).toBeTruthy();
+      });
+      // Nothing selected yet → deck area hidden.
+      expect(screen.queryByTestId(DECK_AREA_TEST_ID)).toBeNull();
+
+      fireEvent.press(screen.getByTestId("card-language-option-Dutch"));
+
+      // Deck area for Dutch is now revealed and exposes the active language.
+      const deck = screen.getByTestId(DECK_AREA_TEST_ID);
+      expect(deck).toBeTruthy();
+      expect(deck.props.accessibilityLabel).toBe("Cards for Dutch");
+      // The active option is announced as selected.
+      expect(
+        screen.getByTestId("card-language-option-Dutch").props
+          .accessibilityState.selected,
+      ).toBe(true);
+    });
+  });
+
+  describe("Scenario: Single profile language is auto-selected", () => {
+    it("auto-selects the only language and collapses the picker", async () => {
+      mockGetMyProfile.mockResolvedValue(
+        profileWith([{ language: "Dutch", type: "learning" }]),
+      );
+
+      renderScreen();
+
+      await waitFor(() => {
+        expect(screen.getByTestId(ENTRY_POINT_TEST_ID)).toBeTruthy();
+      });
+      // Picker collapsed — no manual pick needed.
+      expect(screen.queryByTestId(PICKER_TEST_ID)).toBeNull();
+      // Dutch is already active → deck area shown.
+      const deck = screen.getByTestId(DECK_AREA_TEST_ID);
+      expect(deck.props.accessibilityLabel).toBe("Cards for Dutch");
+    });
+  });
+
+  describe("Scenario: Duplicate across spoken and learning is shown once", () => {
+    it("auto-selects when the only language appears in both lists", async () => {
+      mockGetMyProfile.mockResolvedValue(
+        profileWith([
+          { language: "Dutch", type: "spoken" },
+          { language: "Dutch", type: "learning" },
+        ]),
+      );
+
+      renderScreen();
+
+      await waitFor(() => {
+        expect(screen.getByTestId(ENTRY_POINT_TEST_ID)).toBeTruthy();
+      });
+      // De-duped to one → behaves as a single language: collapsed + auto-select.
+      expect(screen.queryByTestId(PICKER_TEST_ID)).toBeNull();
+      expect(screen.getByTestId(DECK_AREA_TEST_ID).props.accessibilityLabel).toBe(
+        "Cards for Dutch",
+      );
+    });
+  });
+
+  describe("Scenario: Selection persists while on the tab", () => {
+    it("keeps the chosen language active across re-renders", async () => {
+      mockGetMyProfile.mockResolvedValue(
+        profileWith([
+          { language: "Dutch", type: "spoken" },
+          { language: "Spanish", type: "learning" },
+        ]),
+      );
+
+      const client = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
+      const tree = (
+        <QueryClientProvider client={client}>
+          <ConversationStartersScreen />
+        </QueryClientProvider>
+      );
+      const { rerender } = render(tree);
+
+      await waitFor(() => {
+        expect(screen.getByTestId(PICKER_TEST_ID)).toBeTruthy();
+      });
+
+      fireEvent.press(screen.getByTestId("card-language-option-Spanish"));
+      expect(screen.getByTestId(DECK_AREA_TEST_ID).props.accessibilityLabel).toBe(
+        "Cards for Spanish",
+      );
+
+      // A re-render of the same mounted tree (still on the tab) must keep the
+      // chosen language — screen-local useState is the persistence mechanism.
+      rerender(tree);
+
+      expect(screen.getByTestId(DECK_AREA_TEST_ID).props.accessibilityLabel).toBe(
+        "Cards for Spanish",
+      );
+    });
+  });
+});

--- a/apps/native/__tests__/conversation-starters-tab.test.tsx
+++ b/apps/native/__tests__/conversation-starters-tab.test.tsx
@@ -110,6 +110,10 @@ describe("Conversation Starters screen", () => {
     const ConversationStartersScreen = require("@/app/(tabs)/conversation-starters").default;
     render(<ConversationStartersScreen />);
 
-    expect(screen.getByText("Conversation Starters")).toBeTruthy();
+    // The screen renders its ready-state content (the cards entry point that
+    // task #403 fills with the language picker / deck area).
+    expect(
+      screen.getByTestId("conversation-starters-entry-point"),
+    ).toBeTruthy();
   });
 });

--- a/apps/native/app/(tabs)/conversation-starters.tsx
+++ b/apps/native/app/(tabs)/conversation-starters.tsx
@@ -1,7 +1,13 @@
 import { useQuery } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
+import { useState } from "react";
 import { Pressable, Text, View } from "react-native";
 
+import {
+  CardLanguagePicker,
+  dedupeLanguages,
+  type ProfileLanguage,
+} from "@/components/conversation-starters/card-language-picker";
 import { Container } from "@/components/container";
 import { trpc } from "@/utils/trpc";
 
@@ -32,7 +38,7 @@ export default function ConversationStartersScreen() {
     return <EmptyState onAddLanguages={() => router.push("/(tabs)/home")} />;
   }
 
-  return <ReadyState />;
+  return <ReadyState languages={languages} />;
 }
 
 function Centered({ children }: { children: React.ReactNode }) {
@@ -98,16 +104,46 @@ function EmptyState({ onAddLanguages }: { onAddLanguages: () => void }) {
   );
 }
 
-function ReadyState() {
+function ReadyState({ languages }: { languages: ProfileLanguage[] }) {
+  const options = dedupeLanguages(languages);
+  // A buddy with exactly one profile language never needs to pick — the
+  // language is auto-selected and the picker collapses (issue #403).
+  const autoSelected = options.length === 1 ? options[0] : null;
+  const [activeLanguage, setActiveLanguage] = useState<string | null>(
+    autoSelected,
+  );
+
+  // Hide the picker when there is nothing to choose between.
+  const showPicker = options.length > 1;
+
   return (
     <Centered>
-      <View testID="conversation-starters-entry-point" className="items-center">
-        <Text className="text-center text-lg font-semibold text-foreground">
-          Conversation Starters
-        </Text>
-        <Text className="mt-2 text-center text-sm text-muted-foreground">
-          Your practice cards will appear here.
-        </Text>
+      <View testID="conversation-starters-entry-point" className="w-full">
+        {showPicker ? (
+          <CardLanguagePicker
+            languages={languages}
+            activeLanguage={activeLanguage}
+            onSelect={setActiveLanguage}
+          />
+        ) : null}
+
+        {activeLanguage ? (
+          // Deck-area entry point. Feature #378 (#405) renders the actual deck
+          // here; this task only exposes the active language to it.
+          <View
+            testID="conversation-starters-deck-area"
+            accessibilityLabel={`Cards for ${activeLanguage}`}
+            className="mt-6 items-center"
+          >
+            <Text className="text-center text-sm text-muted-foreground">
+              Your {activeLanguage} practice cards will appear here.
+            </Text>
+          </View>
+        ) : (
+          <Text className="mt-6 text-center text-sm text-muted-foreground">
+            Pick a language to start practising.
+          </Text>
+        )}
       </View>
     </Centered>
   );

--- a/apps/native/components/conversation-starters/card-language-picker.tsx
+++ b/apps/native/components/conversation-starters/card-language-picker.tsx
@@ -1,0 +1,85 @@
+import { Pressable, Text, View } from "react-native";
+
+import { getLanguageFlag, getNativeName } from "@/utils/language-flags";
+
+export type ProfileLanguage = {
+  language: string;
+  type: "spoken" | "learning";
+};
+
+/**
+ * De-duplicate the buddy's profile languages into the picker's option list.
+ *
+ * A language a buddy both speaks and is learning must appear exactly once. The
+ * first occurrence wins so the original profile order is preserved.
+ */
+export function dedupeLanguages(languages: ProfileLanguage[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const { language } of languages) {
+    if (seen.has(language)) {
+      continue;
+    }
+    seen.add(language);
+    result.push(language);
+  }
+  return result;
+}
+
+type CardLanguagePickerProps = {
+  /** The buddy's profile languages (spoken + learning, possibly overlapping). */
+  languages: ProfileLanguage[];
+  /** The currently active card language, or null when nothing is selected yet. */
+  activeLanguage: string | null;
+  /** Called with the chosen language when the buddy taps an option. */
+  onSelect: (language: string) => void;
+};
+
+/**
+ * Lets a buddy pick which of *their own* profile languages to browse cards in.
+ *
+ * Shows only the de-duplicated union of the buddy's spoken + learning
+ * languages — never the full catalogue — each with its flag and native name.
+ * The active option is announced as selected for accessibility.
+ */
+export function CardLanguagePicker({
+  languages,
+  activeLanguage,
+  onSelect,
+}: CardLanguagePickerProps) {
+  const options = dedupeLanguages(languages);
+
+  return (
+    <View testID="card-language-picker" accessibilityRole="radiogroup">
+      <Text className="mb-3 text-center text-sm font-semibold text-foreground">
+        Pick a language to practise
+      </Text>
+      <View className="gap-2">
+        {options.map((language) => {
+          const isActive = language === activeLanguage;
+          return (
+            <Pressable
+              key={language}
+              testID={`card-language-option-${language}`}
+              accessibilityRole="button"
+              accessibilityState={{ selected: isActive }}
+              onPress={() => onSelect(language)}
+              className={`flex-row items-center gap-3 rounded-2xl px-4 py-3 ${
+                isActive ? "bg-primary" : "bg-muted"
+              }`}
+            >
+              <Text style={{ fontSize: 24 }}>{getLanguageFlag(language)}</Text>
+              <Text
+                className={`text-base font-semibold ${
+                  isActive ? "text-primary-foreground" : "text-foreground"
+                }`}
+              >
+                {getNativeName(language)}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </View>
+    </View>
+  );
+}


### PR DESCRIPTION
## Summary

Adds the card-language picker to the Conversation Starters screen (Task #403, Feature #377, Epic #375). Once past the #381 "has at least one profile language" gate, a buddy can pick which of *their own* practice languages to browse cards in — without scrolling the full 40+ language catalogue — and jump straight to the language they came to practice.

## Changes

- New `CardLanguagePicker` component (`apps/native/components/conversation-starters/card-language-picker.tsx`) that renders the de-duplicated union of the buddy's `spoken` + `learning` profile languages, each with its flag + native name via the existing `language-flags` utils (`getLanguageFlag`, `getNativeName`). The active option is announced as selected (`accessibilityState`). Exposes a pure `dedupeLanguages` helper.
- Wired the picker into the screen's ready state (`apps/native/app/(tabs)/conversation-starters.tsx`): the active card language is held in screen-local `useState` (persists while on the tab, resets on leave — no global store, no persistence). A single profile language is auto-selected and the picker collapses; otherwise the picker is shown. The active language is exposed to a deck-area entry point (`conversation-starters-deck-area`) that Feature #378 (#405) will fill — the deck/cards are intentionally not rendered here.
- Updated the superseded #380 ready-state assertion to check the entry-point container rather than the removed placeholder text.

## Test plan

- [x] Picker shows only profile languages (flag + native name; full catalogue excluded)
- [x] Selecting a language activates it and reveals the deck area
- [x] Single profile language is auto-selected and the picker collapses
- [x] Duplicate across spoken and learning is shown once
- [x] Selection persists while on the tab
- [x] `bun run check-types` clean; full native suite green serially (37 suites / 177 tests)

## Related

Closes #403

🤖 Generated with [Claude Code](https://claude.com/claude-code)
