### PR TITLE
feat: conversation starter cards for meet-ups (Epic #375)

### DIFF
--- a/apps/native/__tests__/card-language-picker.test.tsx
+++ b/apps/native/__tests__/card-language-picker.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * Tests for task #403 — the card-language picker inside the Conversation
+ * Starters screen. These cover the picker component in isolation:
+ *   - shows only the buddy's profile languages (not the full catalogue)
+ *   - de-duplicates a language present in both spoken + learning
+ *   - shows flag + native name per option
+ *   - announces the active option as selected (accessibility)
+ *   - reports the chosen language on press
+ *
+ * Screen-level scenarios (auto-select, collapse, persistence, deck reveal)
+ * live in conversation-starters-picker.test.tsx.
+ */
+import { render, screen, fireEvent } from "@testing-library/react-native";
+import React from "react";
+
+import {
+  CardLanguagePicker,
+  dedupeLanguages,
+  type ProfileLanguage,
+} from "../components/conversation-starters/card-language-picker";
+
+jest.mock("@/components/container", () => {
+  const { View } = require("react-native");
+  return {
+    Container: ({ children }: { children: React.ReactNode }) => (
+      <View>{children}</View>
+    ),
+  };
+});
+
+describe("#403 — dedupeLanguages", () => {
+  it("returns the union of spoken + learning with each language once", () => {
+    const languages: ProfileLanguage[] = [
+      { language: "Dutch", type: "spoken" },
+      { language: "Dutch", type: "learning" },
+      { language: "Spanish", type: "learning" },
+    ];
+    expect(dedupeLanguages(languages)).toEqual(["Dutch", "Spanish"]);
+  });
+
+  it("preserves first-occurrence order", () => {
+    const languages: ProfileLanguage[] = [
+      { language: "Spanish", type: "spoken" },
+      { language: "Dutch", type: "learning" },
+    ];
+    expect(dedupeLanguages(languages)).toEqual(["Spanish", "Dutch"]);
+  });
+});
+
+describe("#403 — CardLanguagePicker", () => {
+  describe("Scenario: Picker shows only profile languages", () => {
+    it("offers only the buddy's languages, each with flag and native name", () => {
+      render(
+        <CardLanguagePicker
+          languages={[
+            { language: "Dutch", type: "learning" },
+            { language: "Spanish", type: "spoken" },
+          ]}
+          activeLanguage={null}
+          onSelect={jest.fn()}
+        />,
+      );
+
+      // Only the two profile languages are offered.
+      expect(screen.getByTestId("card-language-option-Dutch")).toBeTruthy();
+      expect(screen.getByTestId("card-language-option-Spanish")).toBeTruthy();
+      // A language NOT on the profile is never shown (full catalogue excluded).
+      expect(
+        screen.queryByTestId("card-language-option-French"),
+      ).toBeNull();
+
+      // Each shows its flag + native name.
+      expect(screen.getByText("🇳🇱")).toBeTruthy();
+      expect(screen.getByText("Nederlands")).toBeTruthy();
+      expect(screen.getByText("🇪🇸")).toBeTruthy();
+      expect(screen.getByText("Español")).toBeTruthy();
+    });
+  });
+
+  describe("Scenario: Duplicate across spoken and learning is shown once", () => {
+    it("renders a language present in both lists exactly once", () => {
+      render(
+        <CardLanguagePicker
+          languages={[
+            { language: "Dutch", type: "spoken" },
+            { language: "Dutch", type: "learning" },
+          ]}
+          activeLanguage={null}
+          onSelect={jest.fn()}
+        />,
+      );
+
+      expect(screen.getAllByTestId("card-language-option-Dutch")).toHaveLength(
+        1,
+      );
+    });
+  });
+
+  describe("Scenario: Selecting a language activates it", () => {
+    it("reports the chosen language on press", () => {
+      const onSelect = jest.fn();
+      render(
+        <CardLanguagePicker
+          languages={[
+            { language: "Dutch", type: "learning" },
+            { language: "Spanish", type: "spoken" },
+          ]}
+          activeLanguage={null}
+          onSelect={onSelect}
+        />,
+      );
+
+      fireEvent.press(screen.getByTestId("card-language-option-Dutch"));
+      expect(onSelect).toHaveBeenCalledWith("Dutch");
+    });
+  });
+
+  describe("Accessibility: active option is announced as selected", () => {
+    it("marks the active option with accessibilityState selected", () => {
+      render(
+        <CardLanguagePicker
+          languages={[
+            { language: "Dutch", type: "learning" },
+            { language: "Spanish", type: "spoken" },
+          ]}
+          activeLanguage="Dutch"
+          onSelect={jest.fn()}
+        />,
+      );
+
+      expect(
+        screen.getByTestId("card-language-option-Dutch").props
+          .accessibilityState.selected,
+      ).toBe(true);
+      expect(
+        screen.getByTestId("card-language-option-Spanish").props
+          .accessibilityState.selected,
+      ).toBe(false);
+    });
+  });
+});

--- a/apps/native/__tests__/conversation-starters-deck.test.tsx
+++ b/apps/native/__tests__/conversation-starters-deck.test.tsx
@@ -48,6 +48,8 @@ const CARD_TEXT_TEST_ID = "card-deck-text";
 const NEXT_TEST_ID = "card-deck-next";
 const PREV_TEST_ID = "card-deck-previous";
 const EMPTY_TEST_ID = "card-deck-empty";
+const CARD_TEST_ID = "card-deck-card";
+const REVEAL_HINT_TEST_ID = "card-deck-translation-hint";
 
 function makeCards(language: string, count: number): Card[] {
   return Array.from({ length: count }, (_, i) => {
@@ -264,6 +266,180 @@ describe("#405 — Conversation-starter card deck browser", () => {
       await waitFor(() => {
         expect(screen.getByTestId("card-deck-error")).toBeTruthy();
       });
+    });
+  });
+});
+
+describe("#406 — Tap-to-reveal English translation on a card", () => {
+  beforeEach(() => {
+    mockListByLanguage.mockReset();
+  });
+
+  describe("Scenario: Tap reveals the English translation", () => {
+    it("shows the English translation after tapping a Dutch card", async () => {
+      const cards = makeCards("Dutch", 3);
+      mockListByLanguage.mockResolvedValue({ language: "Dutch", cards });
+
+      renderDeck("Dutch");
+
+      await waitFor(() => {
+        expect(screen.getByTestId(CARD_TEXT_TEST_ID).props.children).toBe(
+          cards[0].text,
+        );
+      });
+
+      fireEvent.press(screen.getByTestId(CARD_TEST_ID));
+
+      expect(screen.getByTestId(CARD_TEXT_TEST_ID).props.children).toBe(
+        cards[0].translation,
+      );
+    });
+  });
+
+  describe("Scenario: Tapping again returns to the chosen language", () => {
+    it("toggles back to the Dutch text on a second tap", async () => {
+      const cards = makeCards("Dutch", 3);
+      mockListByLanguage.mockResolvedValue({ language: "Dutch", cards });
+
+      renderDeck("Dutch");
+
+      await waitFor(() => {
+        expect(screen.getByTestId(CARD_TEXT_TEST_ID)).toBeTruthy();
+      });
+
+      fireEvent.press(screen.getByTestId(CARD_TEST_ID));
+      expect(screen.getByTestId(CARD_TEXT_TEST_ID).props.children).toBe(
+        cards[0].translation,
+      );
+
+      fireEvent.press(screen.getByTestId(CARD_TEST_ID));
+      expect(screen.getByTestId(CARD_TEXT_TEST_ID).props.children).toBe(
+        cards[0].text,
+      );
+    });
+  });
+
+  describe("Scenario: Navigation resets to the chosen language", () => {
+    it("shows the next card in the chosen language after revealing, then Next", async () => {
+      const cards = makeCards("Dutch", 3);
+      mockListByLanguage.mockResolvedValue({ language: "Dutch", cards });
+
+      renderDeck("Dutch");
+
+      await waitFor(() => {
+        expect(screen.getByTestId(CARD_TEXT_TEST_ID)).toBeTruthy();
+      });
+
+      // Reveal the first card's translation.
+      fireEvent.press(screen.getByTestId(CARD_TEST_ID));
+      expect(screen.getByTestId(CARD_TEXT_TEST_ID).props.children).toBe(
+        cards[0].translation,
+      );
+
+      // Move to the next card → it must show the chosen language, not English.
+      fireEvent.press(screen.getByTestId(NEXT_TEST_ID));
+      expect(screen.getByTestId(CARD_TEXT_TEST_ID).props.children).toBe(
+        cards[1].text,
+      );
+
+      // Going back also resets reveal.
+      fireEvent.press(screen.getByTestId(CARD_TEST_ID));
+      expect(screen.getByTestId(CARD_TEXT_TEST_ID).props.children).toBe(
+        cards[1].translation,
+      );
+      fireEvent.press(screen.getByTestId(PREV_TEST_ID));
+      expect(screen.getByTestId(CARD_TEXT_TEST_ID).props.children).toBe(
+        cards[0].text,
+      );
+    });
+  });
+
+  describe("Scenario: English chosen language has no translation affordance", () => {
+    it("hides the affordance and makes tapping a no-op when text === translation", async () => {
+      // English cards carry the same value for text and translation.
+      const cards = [
+        { id: "English-001", text: "How are you?", translation: "How are you?" },
+        { id: "English-002", text: "What's new?", translation: "What's new?" },
+      ];
+      mockListByLanguage.mockResolvedValue({ language: "English", cards });
+
+      renderDeck("English");
+
+      await waitFor(() => {
+        expect(screen.getByTestId(CARD_TEXT_TEST_ID).props.children).toBe(
+          cards[0].text,
+        );
+      });
+
+      // No tap-to-translate hint is rendered.
+      expect(screen.queryByTestId(REVEAL_HINT_TEST_ID)).toBeNull();
+
+      // Tapping does nothing — the card keeps showing the same text.
+      fireEvent.press(screen.getByTestId(CARD_TEST_ID));
+      expect(screen.getByTestId(CARD_TEXT_TEST_ID).props.children).toBe(
+        cards[0].text,
+      );
+    });
+
+    it("shows the translation hint when there is something to translate", async () => {
+      const cards = makeCards("Dutch", 2);
+      mockListByLanguage.mockResolvedValue({ language: "Dutch", cards });
+
+      renderDeck("Dutch");
+
+      await waitFor(() => {
+        expect(screen.getByTestId(REVEAL_HINT_TEST_ID)).toBeTruthy();
+      });
+    });
+  });
+
+  describe("Scenario: Rapid tapping stays in sync", () => {
+    it("never gets stuck between faces after many quick taps", async () => {
+      const cards = makeCards("Dutch", 3);
+      mockListByLanguage.mockResolvedValue({ language: "Dutch", cards });
+
+      renderDeck("Dutch");
+
+      await waitFor(() => {
+        expect(screen.getByTestId(CARD_TEXT_TEST_ID)).toBeTruthy();
+      });
+
+      const card = screen.getByTestId(CARD_TEST_ID);
+      // Even number of taps → back to the chosen language.
+      for (let i = 0; i < 6; i++) {
+        fireEvent.press(card);
+      }
+      expect(screen.getByTestId(CARD_TEXT_TEST_ID).props.children).toBe(
+        cards[0].text,
+      );
+
+      // Odd number of taps → English translation.
+      fireEvent.press(card);
+      expect(screen.getByTestId(CARD_TEXT_TEST_ID).props.children).toBe(
+        cards[0].translation,
+      );
+    });
+  });
+
+  describe("Accessibility", () => {
+    it("announces the reveal state via the tappable card", async () => {
+      const cards = makeCards("Dutch", 2);
+      mockListByLanguage.mockResolvedValue({ language: "Dutch", cards });
+
+      renderDeck("Dutch");
+
+      await waitFor(() => {
+        expect(screen.getByTestId(CARD_TEST_ID)).toBeTruthy();
+      });
+
+      const card = screen.getByTestId(CARD_TEST_ID);
+      expect(card.props.accessibilityRole).toBe("button");
+      expect(card.props.accessibilityState.expanded).toBe(false);
+
+      fireEvent.press(card);
+      expect(
+        screen.getByTestId(CARD_TEST_ID).props.accessibilityState.expanded,
+      ).toBe(true);
     });
   });
 });

