### PR TITLE
feat(auth): send OTP emails via Resend, keep logging

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -193,6 +193,7 @@
         "better-auth": "catalog:",
         "dotenv": "catalog:",
         "drizzle-orm": "^0.45.1",
+        "resend": "^6.14.0",
         "zod": "catalog:",
       },
       "devDependencies": {
@@ -2443,6 +2444,8 @@
 
     "pngjs": ["pngjs@3.4.0", "", {}, "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w=="],
 
+    "postal-mime": ["postal-mime@2.7.4", "", {}, "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g=="],
+
     "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
 
     "postcss-selector-parser": ["postcss-selector-parser@7.1.1", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg=="],
@@ -2588,6 +2591,8 @@
     "requires-port": ["requires-port@1.0.0", "", {}, "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="],
 
     "reselect": ["reselect@5.1.1", "", {}, "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="],
+
+    "resend": ["resend@6.14.0", "", { "dependencies": { "postal-mime": "2.7.4", "standardwebhooks": "1.0.0" }, "peerDependencies": { "@react-email/render": "*" }, "optionalPeers": ["@react-email/render"] }, "sha512-jVdpUgOoWGLjaP64lo8KwzHT9gY4w6Dl8c36CIb2F+ayYOMLr3khqs8xrNjXM2k19b+lPoj0VWQFhVNLiToBjA=="],
 
     "resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
 

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -21,6 +21,7 @@
     "better-auth": "catalog:",
     "dotenv": "catalog:",
     "drizzle-orm": "^0.45.1",
+    "resend": "^6.14.0",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -7,8 +7,11 @@ import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { emailOTP } from "better-auth/plugins";
 import { eq } from "drizzle-orm";
+import { Resend } from "resend";
 
 import { polarClient } from "./lib/payments";
+
+const resend = env.RESEND_API_KEY ? new Resend(env.RESEND_API_KEY) : null;
 
 export function createAuth() {
   const db = createDb();
@@ -92,8 +95,23 @@ export function createAuth() {
         expiresIn: 600, // 10 minutes
         generateOTP: () => "310394",
         async sendVerificationOTP({ email, otp, type }) {
-          // TODO: Replace with real email provider (Resend, SendGrid, etc.)
+          // Always log the code (dev/debug visibility)
           console.log(`[OTP] ${type} → ${email}: ${otp}`);
+
+          if (!resend || !env.RESEND_FROM) {
+            return;
+          }
+
+          try {
+            await resend.emails.send({
+              from: env.RESEND_FROM,
+              to: email,
+              subject: "Your Sip & Speak verification code",
+              text: `Your verification code is ${otp}. It expires in 10 minutes.`,
+            });
+          } catch (e) {
+            console.error("[resend] OTP send failed for", email, e instanceof Error ? e.message : e);
+          }
         },
       }),
     ],

--- a/packages/env/src/server.ts
+++ b/packages/env/src/server.ts
@@ -10,6 +10,8 @@ export const env = createEnv({
     POLAR_ACCESS_TOKEN: z.string().min(1),
     POLAR_SUCCESS_URL: z.url(),
     CORS_ORIGIN: z.url(),
+    RESEND_API_KEY: z.string().min(1).optional(),
+    RESEND_FROM: z.email().optional(),
     NODE_ENV: z.enum(["development", "production", "test"]).default("development"),
   },
   runtimeEnv: process.env,


### PR DESCRIPTION
## Summary
- Wire Resend into `emailOTP.sendVerificationOTP`
- Falls back to log-only when `RESEND_API_KEY`/`RESEND_FROM` are unset — dev flow unchanged
- OTP always `console.log`ged for debug visibility

## Config
Set `RESEND_API_KEY` + `RESEND_FROM` (verified Resend domain) in server env to activate sending.

## Note
`generateOTP` still returns a hardcoded `"310394"` (pre-existing). Real email delivery of a fixed code is a prod security hole — flagged for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)