### PR TITLE
feat(native): add conversation-starter card deck browser

### DIFF
--- a/apps/native/__tests__/conversation-starters-deck.test.tsx
+++ b/apps/native/__tests__/conversation-starters-deck.test.tsx
@@ -1,0 +1,269 @@
+/**
+ * Tests for task #405 — the conversation-starter card deck browser.
+ *
+ * Gherkin scenarios (Feature #378):
+ *   - First card shown on open (with "1 / N" position indicator).
+ *   - Stepping forward and back one card at a time.
+ *   - No wrap-around at the ends (Previous disabled on first, Next on last).
+ *   - Changing language resets the deck to the first card.
+ *   - No curated cards for a language → a clear "no cards yet" state.
+ *
+ * The deck fetches its cards via `content.starters.listByLanguage` (#404) and
+ * holds the current position in screen-local `useState`, mirroring the
+ * index-based stepper in `apps/native/app/match.tsx`.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react-native";
+import React from "react";
+
+type Card = { id: string; text: string; translation: string };
+
+const mockListByLanguage = jest.fn();
+
+jest.mock("@/utils/trpc", () => ({
+  trpc: {
+    content: {
+      starters: {
+        listByLanguage: {
+          queryOptions: (input: { language: string }) => ({
+            queryKey: ["content.starters.listByLanguage", input],
+            queryFn: () => mockListByLanguage(input),
+          }),
+        },
+      },
+    },
+  },
+}));
+
+// eslint-disable-next-line import/first
+import { CardDeck } from "@/components/conversation-starters/card-deck";
+
+const POSITION_TEST_ID = "card-deck-position";
+const CARD_TEXT_TEST_ID = "card-deck-text";
+const NEXT_TEST_ID = "card-deck-next";
+const PREV_TEST_ID = "card-deck-previous";
+const EMPTY_TEST_ID = "card-deck-empty";
+
+function makeCards(language: string, count: number): Card[] {
+  return Array.from({ length: count }, (_, i) => {
+    const n = String(i + 1).padStart(3, "0");
+    return {
+      id: `${language}-${n}`,
+      text: `${language} question ${i + 1}`,
+      translation: `English ${i + 1}`,
+    };
+  });
+}
+
+function renderDeck(language: string) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <CardDeck language={language} />
+    </QueryClientProvider>,
+  );
+}
+
+describe("#405 — Conversation-starter card deck browser", () => {
+  beforeEach(() => {
+    mockListByLanguage.mockReset();
+  });
+
+  describe("Scenario: First card shown on open", () => {
+    it("shows the first Dutch card and a '1 / 30' indicator", async () => {
+      const cards = makeCards("Dutch", 30);
+      mockListByLanguage.mockResolvedValue({ language: "Dutch", cards });
+
+      renderDeck("Dutch");
+
+      await waitFor(() => {
+        expect(screen.getByTestId(CARD_TEXT_TEST_ID)).toBeTruthy();
+      });
+      expect(screen.getByTestId(CARD_TEXT_TEST_ID).props.children).toBe(
+        cards[0].text,
+      );
+      expect(screen.getByTestId(POSITION_TEST_ID).props.children).toBe("1 / 30");
+    });
+
+    it("renders the card text in the chosen language, not the translation", async () => {
+      const cards = makeCards("Dutch", 30);
+      mockListByLanguage.mockResolvedValue({ language: "Dutch", cards });
+
+      renderDeck("Dutch");
+
+      await waitFor(() => {
+        expect(screen.getByTestId(CARD_TEXT_TEST_ID).props.children).toBe(
+          "Dutch question 1",
+        );
+      });
+      expect(screen.queryByText("English 1")).toBeNull();
+    });
+  });
+
+  describe("Scenario: Stepping forward and back", () => {
+    it("advances on Next and returns on Previous", async () => {
+      const cards = makeCards("Dutch", 30);
+      mockListByLanguage.mockResolvedValue({ language: "Dutch", cards });
+
+      renderDeck("Dutch");
+
+      await waitFor(() => {
+        expect(screen.getByTestId(CARD_TEXT_TEST_ID)).toBeTruthy();
+      });
+
+      fireEvent.press(screen.getByTestId(NEXT_TEST_ID));
+      expect(screen.getByTestId(CARD_TEXT_TEST_ID).props.children).toBe(
+        cards[1].text,
+      );
+      expect(screen.getByTestId(POSITION_TEST_ID).props.children).toBe("2 / 30");
+
+      fireEvent.press(screen.getByTestId(PREV_TEST_ID));
+      expect(screen.getByTestId(CARD_TEXT_TEST_ID).props.children).toBe(
+        cards[0].text,
+      );
+      expect(screen.getByTestId(POSITION_TEST_ID).props.children).toBe("1 / 30");
+    });
+  });
+
+  describe("Scenario: No wrap-around at the ends", () => {
+    it("disables Previous on the first card and Next on the last", async () => {
+      const cards = makeCards("Dutch", 3);
+      mockListByLanguage.mockResolvedValue({ language: "Dutch", cards });
+
+      renderDeck("Dutch");
+
+      await waitFor(() => {
+        expect(screen.getByTestId(CARD_TEXT_TEST_ID)).toBeTruthy();
+      });
+
+      // First card → Previous disabled, Next enabled.
+      expect(
+        screen.getByTestId(PREV_TEST_ID).props.accessibilityState.disabled,
+      ).toBe(true);
+      expect(
+        screen.getByTestId(NEXT_TEST_ID).props.accessibilityState.disabled,
+      ).toBe(false);
+
+      // Pressing a disabled Previous must not wrap to the last card.
+      fireEvent.press(screen.getByTestId(PREV_TEST_ID));
+      expect(screen.getByTestId(POSITION_TEST_ID).props.children).toBe("1 / 3");
+
+      // Walk to the last card.
+      fireEvent.press(screen.getByTestId(NEXT_TEST_ID));
+      fireEvent.press(screen.getByTestId(NEXT_TEST_ID));
+      expect(screen.getByTestId(POSITION_TEST_ID).props.children).toBe("3 / 3");
+
+      // Last card → Next disabled, Previous enabled.
+      expect(
+        screen.getByTestId(NEXT_TEST_ID).props.accessibilityState.disabled,
+      ).toBe(true);
+      expect(
+        screen.getByTestId(PREV_TEST_ID).props.accessibilityState.disabled,
+      ).toBe(false);
+
+      // Pressing a disabled Next must not wrap to the first card.
+      fireEvent.press(screen.getByTestId(NEXT_TEST_ID));
+      expect(screen.getByTestId(POSITION_TEST_ID).props.children).toBe("3 / 3");
+    });
+  });
+
+  describe("Scenario: Changing language resets the deck", () => {
+    it("resets to the first card when the language prop changes", async () => {
+      const dutch = makeCards("Dutch", 30);
+      const spanish = makeCards("Spanish", 30);
+      mockListByLanguage.mockImplementation(
+        ({ language }: { language: string }) =>
+          Promise.resolve({
+            language,
+            cards: language === "Dutch" ? dutch : spanish,
+          }),
+      );
+
+      const client = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
+      const { rerender } = render(
+        <QueryClientProvider client={client}>
+          <CardDeck language="Dutch" />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId(CARD_TEXT_TEST_ID)).toBeTruthy();
+      });
+
+      // Advance to card 5 of Dutch.
+      for (let i = 0; i < 4; i++) {
+        fireEvent.press(screen.getByTestId(NEXT_TEST_ID));
+      }
+      expect(screen.getByTestId(POSITION_TEST_ID).props.children).toBe("5 / 30");
+
+      // Switch language → deck resets to the first card.
+      rerender(
+        <QueryClientProvider client={client}>
+          <CardDeck language="Spanish" />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId(CARD_TEXT_TEST_ID).props.children).toBe(
+          spanish[0].text,
+        );
+      });
+      expect(screen.getByTestId(POSITION_TEST_ID).props.children).toBe("1 / 30");
+    });
+  });
+
+  describe("Scenario: No curated cards for a language", () => {
+    it("shows a 'no cards yet' state instead of a blank deck", async () => {
+      mockListByLanguage.mockResolvedValue({ language: "Klingon", cards: [] });
+
+      renderDeck("Klingon");
+
+      await waitFor(() => {
+        expect(screen.getByTestId(EMPTY_TEST_ID)).toBeTruthy();
+      });
+      // No card, no position indicator, no stepper buttons.
+      expect(screen.queryByTestId(CARD_TEXT_TEST_ID)).toBeNull();
+      expect(screen.queryByTestId(POSITION_TEST_ID)).toBeNull();
+      expect(screen.queryByTestId(NEXT_TEST_ID)).toBeNull();
+      expect(screen.queryByTestId(PREV_TEST_ID)).toBeNull();
+    });
+  });
+
+  describe("Loading and error states", () => {
+    it("shows a loading state while fetching", async () => {
+      let resolve: (v: { language: string; cards: Card[] }) => void = () => {};
+      mockListByLanguage.mockReturnValue(
+        new Promise((r) => {
+          resolve = r;
+        }),
+      );
+
+      renderDeck("Dutch");
+
+      expect(screen.getByTestId("card-deck-loading")).toBeTruthy();
+      resolve({ language: "Dutch", cards: makeCards("Dutch", 30) });
+      await waitFor(() => {
+        expect(screen.getByTestId(CARD_TEXT_TEST_ID)).toBeTruthy();
+      });
+    });
+
+    it("shows an error state when the query fails", async () => {
+      mockListByLanguage.mockRejectedValue(new Error("boom"));
+
+      renderDeck("Dutch");
+
+      await waitFor(() => {
+        expect(screen.getByTestId("card-deck-error")).toBeTruthy();
+      });
+    });
+  });
+});

--- a/apps/native/__tests__/conversation-starters-gate.test.tsx
+++ b/apps/native/__tests__/conversation-starters-gate.test.tsx
@@ -47,6 +47,19 @@ jest.mock("@/utils/trpc", () => ({
         }),
       },
     },
+    // The ready-state deck (#405) lives behind the gate; stub it with an empty
+    // set so this gate-focused suite never touches real content.
+    content: {
+      starters: {
+        listByLanguage: {
+          queryOptions: (input: { language: string }) => ({
+            queryKey: ["content.starters.listByLanguage", input],
+            queryFn: () =>
+              Promise.resolve({ language: input.language, cards: [] }),
+          }),
+        },
+      },
+    },
   },
 }));
 

--- a/apps/native/__tests__/conversation-starters-picker.test.tsx
+++ b/apps/native/__tests__/conversation-starters-picker.test.tsx
@@ -41,6 +41,19 @@ jest.mock("@/utils/trpc", () => ({
         }),
       },
     },
+    // Deck content (#405) is exercised in conversation-starters-deck.test.tsx;
+    // here it is stubbed empty so the picker assertions stay focused.
+    content: {
+      starters: {
+        listByLanguage: {
+          queryOptions: (input: { language: string }) => ({
+            queryKey: ["content.starters.listByLanguage", input],
+            queryFn: () =>
+              Promise.resolve({ language: input.language, cards: [] }),
+          }),
+        },
+      },
+    },
   },
 }));
 

--- a/apps/native/__tests__/conversation-starters-tab.test.tsx
+++ b/apps/native/__tests__/conversation-starters-tab.test.tsx
@@ -64,6 +64,8 @@ jest.mock("@/utils/trpc", () => ({
     meetup: { list: makeQueryable(), getConfirmed: makeQueryable() },
     chat: { listEntries: makeQueryable() },
     profile: { getMyProfile: makeQueryable() },
+    // The ready-state deck (#405) issues this query once a language is active.
+    content: { starters: { listByLanguage: makeQueryable() } },
   },
 }));
 

--- a/apps/native/app/(tabs)/conversation-starters.tsx
+++ b/apps/native/app/(tabs)/conversation-starters.tsx
@@ -3,6 +3,7 @@ import { useRouter } from "expo-router";
 import { useState } from "react";
 import { Pressable, Text, View } from "react-native";
 
+import { CardDeck } from "@/components/conversation-starters/card-deck";
 import {
   CardLanguagePicker,
   dedupeLanguages,
@@ -133,11 +134,13 @@ function ReadyState({ languages }: { languages: ProfileLanguage[] }) {
           <View
             testID="conversation-starters-deck-area"
             accessibilityLabel={`Cards for ${activeLanguage}`}
-            className="mt-6 items-center"
+            className="mt-6 w-full items-center"
           >
-            <Text className="text-center text-sm text-muted-foreground">
-              Your {activeLanguage} practice cards will appear here.
-            </Text>
+            {/*
+              Keying by language remounts the deck on language change, so its
+              internal position index resets to the first card (issue #405).
+            */}
+            <CardDeck key={activeLanguage} language={activeLanguage} />
           </View>
         ) : (
           <Text className="mt-6 text-center text-sm text-muted-foreground">

--- a/apps/native/components/conversation-starters/card-deck.tsx
+++ b/apps/native/components/conversation-starters/card-deck.tsx
@@ -1,0 +1,177 @@
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { Pressable, Text, View } from "react-native";
+
+import { trpc } from "@/utils/trpc";
+
+type CardDeckProps = {
+  /** The active card language to browse cards in (from the #403 picker). */
+  language: string;
+};
+
+/**
+ * Lets a buddy flip through the curated conversation-starter cards for the
+ * active language, one card at a time.
+ *
+ * Cards come from `content.starters.listByLanguage` (#404). The current
+ * position is held in screen-local `useState`, clamped to
+ * `[0, cards.length - 1]`, with no wrap-around — mirroring the index-based
+ * stepper in `apps/native/app/match.tsx`. Switching language remounts a fresh
+ * deck (the parent keys this component by language), so the index always
+ * starts back at the first card.
+ */
+export function CardDeck({ language }: CardDeckProps) {
+  const cardsQuery = useQuery(
+    trpc.content.starters.listByLanguage.queryOptions({ language }),
+  );
+
+  if (cardsQuery.isPending) {
+    return <DeckLoading />;
+  }
+
+  if (cardsQuery.isError) {
+    return <DeckError />;
+  }
+
+  const cards = cardsQuery.data?.cards ?? [];
+
+  if (cards.length === 0) {
+    return <DeckEmpty language={language} />;
+  }
+
+  return <DeckBrowser cards={cards} language={language} />;
+}
+
+type Card = { id: string; text: string; translation: string };
+
+function DeckBrowser({
+  cards,
+  language,
+}: {
+  cards: Card[];
+  language: string;
+}) {
+  const [index, setIndex] = useState(0);
+  const lastIndex = cards.length - 1;
+
+  // Defensive reset: if the same mounted deck ever receives a shorter card set
+  // for a new language, keep the index inside bounds and back at the start.
+  useEffect(() => {
+    setIndex(0);
+  }, [language]);
+
+  const safeIndex = Math.min(index, lastIndex);
+  const current = cards[safeIndex];
+  const isFirst = safeIndex === 0;
+  const isLast = safeIndex === lastIndex;
+
+  return (
+    <View testID="card-deck" className="w-full items-center">
+      <View
+        testID="card-deck-card"
+        className="w-full items-center justify-center rounded-3xl bg-muted px-6 py-12"
+      >
+        <Text
+          testID="card-deck-text"
+          className="text-center text-2xl font-semibold text-foreground"
+        >
+          {current.text}
+        </Text>
+      </View>
+
+      <Text
+        testID="card-deck-position"
+        className="mt-4 text-center text-sm text-muted-foreground"
+      >
+        {`${safeIndex + 1} / ${cards.length}`}
+      </Text>
+
+      <View className="mt-6 w-full flex-row justify-between gap-3">
+        <StepperButton
+          testID="card-deck-previous"
+          label="Previous"
+          disabled={isFirst}
+          onPress={() => setIndex((i) => Math.max(0, i - 1))}
+        />
+        <StepperButton
+          testID="card-deck-next"
+          label="Next"
+          disabled={isLast}
+          onPress={() => setIndex((i) => Math.min(lastIndex, i + 1))}
+        />
+      </View>
+    </View>
+  );
+}
+
+function StepperButton({
+  testID,
+  label,
+  disabled,
+  onPress,
+}: {
+  testID: string;
+  label: string;
+  disabled: boolean;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      testID={testID}
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      accessibilityState={{ disabled }}
+      disabled={disabled}
+      onPress={onPress}
+      className={`flex-1 rounded-full px-6 py-3 ${
+        disabled ? "bg-muted" : "bg-primary"
+      }`}
+    >
+      <Text
+        className={`text-center text-sm font-semibold ${
+          disabled ? "text-muted-foreground" : "text-primary-foreground"
+        }`}
+      >
+        {label}
+      </Text>
+    </Pressable>
+  );
+}
+
+function DeckLoading() {
+  return (
+    <Text
+      testID="card-deck-loading"
+      className="text-center text-sm text-muted-foreground"
+    >
+      Loading cards…
+    </Text>
+  );
+}
+
+function DeckError() {
+  return (
+    <View testID="card-deck-error" className="items-center">
+      <Text className="text-center text-lg font-semibold text-foreground">
+        Couldn't load cards
+      </Text>
+      <Text className="mt-2 text-center text-sm text-muted-foreground">
+        Something went wrong loading your conversation starters. Please try
+        again.
+      </Text>
+    </View>
+  );
+}
+
+function DeckEmpty({ language }: { language: string }) {
+  return (
+    <View testID="card-deck-empty" className="items-center">
+      <Text className="text-center text-lg font-semibold text-foreground">
+        No cards yet
+      </Text>
+      <Text className="mt-2 text-center text-sm text-muted-foreground">
+        We don't have conversation starters for {language} yet. Check back soon.
+      </Text>
+    </View>
+  );
+}


### PR DESCRIPTION
## Summary

Implements Task #405 (Feature #378, Epic #375): lets a buddy flip through conversation-starter cards in their active card language, one at a time, so they always have something to ask their partner during a meet-up. Builds on #403 (the picker exposing an active language) and #404 (the `content.starters.listByLanguage` query).

## Changes

- New `CardDeck` component (`apps/native/components/conversation-starters/card-deck.tsx`):
  - Fetches the active language's cards via `content.starters.listByLanguage` using `@tanstack/react-query` + the tRPC client.
  - Renders one card at a time (the `text` in the chosen language — translation is intentionally left for #406).
  - Index-based stepper held in screen-local `useState`, clamped to `[0, cards.length - 1]`, **no wrap-around** — mirroring the pattern in `apps/native/app/match.tsx`.
  - Real labelled **Previous / Next** buttons (not swipe; the swipe deck was removed in 34835ba). Previous is disabled on the first card, Next on the last.
  - Position indicator (e.g. `3 / 30`).
  - `"No cards yet"` empty state when a language returns no curated cards, plus loading and error states.
- Wired the deck into the Conversation Starters screen (`apps/native/app/(tabs)/conversation-starters.tsx`), replacing the #403 placeholder. The deck is **keyed by the active language**, so switching languages remounts it and resets to the first card.
- Extended existing screen test mocks (`conversation-starters-{gate,picker,tab}.test.tsx`) to stub the new `content.starters.listByLanguage` query.

## Test plan

- [x] First card shown on open — first card + `1 / 30` indicator
- [x] Stepping forward and back — Next advances, Previous returns
- [x] No wrap-around at the ends — Previous disabled on first, Next disabled on last; disabled press is a no-op
- [x] Changing language resets the deck — switching language returns to the first card / `1 / 30`
- [x] No curated cards for a language — `"no cards yet"` state instead of a blank deck
- [x] Supporting: loading + error states
- [x] Full native suite green (`bun run test --runInBand`: 38 suites / 185 tests) and `bun run check-types` clean

## Related

Closes #405