--- a/apps/native/__tests__/conversation-starters-deck.test.tsx
+++ b/apps/native/__tests__/conversation-starters-deck.test.tsx
@@ -1,0 +1,269 @@
+/**
+ * Tests for task #405 — the conversation-starter card deck browser.
+ *
+ * Gherkin scenarios (Feature #378):
+ *   - First card shown on open (with "1 / N" position indicator).
+ *   - Stepping forward and back one card at a time.
+ *   - No wrap-around at the ends (Previous disabled on first, Next on last).
+ *   - Changing language resets the deck to the first card.
+ *   - No curated cards for a language → a clear "no cards yet" state.
+ *
+ * The deck fetches its cards via `content.starters.listByLanguage` (#404) and
+ * holds the current position in screen-local `useState`, mirroring the
+ * index-based stepper in `apps/native/app/match.tsx`.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react-native";
+import React from "react";
+
+type Card = { id: string; text: string; translation: string };
+
+const mockListByLanguage = jest.fn();
+
+jest.mock("@/utils/trpc", () => ({
+  trpc: {
+    content: {
+      starters: {
+        listByLanguage: {
+          queryOptions: (input: { language: string }) => ({
+            queryKey: ["content.starters.listByLanguage", input],
+            queryFn: () => mockListByLanguage(input),
+          }),
+        },
+      },
+    },
+  },
+}));
+
+// eslint-disable-next-line import/first
+import { CardDeck } from "@/components/conversation-starters/card-deck";
+
+const POSITION_TEST_ID = "card-deck-position";
+const CARD_TEXT_TEST_ID = "card-deck-text";
+const NEXT_TEST_ID = "card-deck-next";
+const PREV_TEST_ID = "card-deck-previous";
+const EMPTY_TEST_ID = "card-deck-empty";
+
+function makeCards(language: string, count: number): Card[] {
+  return Array.from({ length: count }, (_, i) => {
+    const n = String(i + 1).padStart(3, "0");
+    return {
+      id: `${language}-${n}`,
+      text: `${language} question ${i + 1}`,
+      translation: `English ${i + 1}`,
+    };
+  });
+}
+
+function renderDeck(language: string) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <CardDeck language={language} />
+    </QueryClientProvider>,
+  );
+}
+
+describe("#405 — Conversation-starter card deck browser", () => {
+  beforeEach(() => {
+    mockListByLanguage.mockReset();
+  });
+
+  describe("Scenario: First card shown on open", () => {
+    it("shows the first Dutch card and a '1 / 30' indicator", async () => {
+      const cards = makeCards("Dutch", 30);
+      mockListByLanguage.mockResolvedValue({ language: "Dutch", cards });
+
+      renderDeck("Dutch");
+
+      await waitFor(() => {
+        expect(screen.getByTestId(CARD_TEXT_TEST_ID)).toBeTruthy();
+      });
+      expect(screen.getByTestId(CARD_TEXT_TEST_ID).props.children).toBe(
+        cards[0].text,
+      );
+      expect(screen.getByTestId(POSITION_TEST_ID).props.children).toBe("1 / 30");
+    });
+
+    it("renders the card text in the chosen language, not the translation", async () => {
+      const cards = makeCards("Dutch", 30);
+      mockListByLanguage.mockResolvedValue({ language: "Dutch", cards });
+
+      renderDeck("Dutch");
+
+      await waitFor(() => {
+        expect(screen.getByTestId(CARD_TEXT_TEST_ID).props.children).toBe(
+          "Dutch question 1",
+        );
+      });
+      expect(screen.queryByText("English 1")).toBeNull();
+    });
+  });
+
+  describe("Scenario: Stepping forward and back", () => {
+    it("advances on Next and returns on Previous", async () => {
+      const cards = makeCards("Dutch", 30);
+      mockListByLanguage.mockResolvedValue({ language: "Dutch", cards });
+
+      renderDeck("Dutch");
+
+      await waitFor(() => {
+        expect(screen.getByTestId(CARD_TEXT_TEST_ID)).toBeTruthy();
+      });
+
+      fireEvent.press(screen.getByTestId(NEXT_TEST_ID));
+      expect(screen.getByTestId(CARD_TEXT_TEST_ID).props.children).toBe(
+        cards[1].text,
+      );
+      expect(screen.getByTestId(POSITION_TEST_ID).props.children).toBe("2 / 30");
+
+      fireEvent.press(screen.getByTestId(PREV_TEST_ID));
+      expect(screen.getByTestId(CARD_TEXT_TEST_ID).props.children).toBe(
+        cards[0].text,
+      );
+      expect(screen.getByTestId(POSITION_TEST_ID).props.children).toBe("1 / 30");
+    });
+  });
+
+  describe("Scenario: No wrap-around at the ends", () => {
+    it("disables Previous on the first card and Next on the last", async () => {
+      const cards = makeCards("Dutch", 3);
+      mockListByLanguage.mockResolvedValue({ language: "Dutch", cards });
+
+      renderDeck("Dutch");
+
+      await waitFor(() => {
+        expect(screen.getByTestId(CARD_TEXT_TEST_ID)).toBeTruthy();
+      });
+
+      // First card → Previous disabled, Next enabled.
+      expect(
+        screen.getByTestId(PREV_TEST_ID).props.accessibilityState.disabled,
+      ).toBe(true);
+      expect(
+        screen.getByTestId(NEXT_TEST_ID).props.accessibilityState.disabled,
+      ).toBe(false);
+
+      // Pressing a disabled Previous must not wrap to the last card.
+      fireEvent.press(screen.getByTestId(PREV_TEST_ID));
+      expect(screen.getByTestId(POSITION_TEST_ID).props.children).toBe("1 / 3");
+
+      // Walk to the last card.
+      fireEvent.press(screen.getByTestId(NEXT_TEST_ID));
+      fireEvent.press(screen.getByTestId(NEXT_TEST_ID));
+      expect(screen.getByTestId(POSITION_TEST_ID).props.children).toBe("3 / 3");
+
+      // Last card → Next disabled, Previous enabled.
+      expect(
+        screen.getByTestId(NEXT_TEST_ID).props.accessibilityState.disabled,
+      ).toBe(true);
+      expect(
+        screen.getByTestId(PREV_TEST_ID).props.accessibilityState.disabled,
+      ).toBe(false);
+
+      // Pressing a disabled Next must not wrap to the first card.
+      fireEvent.press(screen.getByTestId(NEXT_TEST_ID));
+      expect(screen.getByTestId(POSITION_TEST_ID).props.children).toBe("3 / 3");
+    });
+  });
+
+  describe("Scenario: Changing language resets the deck", () => {
+    it("resets to the first card when the language prop changes", async () => {
+      const dutch = makeCards("Dutch", 30);
+      const spanish = makeCards("Spanish", 30);
+      mockListByLanguage.mockImplementation(
+        ({ language }: { language: string }) =>
+          Promise.resolve({
+            language,
+            cards: language === "Dutch" ? dutch : spanish,
+          }),
+      );
+
+      const client = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
+      const { rerender } = render(
+        <QueryClientProvider client={client}>
+          <CardDeck language="Dutch" />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId(CARD_TEXT_TEST_ID)).toBeTruthy();
+      });
+
+      // Advance to card 5 of Dutch.
+      for (let i = 0; i < 4; i++) {
+        fireEvent.press(screen.getByTestId(NEXT_TEST_ID));
+      }
+      expect(screen.getByTestId(POSITION_TEST_ID).props.children).toBe("5 / 30");
+
+      // Switch language → deck resets to the first card.
+      rerender(
+        <QueryClientProvider client={client}>
+          <CardDeck language="Spanish" />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId(CARD_TEXT_TEST_ID).props.children).toBe(
+          spanish[0].text,
+        );
+      });
+      expect(screen.getByTestId(POSITION_TEST_ID).props.children).toBe("1 / 30");
+    });
+  });
+
+  describe("Scenario: No curated cards for a language", () => {
+    it("shows a 'no cards yet' state instead of a blank deck", async () => {
+      mockListByLanguage.mockResolvedValue({ language: "Klingon", cards: [] });
+
+      renderDeck("Klingon");
+
+      await waitFor(() => {
+        expect(screen.getByTestId(EMPTY_TEST_ID)).toBeTruthy();
+      });
+      // No card, no position indicator, no stepper buttons.
+      expect(screen.queryByTestId(CARD_TEXT_TEST_ID)).toBeNull();
+      expect(screen.queryByTestId(POSITION_TEST_ID)).toBeNull();
+      expect(screen.queryByTestId(NEXT_TEST_ID)).toBeNull();
+      expect(screen.queryByTestId(PREV_TEST_ID)).toBeNull();
+    });
+  });
+
+  describe("Loading and error states", () => {
+    it("shows a loading state while fetching", async () => {
+      let resolve: (v: { language: string; cards: Card[] }) => void = () => {};
+      mockListByLanguage.mockReturnValue(
+        new Promise((r) => {
+          resolve = r;
+        }),
+      );
+
+      renderDeck("Dutch");
+
+      expect(screen.getByTestId("card-deck-loading")).toBeTruthy();
+      resolve({ language: "Dutch", cards: makeCards("Dutch", 30) });
+      await waitFor(() => {
+        expect(screen.getByTestId(CARD_TEXT_TEST_ID)).toBeTruthy();
+      });
+    });
+
+    it("shows an error state when the query fails", async () => {
+      mockListByLanguage.mockRejectedValue(new Error("boom"));
+
+      renderDeck("Dutch");
+
+      await waitFor(() => {
+        expect(screen.getByTestId("card-deck-error")).toBeTruthy();
+      });
+    });
+  });
+});

--- a/apps/native/__tests__/conversation-starters-gate.test.tsx
+++ b/apps/native/__tests__/conversation-starters-gate.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * Tests for task #381 — Gate the Conversation Starters screen on the buddy's
+ * profile languages.
+ *
+ * The screen reads the buddy's spoken + learning languages via the existing
+ * `trpc.profile.getMyProfile` query and branches its render:
+ *   - loading  → a loading state (never the empty state)
+ *   - error    → a sensible fallback, not a false empty state
+ *   - empty    → no spoken/learning languages → "add a language" empty state
+ *                with a CTA that navigates to the profile/onboarding screen
+ *   - ready    → ≥1 language → the cards entry-point container that later
+ *                Features (#377 picker, #378 deck) fill in
+ *
+ * Scenario 1: Buddy with no profile languages sees the empty state.
+ * Scenario 2: Buddy with at least one language reaches the cards entry point.
+ * Scenario 3: Profile is still loading → loading state.
+ * Edge: profile query errors → fallback, not a false empty state.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react-native";
+import React from "react";
+
+const mockPush = jest.fn();
+
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock("@/components/container", () => {
+  const { View } = require("react-native");
+  return {
+    Container: ({ children }: { children: React.ReactNode }) => (
+      <View>{children}</View>
+    ),
+  };
+});
+
+const mockGetMyProfile = jest.fn();
+
+jest.mock("@/utils/trpc", () => ({
+  trpc: {
+    profile: {
+      getMyProfile: {
+        queryOptions: () => ({
+          queryKey: ["profile.getMyProfile"],
+          queryFn: mockGetMyProfile,
+        }),
+      },
+    },
+  },
+}));
+
+// eslint-disable-next-line import/first
+import ConversationStartersScreen from "../app/(tabs)/conversation-starters";
+
+const ENTRY_POINT_TEST_ID = "conversation-starters-entry-point";
+const EMPTY_TEST_ID = "conversation-starters-empty";
+const LOADING_TEST_ID = "conversation-starters-loading";
+
+function renderScreen() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <ConversationStartersScreen />
+    </QueryClientProvider>,
+  );
+}
+
+const profileWith = (
+  languages: { language: string; type: "spoken" | "learning" }[],
+) => ({
+  identity: { name: "Anna", surname: "de Vries", image: null, email: "a@b.nl" },
+  profile: null,
+  languages,
+  interests: [],
+});
+
+describe("#381 — Gate Conversation Starters on profile languages", () => {
+  beforeEach(() => {
+    mockGetMyProfile.mockReset();
+    mockPush.mockReset();
+  });
+
+  describe("Scenario: Buddy with no profile languages sees the empty state", () => {
+    it("shows the empty state with a CTA to the profile/onboarding screen", async () => {
+      mockGetMyProfile.mockResolvedValue(profileWith([]));
+
+      renderScreen();
+
+      await waitFor(() => {
+        expect(screen.getByTestId(EMPTY_TEST_ID)).toBeTruthy();
+      });
+
+      // Empty state explains that languages must be added.
+      expect(screen.getByText(/add a language/i)).toBeTruthy();
+      // Entry point is NOT rendered while there are no languages.
+      expect(screen.queryByTestId(ENTRY_POINT_TEST_ID)).toBeNull();
+
+      // CTA navigates to the profile/onboarding screen.
+      fireEvent.press(screen.getByTestId("conversation-starters-empty-cta"));
+      expect(mockPush).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("Scenario: Buddy with at least one language reaches the cards entry point", () => {
+    it("renders the entry point for a spoken language", async () => {
+      mockGetMyProfile.mockResolvedValue(
+        profileWith([{ language: "es", type: "spoken" }]),
+      );
+
+      renderScreen();
+
+      await waitFor(() => {
+        expect(screen.getByTestId(ENTRY_POINT_TEST_ID)).toBeTruthy();
+      });
+      expect(screen.queryByTestId(EMPTY_TEST_ID)).toBeNull();
+    });
+
+    it("renders the entry point for a learning-only language", async () => {
+      mockGetMyProfile.mockResolvedValue(
+        profileWith([{ language: "fr", type: "learning" }]),
+      );
+
+      renderScreen();
+
+      await waitFor(() => {
+        expect(screen.getByTestId(ENTRY_POINT_TEST_ID)).toBeTruthy();
+      });
+      expect(screen.queryByTestId(EMPTY_TEST_ID)).toBeNull();
+    });
+  });
+
+  describe("Scenario: Profile is still loading", () => {
+    it("shows the loading state, not the empty state", async () => {
+      // A promise that never resolves keeps the query pending.
+      mockGetMyProfile.mockReturnValue(new Promise(() => {}));
+
+      renderScreen();
+
+      expect(screen.getByTestId(LOADING_TEST_ID)).toBeTruthy();
+      expect(screen.queryByTestId(EMPTY_TEST_ID)).toBeNull();
+      expect(screen.queryByTestId(ENTRY_POINT_TEST_ID)).toBeNull();
+    });
+  });
+
+  describe("Edge: profile query errors", () => {
+    it("shows a fallback rather than a false empty state", async () => {
+      mockGetMyProfile.mockRejectedValue(new Error("network"));
+
+      renderScreen();
+
+      await waitFor(() => {
+        expect(screen.getByTestId("conversation-starters-error")).toBeTruthy();
+      });
+      // Must NOT misrepresent an error as "no languages".
+      expect(screen.queryByTestId(EMPTY_TEST_ID)).toBeNull();
+    });
+  });
+});

--- a/apps/native/__tests__/conversation-starters-gate.test.tsx
+++ b/apps/native/__tests__/conversation-starters-gate.test.tsx
@@ -47,6 +47,19 @@ jest.mock("@/utils/trpc", () => ({
         }),
       },
     },
+    // The ready-state deck (#405) lives behind the gate; stub it with an empty
+    // set so this gate-focused suite never touches real content.
+    content: {
+      starters: {
+        listByLanguage: {
+          queryOptions: (input: { language: string }) => ({
+            queryKey: ["content.starters.listByLanguage", input],
+            queryFn: () =>
+              Promise.resolve({ language: input.language, cards: [] }),
+          }),
+        },
+      },
+    },
   },
 }));
 

--- a/apps/native/__tests__/conversation-starters-picker.test.tsx
+++ b/apps/native/__tests__/conversation-starters-picker.test.tsx
@@ -1,0 +1,208 @@
+/**
+ * Tests for task #403 — wiring the card-language picker into the Conversation
+ * Starters screen's ready state (past the #381 gate).
+ *
+ * Screen-level Gherkin scenarios:
+ *   - Selecting a language activates it and reveals the deck area.
+ *   - A single profile language is auto-selected and the picker collapses.
+ *   - The selection persists while the buddy stays on the tab.
+ *
+ * The picker's own option rendering / de-dup is covered in
+ * card-language-picker.test.tsx.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react-native";
+import React from "react";
+
+const mockPush = jest.fn();
+
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock("@/components/container", () => {
+  const { View } = require("react-native");
+  return {
+    Container: ({ children }: { children: React.ReactNode }) => (
+      <View>{children}</View>
+    ),
+  };
+});
+
+const mockGetMyProfile = jest.fn();
+
+jest.mock("@/utils/trpc", () => ({
+  trpc: {
+    profile: {
+      getMyProfile: {
+        queryOptions: () => ({
+          queryKey: ["profile.getMyProfile"],
+          queryFn: mockGetMyProfile,
+        }),
+      },
+    },
+  },
+}));
+
+// eslint-disable-next-line import/first
+import ConversationStartersScreen from "../app/(tabs)/conversation-starters";
+
+const ENTRY_POINT_TEST_ID = "conversation-starters-entry-point";
+const PICKER_TEST_ID = "card-language-picker";
+const DECK_AREA_TEST_ID = "conversation-starters-deck-area";
+
+function renderScreen() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <ConversationStartersScreen />
+    </QueryClientProvider>,
+  );
+}
+
+const profileWith = (
+  languages: { language: string; type: "spoken" | "learning" }[],
+) => ({
+  identity: { name: "Anna", surname: "de Vries", image: null, email: "a@b.nl" },
+  profile: null,
+  languages,
+  interests: [],
+});
+
+describe("#403 — Card-language picker on Conversation Starters", () => {
+  beforeEach(() => {
+    mockGetMyProfile.mockReset();
+    mockPush.mockReset();
+  });
+
+  describe("Scenario: Picker shows only profile languages", () => {
+    it("renders the picker with the buddy's two languages", async () => {
+      mockGetMyProfile.mockResolvedValue(
+        profileWith([
+          { language: "Dutch", type: "spoken" },
+          { language: "Spanish", type: "learning" },
+        ]),
+      );
+
+      renderScreen();
+
+      await waitFor(() => {
+        expect(screen.getByTestId(PICKER_TEST_ID)).toBeTruthy();
+      });
+      expect(screen.getByTestId("card-language-option-Dutch")).toBeTruthy();
+      expect(screen.getByTestId("card-language-option-Spanish")).toBeTruthy();
+    });
+  });
+
+  describe("Scenario: Selecting a language activates it and reveals the deck area", () => {
+    it("activates Dutch and reveals the deck area on press", async () => {
+      mockGetMyProfile.mockResolvedValue(
+        profileWith([
+          { language: "Dutch", type: "spoken" },
+          { language: "Spanish", type: "learning" },
+        ]),
+      );
+
+      renderScreen();
+
+      await waitFor(() => {
+        expect(screen.getByTestId(PICKER_TEST_ID)).toBeTruthy();
+      });
+      // Nothing selected yet → deck area hidden.
+      expect(screen.queryByTestId(DECK_AREA_TEST_ID)).toBeNull();
+
+      fireEvent.press(screen.getByTestId("card-language-option-Dutch"));
+
+      // Deck area for Dutch is now revealed and exposes the active language.
+      const deck = screen.getByTestId(DECK_AREA_TEST_ID);
+      expect(deck).toBeTruthy();
+      expect(deck.props.accessibilityLabel).toBe("Cards for Dutch");
+      // The active option is announced as selected.
+      expect(
+        screen.getByTestId("card-language-option-Dutch").props
+          .accessibilityState.selected,
+      ).toBe(true);
+    });
+  });
+
+  describe("Scenario: Single profile language is auto-selected", () => {
+    it("auto-selects the only language and collapses the picker", async () => {
+      mockGetMyProfile.mockResolvedValue(
+        profileWith([{ language: "Dutch", type: "learning" }]),
+      );
+
+      renderScreen();
+
+      await waitFor(() => {
+        expect(screen.getByTestId(ENTRY_POINT_TEST_ID)).toBeTruthy();
+      });
+      // Picker collapsed — no manual pick needed.
+      expect(screen.queryByTestId(PICKER_TEST_ID)).toBeNull();
+      // Dutch is already active → deck area shown.
+      const deck = screen.getByTestId(DECK_AREA_TEST_ID);
+      expect(deck.props.accessibilityLabel).toBe("Cards for Dutch");
+    });
+  });
+
+  describe("Scenario: Duplicate across spoken and learning is shown once", () => {
+    it("auto-selects when the only language appears in both lists", async () => {
+      mockGetMyProfile.mockResolvedValue(
+        profileWith([
+          { language: "Dutch", type: "spoken" },
+          { language: "Dutch", type: "learning" },
+        ]),
+      );
+
+      renderScreen();
+
+      await waitFor(() => {
+        expect(screen.getByTestId(ENTRY_POINT_TEST_ID)).toBeTruthy();
+      });
+      // De-duped to one → behaves as a single language: collapsed + auto-select.
+      expect(screen.queryByTestId(PICKER_TEST_ID)).toBeNull();
+      expect(screen.getByTestId(DECK_AREA_TEST_ID).props.accessibilityLabel).toBe(
+        "Cards for Dutch",
+      );
+    });
+  });
+
+  describe("Scenario: Selection persists while on the tab", () => {
+    it("keeps the chosen language active across re-renders", async () => {
+      mockGetMyProfile.mockResolvedValue(
+        profileWith([
+          { language: "Dutch", type: "spoken" },
+          { language: "Spanish", type: "learning" },
+        ]),
+      );
+
+      const client = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
+      const tree = (
+        <QueryClientProvider client={client}>
+          <ConversationStartersScreen />
+        </QueryClientProvider>
+      );
+      const { rerender } = render(tree);
+
+      await waitFor(() => {
+        expect(screen.getByTestId(PICKER_TEST_ID)).toBeTruthy();
+      });
+
+      fireEvent.press(screen.getByTestId("card-language-option-Spanish"));
+      expect(screen.getByTestId(DECK_AREA_TEST_ID).props.accessibilityLabel).toBe(
+        "Cards for Spanish",
+      );
+
+      // A re-render of the same mounted tree (still on the tab) must keep the
+      // chosen language — screen-local useState is the persistence mechanism.
+      rerender(tree);
+
+      expect(screen.getByTestId(DECK_AREA_TEST_ID).props.accessibilityLabel).toBe(
+        "Cards for Spanish",
+      );
+    });
+  });
+});

--- a/apps/native/__tests__/conversation-starters-picker.test.tsx
+++ b/apps/native/__tests__/conversation-starters-picker.test.tsx
@@ -41,6 +41,19 @@ jest.mock("@/utils/trpc", () => ({
         }),
       },
     },
+    // Deck content (#405) is exercised in conversation-starters-deck.test.tsx;
+    // here it is stubbed empty so the picker assertions stay focused.
+    content: {
+      starters: {
+        listByLanguage: {
+          queryOptions: (input: { language: string }) => ({
+            queryKey: ["content.starters.listByLanguage", input],
+            queryFn: () =>
+              Promise.resolve({ language: input.language, cards: [] }),
+          }),
+        },
+      },
+    },
   },
 }));
 

--- a/apps/native/__tests__/conversation-starters-tab.test.tsx
+++ b/apps/native/__tests__/conversation-starters-tab.test.tsx
@@ -110,6 +110,10 @@ describe("Conversation Starters screen", () => {
     const ConversationStartersScreen = require("@/app/(tabs)/conversation-starters").default;
     render(<ConversationStartersScreen />);
 
-    expect(screen.getByText("Conversation Starters")).toBeTruthy();
+    // The screen renders its ready-state content (the cards entry point that
+    // task #403 fills with the language picker / deck area).
+    expect(
+      screen.getByTestId("conversation-starters-entry-point"),
+    ).toBeTruthy();
   });
 });

--- a/apps/native/__tests__/conversation-starters-tab.test.tsx
+++ b/apps/native/__tests__/conversation-starters-tab.test.tsx
@@ -64,6 +64,8 @@ jest.mock("@/utils/trpc", () => ({
     meetup: { list: makeQueryable(), getConfirmed: makeQueryable() },
     chat: { listEntries: makeQueryable() },
     profile: { getMyProfile: makeQueryable() },
+    // The ready-state deck (#405) issues this query once a language is active.
+    content: { starters: { listByLanguage: makeQueryable() } },
   },
 }));
 

--- a/apps/native/__tests__/conversation-starters-tab.test.tsx
+++ b/apps/native/__tests__/conversation-starters-tab.test.tsx
@@ -31,7 +31,7 @@ jest.mock("expo-router", () => {
     registeredScreens.push({ name, options });
     return null;
   };
-  return { Tabs };
+  return { Tabs, useRouter: () => ({ push: jest.fn() }) };
 });
 
 jest.mock("@expo/vector-icons", () => {
@@ -45,9 +45,17 @@ jest.mock("uniwind", () => ({
   withUniwind: (Component: unknown) => Component,
 }));
 
-jest.mock("@tanstack/react-query", () => ({
-  useQuery: () => ({ data: [] }),
-}));
+jest.mock("@tanstack/react-query", () => {
+  // The layout's badge queries read `.data.length` / `.data.filter(...)` (an
+  // array), while the Conversation Starters screen reads `.data.languages`.
+  // An array carrying a `languages` property satisfies both: the badges see an
+  // empty array, and the screen sees one language → ready entry point.
+  const data: unknown[] & { languages?: unknown } = [];
+  data.languages = [{ language: "es", type: "spoken" }];
+  return {
+    useQuery: () => ({ data, isPending: false, isError: false }),
+  };
+});
 
 const makeQueryable = () => ({ queryOptions: () => ({}) });
 jest.mock("@/utils/trpc", () => ({
@@ -55,6 +63,7 @@ jest.mock("@/utils/trpc", () => ({
     matching: { getIncomingRequests: makeQueryable() },
     meetup: { list: makeQueryable(), getConfirmed: makeQueryable() },
     chat: { listEntries: makeQueryable() },
+    profile: { getMyProfile: makeQueryable() },
   },
 }));
 

--- a/apps/native/__tests__/conversation-starters-tab.test.tsx
+++ b/apps/native/__tests__/conversation-starters-tab.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * Tests for task #380 — Add the Conversation Starters tab and screen to the
+ * bottom navigation.
+ *
+ * Scenario 1: Tab is visible in the bottom navigation.
+ *   The tabs layout registers a "Conversation Starters" <Tabs.Screen> with a
+ *   label (title) and an Ionicons tabBarIcon, alongside the existing tabs.
+ *
+ * Scenario 2: Opening the tab.
+ *   The Conversation Starters screen component renders its own content.
+ *
+ * `expo-router`'s <Tabs> is mocked to capture the registered screens (name +
+ * options) so we can assert registration without a navigation container. The
+ * tRPC badge queries used by the layout are mocked to return empty data.
+ */
+import { render, screen } from "@testing-library/react-native";
+import React from "react";
+
+type ScreenOptions = {
+  title?: string;
+  href?: string | null;
+  tabBarIcon?: (p: { color: string; size: number }) => React.ReactNode;
+};
+
+const registeredScreens: { name: string; options?: ScreenOptions }[] = [];
+
+jest.mock("expo-router", () => {
+  const { View } = require("react-native");
+  const Tabs = ({ children }: { children: React.ReactNode }) => <View>{children}</View>;
+  Tabs.Screen = ({ name, options }: { name: string; options?: ScreenOptions }) => {
+    registeredScreens.push({ name, options });
+    return null;
+  };
+  return { Tabs };
+});
+
+jest.mock("@expo/vector-icons", () => {
+  const { Text } = require("react-native");
+  return {
+    Ionicons: ({ name }: { name: string }) => <Text>{name}</Text>,
+  };
+});
+
+jest.mock("uniwind", () => ({
+  withUniwind: (Component: unknown) => Component,
+}));
+
+jest.mock("@tanstack/react-query", () => ({
+  useQuery: () => ({ data: [] }),
+}));
+
+const makeQueryable = () => ({ queryOptions: () => ({}) });
+jest.mock("@/utils/trpc", () => ({
+  trpc: {
+    matching: { getIncomingRequests: makeQueryable() },
+    meetup: { list: makeQueryable(), getConfirmed: makeQueryable() },
+    chat: { listEntries: makeQueryable() },
+  },
+}));
+
+jest.mock("@/components/container", () => {
+  const { View } = require("react-native");
+  return {
+    Container: ({ children }: { children: React.ReactNode }) => <View>{children}</View>,
+  };
+});
+
+describe("Conversation Starters tab registration", () => {
+  beforeEach(() => {
+    registeredScreens.length = 0;
+  });
+
+  it("registers a Conversation Starters tab with a label and icon", () => {
+    const TabsLayout = require("@/app/(tabs)/_layout").default;
+    render(<TabsLayout />);
+
+    const tab = registeredScreens.find((s) => s.name === "conversation-starters");
+    expect(tab).toBeDefined();
+    expect(tab?.options?.title).toBe("Conversation Starters");
+    // Icon renderer is provided and yields a node (Ionicons element).
+    const iconNode = tab?.options?.tabBarIcon?.({ color: "#000", size: 24 });
+    expect(iconNode).toBeTruthy();
+  });
+
+  it("registers it as a visible tab (not href: null) alongside existing tabs", () => {
+    const TabsLayout = require("@/app/(tabs)/_layout").default;
+    render(<TabsLayout />);
+
+    const names = registeredScreens.map((s) => s.name);
+    expect(names).toEqual(
+      expect.arrayContaining(["home", "matches", "confirmed-meetups", "chats", "conversation-starters"]),
+    );
+
+    const tab = registeredScreens.find((s) => s.name === "conversation-starters");
+    expect(tab?.options?.href).toBeUndefined();
+  });
+});
+
+describe("Conversation Starters screen", () => {
+  it("renders its own content when opened", () => {
+    const ConversationStartersScreen = require("@/app/(tabs)/conversation-starters").default;
+    render(<ConversationStartersScreen />);
+
+    expect(screen.getByText("Conversation Starters")).toBeTruthy();
+  });
+});

--- a/apps/native/app/(tabs)/_layout.tsx
+++ b/apps/native/app/(tabs)/_layout.tsx
@@ -84,6 +84,15 @@ export default function TabsLayout() {
         }}
       />
       <Tabs.Screen
+        name="conversation-starters"
+        options={{
+          title: "Conversation Starters",
+          tabBarIcon: ({ color, size }) => (
+            <StyledIonicons name="chatbox-ellipses-outline" size={size} color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
         name="suggestions"
         options={{ href: null }}
       />

--- a/apps/native/app/(tabs)/conversation-starters.tsx
+++ b/apps/native/app/(tabs)/conversation-starters.tsx
@@ -1,11 +1,107 @@
-import { Text, View } from "react-native";
+import { useQuery } from "@tanstack/react-query";
+import { useRouter } from "expo-router";
+import { Pressable, Text, View } from "react-native";
 
 import { Container } from "@/components/container";
+import { trpc } from "@/utils/trpc";
 
+/**
+ * Conversation Starters entry point, gated on the buddy's profile languages.
+ *
+ * A buddy with no spoken or learning languages has nothing to practice, so the
+ * screen guides them to add languages first. Everyone with at least one
+ * language reaches the ready-state container that later Features (#377 picker,
+ * #378 deck) fill in.
+ */
 export default function ConversationStartersScreen() {
+  const router = useRouter();
+  const profileQuery = useQuery(trpc.profile.getMyProfile.queryOptions());
+
+  if (profileQuery.isPending) {
+    return <LoadingState />;
+  }
+
+  if (profileQuery.isError) {
+    return <ErrorState />;
+  }
+
+  const languages = profileQuery.data?.languages ?? [];
+  const hasLanguages = languages.length > 0;
+
+  if (!hasLanguages) {
+    return <EmptyState onAddLanguages={() => router.push("/(tabs)/home")} />;
+  }
+
+  return <ReadyState />;
+}
+
+function Centered({ children }: { children: React.ReactNode }) {
   return (
     <Container>
-      <View className="flex-1 items-center justify-center p-6">
+      <View className="flex-1 items-center justify-center p-6">{children}</View>
+    </Container>
+  );
+}
+
+function LoadingState() {
+  return (
+    <Centered>
+      <Text
+        testID="conversation-starters-loading"
+        className="text-center text-sm text-muted-foreground"
+      >
+        Loading your languages…
+      </Text>
+    </Centered>
+  );
+}
+
+function ErrorState() {
+  return (
+    <Centered>
+      <Text
+        testID="conversation-starters-error"
+        className="text-center text-lg font-semibold text-foreground"
+      >
+        Something went wrong
+      </Text>
+      <Text className="mt-2 text-center text-sm text-muted-foreground">
+        We couldn't load your languages. Please try again.
+      </Text>
+    </Centered>
+  );
+}
+
+function EmptyState({ onAddLanguages }: { onAddLanguages: () => void }) {
+  return (
+    <Centered>
+      <View testID="conversation-starters-empty" className="items-center">
+        <Text className="text-center text-lg font-semibold text-foreground">
+          No languages yet
+        </Text>
+        <Text className="mt-2 text-center text-sm text-muted-foreground">
+          Add the languages you speak or want to learn to your profile to start
+          practising with conversation starters.
+        </Text>
+        <Pressable
+          testID="conversation-starters-empty-cta"
+          accessibilityRole="button"
+          onPress={onAddLanguages}
+          className="mt-6 rounded-full bg-primary px-6 py-3"
+        >
+          <Text className="text-center text-sm font-semibold text-primary-foreground">
+            Add a language
+          </Text>
+        </Pressable>
+      </View>
+    </Centered>
+  );
+}
+
+function ReadyState() {
+  return (
+    <Centered>
+      <View testID="conversation-starters-entry-point" className="items-center">
         <Text className="text-center text-lg font-semibold text-foreground">
           Conversation Starters
         </Text>
@@ -13,6 +109,6 @@ export default function ConversationStartersScreen() {
           Your practice cards will appear here.
         </Text>
       </View>
-    </Container>
+    </Centered>
   );
 }

--- a/apps/native/app/(tabs)/conversation-starters.tsx
+++ b/apps/native/app/(tabs)/conversation-starters.tsx
@@ -1,0 +1,18 @@
+import { Text, View } from "react-native";
+
+import { Container } from "@/components/container";
+
+export default function ConversationStartersScreen() {
+  return (
+    <Container>
+      <View className="flex-1 items-center justify-center p-6">
+        <Text className="text-center text-lg font-semibold text-foreground">
+          Conversation Starters
+        </Text>
+        <Text className="mt-2 text-center text-sm text-muted-foreground">
+          Your practice cards will appear here.
+        </Text>
+      </View>
+    </Container>
+  );
+}

--- a/apps/native/app/(tabs)/conversation-starters.tsx
+++ b/apps/native/app/(tabs)/conversation-starters.tsx
@@ -1,7 +1,13 @@
 import { useQuery } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
+import { useState } from "react";
 import { Pressable, Text, View } from "react-native";
 
+import {
+  CardLanguagePicker,
+  dedupeLanguages,
+  type ProfileLanguage,
+} from "@/components/conversation-starters/card-language-picker";
 import { Container } from "@/components/container";
 import { trpc } from "@/utils/trpc";
 
@@ -32,7 +38,7 @@ export default function ConversationStartersScreen() {
     return <EmptyState onAddLanguages={() => router.push("/(tabs)/home")} />;
   }
 
-  return <ReadyState />;
+  return <ReadyState languages={languages} />;
 }
 
 function Centered({ children }: { children: React.ReactNode }) {
@@ -98,16 +104,46 @@ function EmptyState({ onAddLanguages }: { onAddLanguages: () => void }) {
   );
 }
 
-function ReadyState() {
+function ReadyState({ languages }: { languages: ProfileLanguage[] }) {
+  const options = dedupeLanguages(languages);
+  // A buddy with exactly one profile language never needs to pick — the
+  // language is auto-selected and the picker collapses (issue #403).
+  const autoSelected = options.length === 1 ? options[0] : null;
+  const [activeLanguage, setActiveLanguage] = useState<string | null>(
+    autoSelected,
+  );
+
+  // Hide the picker when there is nothing to choose between.
+  const showPicker = options.length > 1;
+
   return (
     <Centered>
-      <View testID="conversation-starters-entry-point" className="items-center">
-        <Text className="text-center text-lg font-semibold text-foreground">
-          Conversation Starters
-        </Text>
-        <Text className="mt-2 text-center text-sm text-muted-foreground">
-          Your practice cards will appear here.
-        </Text>
+      <View testID="conversation-starters-entry-point" className="w-full">
+        {showPicker ? (
+          <CardLanguagePicker
+            languages={languages}
+            activeLanguage={activeLanguage}
+            onSelect={setActiveLanguage}
+          />
+        ) : null}
+
+        {activeLanguage ? (
+          // Deck-area entry point. Feature #378 (#405) renders the actual deck
+          // here; this task only exposes the active language to it.
+          <View
+            testID="conversation-starters-deck-area"
+            accessibilityLabel={`Cards for ${activeLanguage}`}
+            className="mt-6 items-center"
+          >
+            <Text className="text-center text-sm text-muted-foreground">
+              Your {activeLanguage} practice cards will appear here.
+            </Text>
+          </View>
+        ) : (
+          <Text className="mt-6 text-center text-sm text-muted-foreground">
+            Pick a language to start practising.
+          </Text>
+        )}
       </View>
     </Centered>
   );

--- a/apps/native/app/(tabs)/conversation-starters.tsx
+++ b/apps/native/app/(tabs)/conversation-starters.tsx
@@ -3,6 +3,7 @@ import { useRouter } from "expo-router";
 import { useState } from "react";
 import { Pressable, Text, View } from "react-native";
 
+import { CardDeck } from "@/components/conversation-starters/card-deck";
 import {
   CardLanguagePicker,
   dedupeLanguages,
@@ -133,11 +134,13 @@ function ReadyState({ languages }: { languages: ProfileLanguage[] }) {
           <View
             testID="conversation-starters-deck-area"
             accessibilityLabel={`Cards for ${activeLanguage}`}
-            className="mt-6 items-center"
+            className="mt-6 w-full items-center"
           >
-            <Text className="text-center text-sm text-muted-foreground">
-              Your {activeLanguage} practice cards will appear here.
-            </Text>
+            {/*
+              Keying by language remounts the deck on language change, so its
+              internal position index resets to the first card (issue #405).
+            */}
+            <CardDeck key={activeLanguage} language={activeLanguage} />
           </View>
         ) : (
           <Text className="mt-6 text-center text-sm text-muted-foreground">

--- a/apps/native/components/conversation-starters/card-deck.tsx
+++ b/apps/native/components/conversation-starters/card-deck.tsx
@@ -65,19 +65,58 @@ function DeckBrowser({
   const isFirst = safeIndex === 0;
   const isLast = safeIndex === lastIndex;
 
+  // Per-card reveal: tapping flips between the chosen-language `text` and the
+  // English `translation`. Reset to the chosen language whenever the active
+  // card changes so the reveal never leaks across Next/Previous.
+  const [revealed, setRevealed] = useState(false);
+  useEffect(() => {
+    setRevealed(false);
+  }, [safeIndex, language]);
+
+  // When the chosen language is English there is nothing to translate — the
+  // card already carries identical `text`/`translation`. Hide the affordance
+  // and make tapping a no-op so the card never looks broken.
+  const canTranslate = current.translation !== current.text;
+  const showTranslation = canTranslate && revealed;
+
+  function toggleReveal() {
+    if (!canTranslate) return;
+    setRevealed((r) => !r);
+  }
+
   return (
     <View testID="card-deck" className="w-full items-center">
-      <View
+      <Pressable
         testID="card-deck-card"
+        accessibilityRole="button"
+        accessibilityLabel={
+          canTranslate
+            ? showTranslation
+              ? "Card, showing English translation. Tap to show the original."
+              : "Card. Tap to reveal the English translation."
+            : undefined
+        }
+        accessibilityState={{ expanded: canTranslate ? showTranslation : false }}
+        disabled={!canTranslate}
+        onPress={toggleReveal}
         className="w-full items-center justify-center rounded-3xl bg-muted px-6 py-12"
       >
         <Text
           testID="card-deck-text"
           className="text-center text-2xl font-semibold text-foreground"
         >
-          {current.text}
+          {showTranslation ? current.translation : current.text}
         </Text>
-      </View>
+
+        {canTranslate ? (
+          <Text
+            testID="card-deck-translation-hint"
+            className="mt-4 text-center text-xs font-medium uppercase tracking-wide text-muted-foreground"
+          >
+            {showTranslation ? "Tap to show original" : "Tap to translate"}
+          </Text>
+        ) : null}
+      </Pressable>
 
       <Text
         testID="card-deck-position"

--- a/apps/native/components/conversation-starters/card-deck.tsx
+++ b/apps/native/components/conversation-starters/card-deck.tsx
@@ -1,0 +1,177 @@
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { Pressable, Text, View } from "react-native";
+
+import { trpc } from "@/utils/trpc";
+
+type CardDeckProps = {
+  /** The active card language to browse cards in (from the #403 picker). */
+  language: string;
+};
+
+/**
+ * Lets a buddy flip through the curated conversation-starter cards for the
+ * active language, one card at a time.
+ *
+ * Cards come from `content.starters.listByLanguage` (#404). The current
+ * position is held in screen-local `useState`, clamped to
+ * `[0, cards.length - 1]`, with no wrap-around — mirroring the index-based
+ * stepper in `apps/native/app/match.tsx`. Switching language remounts a fresh
+ * deck (the parent keys this component by language), so the index always
+ * starts back at the first card.
+ */
+export function CardDeck({ language }: CardDeckProps) {
+  const cardsQuery = useQuery(
+    trpc.content.starters.listByLanguage.queryOptions({ language }),
+  );
+
+  if (cardsQuery.isPending) {
+    return <DeckLoading />;
+  }
+
+  if (cardsQuery.isError) {
+    return <DeckError />;
+  }
+
+  const cards = cardsQuery.data?.cards ?? [];
+
+  if (cards.length === 0) {
+    return <DeckEmpty language={language} />;
+  }
+
+  return <DeckBrowser cards={cards} language={language} />;
+}
+
+type Card = { id: string; text: string; translation: string };
+
+function DeckBrowser({
+  cards,
+  language,
+}: {
+  cards: Card[];
+  language: string;
+}) {
+  const [index, setIndex] = useState(0);
+  const lastIndex = cards.length - 1;
+
+  // Defensive reset: if the same mounted deck ever receives a shorter card set
+  // for a new language, keep the index inside bounds and back at the start.
+  useEffect(() => {
+    setIndex(0);
+  }, [language]);
+
+  const safeIndex = Math.min(index, lastIndex);
+  const current = cards[safeIndex];
+  const isFirst = safeIndex === 0;
+  const isLast = safeIndex === lastIndex;
+
+  return (
+    <View testID="card-deck" className="w-full items-center">
+      <View
+        testID="card-deck-card"
+        className="w-full items-center justify-center rounded-3xl bg-muted px-6 py-12"
+      >
+        <Text
+          testID="card-deck-text"
+          className="text-center text-2xl font-semibold text-foreground"
+        >
+          {current.text}
+        </Text>
+      </View>
+
+      <Text
+        testID="card-deck-position"
+        className="mt-4 text-center text-sm text-muted-foreground"
+      >
+        {`${safeIndex + 1} / ${cards.length}`}
+      </Text>
+
+      <View className="mt-6 w-full flex-row justify-between gap-3">
+        <StepperButton
+          testID="card-deck-previous"
+          label="Previous"
+          disabled={isFirst}
+          onPress={() => setIndex((i) => Math.max(0, i - 1))}
+        />
+        <StepperButton
+          testID="card-deck-next"
+          label="Next"
+          disabled={isLast}
+          onPress={() => setIndex((i) => Math.min(lastIndex, i + 1))}
+        />
+      </View>
+    </View>
+  );
+}
+
+function StepperButton({
+  testID,
+  label,
+  disabled,
+  onPress,
+}: {
+  testID: string;
+  label: string;
+  disabled: boolean;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      testID={testID}
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      accessibilityState={{ disabled }}
+      disabled={disabled}
+      onPress={onPress}
+      className={`flex-1 rounded-full px-6 py-3 ${
+        disabled ? "bg-muted" : "bg-primary"
+      }`}
+    >
+      <Text
+        className={`text-center text-sm font-semibold ${
+          disabled ? "text-muted-foreground" : "text-primary-foreground"
+        }`}
+      >
+        {label}
+      </Text>
+    </Pressable>
+  );
+}
+
+function DeckLoading() {
+  return (
+    <Text
+      testID="card-deck-loading"
+      className="text-center text-sm text-muted-foreground"
+    >
+      Loading cards…
+    </Text>
+  );
+}
+
+function DeckError() {
+  return (
+    <View testID="card-deck-error" className="items-center">
+      <Text className="text-center text-lg font-semibold text-foreground">
+        Couldn't load cards
+      </Text>
+      <Text className="mt-2 text-center text-sm text-muted-foreground">
+        Something went wrong loading your conversation starters. Please try
+        again.
+      </Text>
+    </View>
+  );
+}
+
+function DeckEmpty({ language }: { language: string }) {
+  return (
+    <View testID="card-deck-empty" className="items-center">
+      <Text className="text-center text-lg font-semibold text-foreground">
+        No cards yet
+      </Text>
+      <Text className="mt-2 text-center text-sm text-muted-foreground">
+        We don't have conversation starters for {language} yet. Check back soon.
+      </Text>
+    </View>
+  );
+}

--- a/apps/native/components/conversation-starters/card-language-picker.tsx
+++ b/apps/native/components/conversation-starters/card-language-picker.tsx
@@ -1,0 +1,85 @@
+import { Pressable, Text, View } from "react-native";
+
+import { getLanguageFlag, getNativeName } from "@/utils/language-flags";
+
+export type ProfileLanguage = {
+  language: string;
+  type: "spoken" | "learning";
+};
+
+/**
+ * De-duplicate the buddy's profile languages into the picker's option list.
+ *
+ * A language a buddy both speaks and is learning must appear exactly once. The
+ * first occurrence wins so the original profile order is preserved.
+ */
+export function dedupeLanguages(languages: ProfileLanguage[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const { language } of languages) {
+    if (seen.has(language)) {
+      continue;
+    }
+    seen.add(language);
+    result.push(language);
+  }
+  return result;
+}
+
+type CardLanguagePickerProps = {
+  /** The buddy's profile languages (spoken + learning, possibly overlapping). */
+  languages: ProfileLanguage[];
+  /** The currently active card language, or null when nothing is selected yet. */
+  activeLanguage: string | null;
+  /** Called with the chosen language when the buddy taps an option. */
+  onSelect: (language: string) => void;
+};
+
+/**
+ * Lets a buddy pick which of *their own* profile languages to browse cards in.
+ *
+ * Shows only the de-duplicated union of the buddy's spoken + learning
+ * languages — never the full catalogue — each with its flag and native name.
+ * The active option is announced as selected for accessibility.
+ */
+export function CardLanguagePicker({
+  languages,
+  activeLanguage,
+  onSelect,
+}: CardLanguagePickerProps) {
+  const options = dedupeLanguages(languages);
+
+  return (
+    <View testID="card-language-picker" accessibilityRole="radiogroup">
+      <Text className="mb-3 text-center text-sm font-semibold text-foreground">
+        Pick a language to practise
+      </Text>
+      <View className="gap-2">
+        {options.map((language) => {
+          const isActive = language === activeLanguage;
+          return (
+            <Pressable
+              key={language}
+              testID={`card-language-option-${language}`}
+              accessibilityRole="button"
+              accessibilityState={{ selected: isActive }}
+              onPress={() => onSelect(language)}
+              className={`flex-row items-center gap-3 rounded-2xl px-4 py-3 ${
+                isActive ? "bg-primary" : "bg-muted"
+              }`}
+            >
+              <Text style={{ fontSize: 24 }}>{getLanguageFlag(language)}</Text>
+              <Text
+                className={`text-base font-semibold ${
+                  isActive ? "text-primary-foreground" : "text-foreground"
+                }`}
+              >
+                {getNativeName(language)}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </View>
+    </View>
+  );
+}

--- a/apps/native/eas.json
+++ b/apps/native/eas.json
@@ -21,6 +21,10 @@
     }
   },
   "submit": {
-    "production": {}
+    "production": {
+      "android": {
+        "track": "internal"
+      }
+    }
   }
 }

--- a/apps/native/package.json
+++ b/apps/native/package.json
@@ -20,7 +20,7 @@
     "@expo/metro-runtime": "~55.0.6",
     "@expo/vector-icons": "^15.0.3",
     "@gorhom/bottom-sheet": "^5",
-    "@react-native-async-storage/async-storage": "^3.0.3",
+    "@react-native-async-storage/async-storage": "3.1.1",
     "@react-native-community/datetimepicker": "^9.1.0",
     "@react-navigation/drawer": "^7.3.9",
     "@react-navigation/elements": "^2.8.1",

--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
         "@expo/metro-runtime": "~55.0.6",
         "@expo/vector-icons": "^15.0.3",
         "@gorhom/bottom-sheet": "^5",
-        "@react-native-async-storage/async-storage": "^3.0.3",
+        "@react-native-async-storage/async-storage": "3.1.1",
         "@react-native-community/datetimepicker": "^9.1.0",
         "@react-navigation/drawer": "^7.3.9",
         "@react-navigation/elements": "^2.8.1",
@@ -889,7 +889,7 @@
 
     "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
 
-    "@react-native-async-storage/async-storage": ["@react-native-async-storage/async-storage@3.0.3", "", { "dependencies": { "idb": "8.0.3" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-YDe/BLYns3Q9YL0DHGStDA2uH0imxC65v3XdID6dQNlelR/d5W/u3CHxJqoHNA/0HJKbmwDFQYlBWMHlyir0FA=="],
+    "@react-native-async-storage/async-storage": ["@react-native-async-storage/async-storage@3.1.1", "", { "dependencies": { "idb": "8.0.3" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-z+PnLz1n6ECKhgoHZHkfc+dijXZEyZnNFSajbtE0NEbsJhmX8x9GlOeiMQIKX2E4DUqPSgfIh4FYBv1M49KgPQ=="],
 
     "@react-native-community/datetimepicker": ["@react-native-community/datetimepicker@9.1.0", "", { "dependencies": { "invariant": "^2.2.4" }, "peerDependencies": { "expo": ">=52.0.0", "react": "*", "react-native": "*", "react-native-windows": "*" }, "optionalPeers": ["expo", "react-native-windows"] }, "sha512-eadbnk+I2vxvW30iTAsm/qlCnMMAadkifIMYNEB2lzhxN/SvlKc7S2V4k5DyrwjdCbqdcMk3t9K6fnUMcAV34w=="],
 

--- a/packages/api/src/contexts/conversation-practice/__tests__/starter-content.test.ts
+++ b/packages/api/src/contexts/conversation-practice/__tests__/starter-content.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for:
+ *   #404 — Curate and serve conversation-starter content per language
+ *
+ * Covers the curated content module and its pure lookup helper. The four
+ * Gherkin scenarios from #404 are each named in an `it` block below.
+ */
+import { describe, expect, it } from "bun:test";
+
+import {
+  CURATED_LANGUAGES,
+  STARTER_CARDS,
+  getStartersForLanguage,
+} from "../starter-content";
+
+describe("#404 — curated conversation-starter content", () => {
+  it("Scenario: At least 30 cards per selectable language", () => {
+    expect(CURATED_LANGUAGES.length).toBeGreaterThan(0);
+    for (const language of CURATED_LANGUAGES) {
+      const cards = getStartersForLanguage(language);
+      expect(cards.length).toBeGreaterThanOrEqual(30);
+    }
+  });
+
+  it("Scenario: Each card carries an English translation", () => {
+    for (const language of CURATED_LANGUAGES) {
+      for (const card of getStartersForLanguage(language)) {
+        expect(typeof card.id).toBe("string");
+        expect(card.id.length).toBeGreaterThan(0);
+        expect(typeof card.text).toBe("string");
+        expect(card.text.trim().length).toBeGreaterThan(0);
+        expect(typeof card.translation).toBe("string");
+        expect(card.translation.trim().length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("Scenario: Each card carries an English translation — English maps translation === text", () => {
+    for (const card of getStartersForLanguage("English")) {
+      expect(card.translation).toBe(card.text);
+    }
+  });
+
+  it("Scenario: Uncurated language returns no cards", () => {
+    expect(getStartersForLanguage("Klingon")).toEqual([]);
+    expect(getStartersForLanguage("")).toEqual([]);
+    expect(getStartersForLanguage("dutch")).toEqual([]); // case-sensitive key
+  });
+
+  it("Scenario: Card order is stable", () => {
+    for (const language of CURATED_LANGUAGES) {
+      const first = getStartersForLanguage(language);
+      const second = getStartersForLanguage(language);
+      expect(second.map((c) => c.id)).toEqual(first.map((c) => c.id));
+      expect(second.map((c) => c.text)).toEqual(first.map((c) => c.text));
+    }
+  });
+
+  it("assigns unique, language-prefixed, stable ids within each language", () => {
+    for (const language of CURATED_LANGUAGES) {
+      const ids = getStartersForLanguage(language).map((c) => c.id);
+      expect(new Set(ids).size).toBe(ids.length);
+    }
+    expect(getStartersForLanguage("Dutch")[0]?.id).toBe("nl-001");
+    expect(getStartersForLanguage("English")[0]?.id).toBe("en-001");
+  });
+
+  it("curates English, Dutch, Spanish, German and French", () => {
+    expect(CURATED_LANGUAGES).toEqual(
+      expect.arrayContaining(["English", "Dutch", "Spanish", "German", "French"]),
+    );
+  });
+
+  it("exposes the same number of cards per language (aligned deck positions)", () => {
+    const counts = CURATED_LANGUAGES.map((l) => STARTER_CARDS[l]?.length ?? 0);
+    expect(new Set(counts).size).toBe(1);
+  });
+});

--- a/packages/api/src/contexts/conversation-practice/__tests__/starters.test.ts
+++ b/packages/api/src/contexts/conversation-practice/__tests__/starters.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Integration test for:
+ *   #404 — content.starters.listByLanguage
+ *
+ * Drives the real tRPC caller so the procedure contract (input validation,
+ * protected access, response shape) is verified through the actual router.
+ */
+import "../../../__test-support__/harness";
+
+import { describe, it, expect } from "bun:test";
+
+import { appRouter } from "../../../routers";
+import { buildSessionContext } from "../../../__test-support__/harness";
+
+const USER_ID = "u-starters";
+
+function caller() {
+  return appRouter.createCaller(buildSessionContext(USER_ID));
+}
+
+describe("#404 — content.starters.listByLanguage", () => {
+  it("Scenario: At least 30 cards per selectable language", async () => {
+    const result = await caller().content.starters.listByLanguage({ language: "Dutch" });
+    expect(result.language).toBe("Dutch");
+    expect(result.cards.length).toBeGreaterThanOrEqual(30);
+  });
+
+  it("Scenario: Each card carries an English translation", async () => {
+    const result = await caller().content.starters.listByLanguage({ language: "Dutch" });
+    const card = result.cards[0];
+    expect(card?.text.trim().length).toBeGreaterThan(0);
+    expect(card?.translation.trim().length).toBeGreaterThan(0);
+    expect(card?.text).not.toBe(card?.translation); // Dutch text differs from English
+  });
+
+  it("Scenario: Uncurated language returns no cards", async () => {
+    const result = await caller().content.starters.listByLanguage({ language: "Klingon" });
+    expect(result).toEqual({ language: "Klingon", cards: [] });
+  });
+
+  it("Scenario: Card order is stable", async () => {
+    const a = await caller().content.starters.listByLanguage({ language: "Spanish" });
+    const b = await caller().content.starters.listByLanguage({ language: "Spanish" });
+    expect(b.cards.map((c) => c.id)).toEqual(a.cards.map((c) => c.id));
+  });
+
+  it("echoes the requested language back in the response", async () => {
+    const result = await caller().content.starters.listByLanguage({ language: "French" });
+    expect(result.language).toBe("French");
+    expect(result.cards.length).toBeGreaterThanOrEqual(30);
+  });
+
+  it("requires authentication (protected procedure)", async () => {
+    const anonCaller = appRouter.createCaller({ session: null } as never);
+    await expect(
+      anonCaller.content.starters.listByLanguage({ language: "Dutch" }),
+    ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+  });
+});

--- a/packages/api/src/contexts/conversation-practice/content.ts
+++ b/packages/api/src/contexts/conversation-practice/content.ts
@@ -1,0 +1,10 @@
+import { router } from "../../index";
+import { startersRouter } from "./starters";
+
+/**
+ * Conversation Practice content context. Nests the `starters` sub-router so the
+ * client contract resolves to `content.starters.listByLanguage`.
+ */
+export const contentRouter = router({
+  starters: startersRouter,
+});

--- a/packages/api/src/contexts/conversation-practice/index.ts
+++ b/packages/api/src/contexts/conversation-practice/index.ts
@@ -1,0 +1,7 @@
+export { contentRouter } from "./content";
+export {
+  STARTER_CARDS,
+  CURATED_LANGUAGES,
+  getStartersForLanguage,
+  type StarterCard,
+} from "./starter-content";

--- a/packages/api/src/contexts/conversation-practice/starter-content.ts
+++ b/packages/api/src/contexts/conversation-practice/starter-content.ts
@@ -1,0 +1,229 @@
+/**
+ * Hand-curated conversation-starter content (Task #404, Feature #378, Epic #375).
+ *
+ * Static, version-controlled content — no database table, no migration. Each
+ * selectable language carries at least 30 basic, conversational question cards.
+ * Every card has `text` in that language and a non-empty English `translation`
+ * (for English, `translation === text`). Card order is stable: it is the source
+ * array order, which never changes between requests.
+ */
+
+export interface StarterCard {
+  /** Stable, unique id (language-prefixed, e.g. "nl-001"). */
+  id: string;
+  /** Question text in the card's language. */
+  text: string;
+  /** English translation; non-empty (equals `text` for English). */
+  translation: string;
+}
+
+/**
+ * The 30 basic conversation-starter questions, in English. Every other curated
+ * language is a translation of this same ordered set, so the deck position
+ * indicator lines up across languages.
+ */
+const ENGLISH_STARTERS: readonly string[] = [
+  "How are you today?",
+  "What is your name?",
+  "Where are you from?",
+  "What do you do for work?",
+  "What did you do this weekend?",
+  "Do you have any brothers or sisters?",
+  "What is your favourite food?",
+  "Do you like coffee or tea?",
+  "What music do you like?",
+  "What is your favourite film?",
+  "Do you have any pets?",
+  "What do you like to do in your free time?",
+  "Have you travelled anywhere nice recently?",
+  "What is your favourite season?",
+  "Do you prefer the city or the countryside?",
+  "What languages do you speak?",
+  "Why are you learning this language?",
+  "What is the weather like today?",
+  "What time do you usually wake up?",
+  "Do you play any sports?",
+  "What did you have for breakfast?",
+  "What is your favourite book?",
+  "Do you like to cook?",
+  "What is your dream holiday?",
+  "What makes you happy?",
+  "Do you have any plans for the weekend?",
+  "What is your favourite place in this city?",
+  "How do you usually get to work?",
+  "What is something new you learned recently?",
+  "What are you looking forward to this week?",
+];
+
+/** Localised question text, in the exact same order as `ENGLISH_STARTERS`. */
+const TRANSLATIONS: Record<string, readonly string[]> = {
+  English: ENGLISH_STARTERS,
+  Dutch: [
+    "Hoe gaat het vandaag met je?",
+    "Wat is je naam?",
+    "Waar kom je vandaan?",
+    "Wat voor werk doe je?",
+    "Wat heb je dit weekend gedaan?",
+    "Heb je broers of zussen?",
+    "Wat is je lievelingseten?",
+    "Hou je van koffie of thee?",
+    "Naar welke muziek luister je graag?",
+    "Wat is je favoriete film?",
+    "Heb je huisdieren?",
+    "Wat doe je graag in je vrije tijd?",
+    "Ben je onlangs ergens leuks geweest?",
+    "Wat is je favoriete seizoen?",
+    "Hou je meer van de stad of het platteland?",
+    "Welke talen spreek je?",
+    "Waarom leer je deze taal?",
+    "Wat voor weer is het vandaag?",
+    "Hoe laat sta je meestal op?",
+    "Doe je aan sport?",
+    "Wat heb je als ontbijt gegeten?",
+    "Wat is je favoriete boek?",
+    "Hou je van koken?",
+    "Wat is je droomvakantie?",
+    "Waar word je blij van?",
+    "Heb je plannen voor het weekend?",
+    "Wat is je favoriete plek in deze stad?",
+    "Hoe ga je meestal naar je werk?",
+    "Wat heb je onlangs nieuws geleerd?",
+    "Waar kijk je deze week naar uit?",
+  ],
+  Spanish: [
+    "¿Cómo estás hoy?",
+    "¿Cómo te llamas?",
+    "¿De dónde eres?",
+    "¿A qué te dedicas?",
+    "¿Qué hiciste este fin de semana?",
+    "¿Tienes hermanos o hermanas?",
+    "¿Cuál es tu comida favorita?",
+    "¿Prefieres el café o el té?",
+    "¿Qué música te gusta?",
+    "¿Cuál es tu película favorita?",
+    "¿Tienes mascotas?",
+    "¿Qué te gusta hacer en tu tiempo libre?",
+    "¿Has viajado a algún lugar bonito últimamente?",
+    "¿Cuál es tu estación favorita?",
+    "¿Prefieres la ciudad o el campo?",
+    "¿Qué idiomas hablas?",
+    "¿Por qué estás aprendiendo este idioma?",
+    "¿Qué tiempo hace hoy?",
+    "¿A qué hora te levantas normalmente?",
+    "¿Practicas algún deporte?",
+    "¿Qué desayunaste?",
+    "¿Cuál es tu libro favorito?",
+    "¿Te gusta cocinar?",
+    "¿Cuáles son tus vacaciones soñadas?",
+    "¿Qué te hace feliz?",
+    "¿Tienes planes para el fin de semana?",
+    "¿Cuál es tu lugar favorito de esta ciudad?",
+    "¿Cómo vas normalmente al trabajo?",
+    "¿Qué has aprendido de nuevo últimamente?",
+    "¿Qué esperas con ganas esta semana?",
+  ],
+  German: [
+    "Wie geht es dir heute?",
+    "Wie heißt du?",
+    "Woher kommst du?",
+    "Was machst du beruflich?",
+    "Was hast du dieses Wochenende gemacht?",
+    "Hast du Geschwister?",
+    "Was ist dein Lieblingsessen?",
+    "Magst du lieber Kaffee oder Tee?",
+    "Welche Musik magst du?",
+    "Was ist dein Lieblingsfilm?",
+    "Hast du Haustiere?",
+    "Was machst du gern in deiner Freizeit?",
+    "Warst du in letzter Zeit irgendwo Schönes?",
+    "Was ist deine Lieblingsjahreszeit?",
+    "Magst du lieber die Stadt oder das Land?",
+    "Welche Sprachen sprichst du?",
+    "Warum lernst du diese Sprache?",
+    "Wie ist das Wetter heute?",
+    "Wann stehst du normalerweise auf?",
+    "Treibst du Sport?",
+    "Was hast du zum Frühstück gegessen?",
+    "Was ist dein Lieblingsbuch?",
+    "Kochst du gern?",
+    "Was ist dein Traumurlaub?",
+    "Was macht dich glücklich?",
+    "Hast du Pläne für das Wochenende?",
+    "Was ist dein Lieblingsort in dieser Stadt?",
+    "Wie kommst du normalerweise zur Arbeit?",
+    "Was hast du in letzter Zeit Neues gelernt?",
+    "Worauf freust du dich diese Woche?",
+  ],
+  French: [
+    "Comment vas-tu aujourd'hui ?",
+    "Comment t'appelles-tu ?",
+    "D'où viens-tu ?",
+    "Que fais-tu dans la vie ?",
+    "Qu'as-tu fait ce week-end ?",
+    "As-tu des frères ou des sœurs ?",
+    "Quel est ton plat préféré ?",
+    "Préfères-tu le café ou le thé ?",
+    "Quelle musique aimes-tu ?",
+    "Quel est ton film préféré ?",
+    "As-tu des animaux de compagnie ?",
+    "Qu'aimes-tu faire pendant ton temps libre ?",
+    "As-tu voyagé quelque part de joli récemment ?",
+    "Quelle est ta saison préférée ?",
+    "Préfères-tu la ville ou la campagne ?",
+    "Quelles langues parles-tu ?",
+    "Pourquoi apprends-tu cette langue ?",
+    "Quel temps fait-il aujourd'hui ?",
+    "À quelle heure te lèves-tu d'habitude ?",
+    "Pratiques-tu un sport ?",
+    "Qu'as-tu mangé au petit-déjeuner ?",
+    "Quel est ton livre préféré ?",
+    "Aimes-tu cuisiner ?",
+    "Quelles sont tes vacances de rêve ?",
+    "Qu'est-ce qui te rend heureux ?",
+    "As-tu des projets pour le week-end ?",
+    "Quel est ton endroit préféré dans cette ville ?",
+    "Comment vas-tu au travail d'habitude ?",
+    "Qu'as-tu appris de nouveau récemment ?",
+    "Qu'attends-tu avec impatience cette semaine ?",
+  ],
+};
+
+/** Two-letter id prefix per curated language, matching `language-flags` codes. */
+const ID_PREFIX: Record<string, string> = {
+  English: "en",
+  Dutch: "nl",
+  Spanish: "es",
+  German: "de",
+  French: "fr",
+};
+
+function buildCards(language: string): StarterCard[] {
+  const texts = TRANSLATIONS[language];
+  if (!texts) return [];
+  const prefix = ID_PREFIX[language] ?? language.slice(0, 2).toLowerCase();
+  return texts.map((text, index) => ({
+    id: `${prefix}-${String(index + 1).padStart(3, "0")}`,
+    text,
+    translation: ENGLISH_STARTERS[index] ?? text,
+  }));
+}
+
+/**
+ * Curated cards keyed by language. Built once at module load so the array
+ * identity — and therefore the order — is stable across every request.
+ */
+export const STARTER_CARDS: Readonly<Record<string, readonly StarterCard[]>> =
+  Object.fromEntries(
+    Object.keys(TRANSLATIONS).map((language) => [language, buildCards(language)]),
+  );
+
+/** Languages that currently have curated content. */
+export const CURATED_LANGUAGES: readonly string[] = Object.keys(STARTER_CARDS);
+
+/**
+ * Ordered curated cards for a language, or an empty array when the language has
+ * no curated content yet (so the deck can show a "no cards yet" state).
+ */
+export function getStartersForLanguage(language: string): readonly StarterCard[] {
+  return STARTER_CARDS[language] ?? [];
+}

--- a/packages/api/src/contexts/conversation-practice/starters.ts
+++ b/packages/api/src/contexts/conversation-practice/starters.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+import { protectedProcedure, router } from "../../index";
+import { getStartersForLanguage, type StarterCard } from "./starter-content";
+
+/**
+ * Read-only serving layer for curated conversation-starter content
+ * (Task #404, Feature #378).
+ *
+ * `listByLanguage` returns the ordered cards for the requested language, or an
+ * empty list for an unknown / uncurated language so the deck can render a
+ * "no cards yet" state instead of a blank screen.
+ */
+export const startersRouter = router({
+  listByLanguage: protectedProcedure
+    .input(z.object({ language: z.string() }))
+    .query(({ input }): { language: string; cards: StarterCard[] } => {
+      return {
+        language: input.language,
+        cards: [...getStartersForLanguage(input.language)],
+      };
+    }),
+});

--- a/packages/api/src/routers/index.ts
+++ b/packages/api/src/routers/index.ts
@@ -6,6 +6,7 @@ import { adminVenueRouter } from "../contexts/scheduling/venue-admin";
 import { meetupRouter } from "../contexts/scheduling/meetup";
 import { chatRouter, messagingRouter } from "../contexts/conversation";
 import { moderationRouter } from "../contexts/moderation";
+import { contentRouter } from "../contexts/conversation-practice";
 
 export const appRouter = router({
   healthCheck: publicProcedure.query(() => {
@@ -25,5 +26,6 @@ export const appRouter = router({
   chat: chatRouter,
   messaging: messagingRouter,
   moderation: moderationRouter,
+  content: contentRouter,
 });
 export type AppRouter = typeof appRouter;


### PR DESCRIPTION
## Summary

Implements Epic #375 — **Conversation starter cards for meet-ups**. Adds a dedicated "Conversation Starters" tab where a buddy picks one of their own profile languages and flips through a curated deck of basic conversation-starter questions, tapping any card to reveal its English translation. Gives buddies something concrete to ask their partner during a meet-up, in the language they came to practice.

Delivered as a new **Conversation Practice** bounded context (static, hand-curated content served read-only) plus the native tab/screen/picker/deck/translation UI. No database schema change.

## Changes

- **Content (api):** new `conversation-practice` context serving `content.starters.listByLanguage` (read-only). 5 languages × 30 hand-curated cards (English, Dutch, Spanish, German, French), each with `text` + English `translation`; uncurated languages return an empty set; stable order. (#404)
- **Tab + screen (native):** "Conversation Starters" tab in the bottom nav and its screen. (#380)
- **Profile-language gate (native):** screen reads the buddy's profile languages via the existing profile query — loading / error / empty ("add a language") / ready states. (#381)
- **Language picker (native):** de-duplicated union of spoken + learning profile languages (flag + native name); single language auto-selects and collapses; active language held in screen-local state. (#403)
- **Deck browser (native):** index-based Next/Previous stepper (no wrap-around), `N / M` position indicator, end-disabling, "no cards yet" empty state, resets to first card on language change. (#405)
- **Tap-to-reveal translation (native):** per-card toggle between chosen language and English; resets on navigation; no-op + hidden affordance when the chosen language is English; a11y-announced. (#406)

## Test plan

- [x] Conversation Starters tab is visible and opens its screen
- [x] Screen gates on profile languages (loading / error / empty / ready)
- [x] Picker lists only profile languages, de-duped; single language auto-selects
- [x] Selecting a language activates it and persists while on the tab
- [x] Deck shows first card on open; Next/Previous step with no wrap-around; position indicator correct
- [x] Empty language shows "no cards yet"; switching language resets to first card
- [x] At least 30 cards per curated language, each with an English translation; uncurated → empty
- [x] Tap reveals/hides English translation per-card; resets on navigation; English is a no-op
- [x] `bun run check-types` clean; conversation-starters jest suite green (5 suites / 34 tests)

> Note: this branch also carries two pre-existing main-local commits that were never pushed to origin/main (`async-storage` Android build fix, eas internal track) — unrelated to the epic but legitimately belong on main.

## Related

Closes #375
Closes #376
Closes #377
Closes #378
Closes #379
Closes #380
Closes #381
Closes #403
Closes #404
Closes #405
Closes #406
