### PR TITLE
feat(web): add public /delete-account instructions page

### DIFF
--- a/apps/web/src/__tests__/delete-account.test.tsx
+++ b/apps/web/src/__tests__/delete-account.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * Tests for task #419 — Public /delete-account route with deletion instructions
+ *
+ * Covers:
+ *   - Page renders without authentication and shows the in-app deletion steps
+ *   - Page discloses the full cascade of deleted data (profile, matches, chats, meet-ups)
+ *   - Page states deletion is immediate and irreversible with no recovery
+ *   - Page notes data retention
+ */
+import { render, screen, within } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => () => null,
+}));
+
+import { DeleteAccountPage } from "@/routes/delete-account";
+
+describe("#419 — public /delete-account instructions page", () => {
+  it("renders without authentication and shows the in-app deletion steps", () => {
+    render(<DeleteAccountPage />);
+
+    const heading = screen.getByRole("heading", { level: 1 });
+    expect(heading).toHaveTextContent(/delete your sip & speak account/i);
+
+    expect(screen.getByText(/go to your Profile/i)).toBeInTheDocument();
+    expect(screen.getByText(/Tap Delete account/i)).toBeInTheDocument();
+    expect(screen.getByText(/Confirm when prompted/i)).toBeInTheDocument();
+  });
+
+  it("discloses that all associated data is deleted and lists it", () => {
+    render(<DeleteAccountPage />);
+
+    expect(
+      screen.getByText(/permanently deletes all associated data/i),
+    ).toBeInTheDocument();
+
+    const deletedData = within(screen.getByTestId("deleted-data"));
+    expect(deletedData.getByText("Your profile")).toBeInTheDocument();
+    expect(deletedData.getByText("Your matches")).toBeInTheDocument();
+    expect(deletedData.getByText("Your chats")).toBeInTheDocument();
+    expect(deletedData.getByText("Your meet-ups")).toBeInTheDocument();
+  });
+
+  it("states deletion is immediate and irreversible with no recovery", () => {
+    render(<DeleteAccountPage />);
+
+    expect(screen.getByText(/immediate and irreversible/i)).toBeInTheDocument();
+    expect(screen.getByText(/no recovery/i)).toBeInTheDocument();
+  });
+
+  it("notes data retention", () => {
+    render(<DeleteAccountPage />);
+
+    expect(
+      screen.getByText(/retention note is provisional/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as SuggestionsRouteImport } from './routes/suggestions'
 import { Route as SuccessRouteImport } from './routes/success'
 import { Route as LoginRouteImport } from './routes/login'
+import { Route as DeleteAccountRouteImport } from './routes/delete-account'
 import { Route as DashboardRouteImport } from './routes/dashboard'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as PartnerIdRouteImport } from './routes/partner/$id'
@@ -32,6 +33,11 @@ const SuccessRoute = SuccessRouteImport.update({
 const LoginRoute = LoginRouteImport.update({
   id: '/login',
   path: '/login',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const DeleteAccountRoute = DeleteAccountRouteImport.update({
+  id: '/delete-account',
+  path: '/delete-account',
   getParentRoute: () => rootRouteImport,
 } as any)
 const DashboardRoute = DashboardRouteImport.update({
@@ -68,6 +74,7 @@ const ModeratorFlagsFlagIdRoute = ModeratorFlagsFlagIdRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/dashboard': typeof DashboardRoute
+  '/delete-account': typeof DeleteAccountRoute
   '/login': typeof LoginRoute
   '/success': typeof SuccessRoute
   '/suggestions': typeof SuggestionsRoute
@@ -79,6 +86,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/dashboard': typeof DashboardRoute
+  '/delete-account': typeof DeleteAccountRoute
   '/login': typeof LoginRoute
   '/success': typeof SuccessRoute
   '/suggestions': typeof SuggestionsRoute
@@ -91,6 +99,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/dashboard': typeof DashboardRoute
+  '/delete-account': typeof DeleteAccountRoute
   '/login': typeof LoginRoute
   '/success': typeof SuccessRoute
   '/suggestions': typeof SuggestionsRoute
@@ -104,6 +113,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/dashboard'
+    | '/delete-account'
     | '/login'
     | '/success'
     | '/suggestions'
@@ -115,6 +125,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/dashboard'
+    | '/delete-account'
     | '/login'
     | '/success'
     | '/suggestions'
@@ -126,6 +137,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/dashboard'
+    | '/delete-account'
     | '/login'
     | '/success'
     | '/suggestions'
@@ -138,6 +150,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   DashboardRoute: typeof DashboardRoute
+  DeleteAccountRoute: typeof DeleteAccountRoute
   LoginRoute: typeof LoginRoute
   SuccessRoute: typeof SuccessRoute
   SuggestionsRoute: typeof SuggestionsRoute
@@ -167,6 +180,13 @@ declare module '@tanstack/react-router' {
       path: '/login'
       fullPath: '/login'
       preLoaderRoute: typeof LoginRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/delete-account': {
+      id: '/delete-account'
+      path: '/delete-account'
+      fullPath: '/delete-account'
+      preLoaderRoute: typeof DeleteAccountRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/dashboard': {
@@ -229,6 +249,7 @@ const ModeratorFlagsRouteWithChildren = ModeratorFlagsRoute._addFileChildren(
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   DashboardRoute: DashboardRoute,
+  DeleteAccountRoute: DeleteAccountRoute,
   LoginRoute: LoginRoute,
   SuccessRoute: SuccessRoute,
   SuggestionsRoute: SuggestionsRoute,

--- a/apps/web/src/routes/delete-account.tsx
+++ b/apps/web/src/routes/delete-account.tsx
@@ -1,0 +1,67 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/delete-account")({
+  component: DeleteAccountPage,
+});
+
+const DELETED_DATA = [
+  "Your profile",
+  "Your matches",
+  "Your chats",
+  "Your meet-ups",
+];
+
+export function DeleteAccountPage() {
+  return (
+    <main className="container mx-auto max-w-2xl px-4 py-8">
+      <h1 className="mb-4 text-2xl font-bold">
+        Delete your Sip &amp; Speak account and data
+      </h1>
+
+      <p className="mb-6 text-muted-foreground">
+        You can permanently delete your Sip &amp; Speak account and all of your
+        personal data at any time. This page explains how.
+      </p>
+
+      <section className="mb-6">
+        <h2 className="mb-2 text-xl font-semibold">Delete from the app</h2>
+        <ol className="list-decimal space-y-1 pl-6">
+          <li>Open the Sip &amp; Speak app and go to your Profile.</li>
+          <li>Tap Delete account.</li>
+          <li>Confirm when prompted.</li>
+        </ol>
+      </section>
+
+      <section className="mb-6">
+        <h2 className="mb-2 text-xl font-semibold">What gets deleted</h2>
+        <p className="mb-2">
+          Deleting your account permanently deletes all associated data. This
+          includes:
+        </p>
+        <ul className="list-disc space-y-1 pl-6" data-testid="deleted-data">
+          {DELETED_DATA.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="mb-6">
+        <h2 className="mb-2 text-xl font-semibold">This cannot be undone</h2>
+        <p>
+          Deletion is immediate and irreversible. There is no recovery and no
+          grace period — once your account is deleted, it and its data cannot be
+          restored.
+        </p>
+      </section>
+
+      <section className="mb-6">
+        <h2 className="mb-2 text-xl font-semibold">Data retention</h2>
+        <p>
+          Some limited records may be retained where required (for example, to
+          comply with legal obligations). This retention note is provisional and
+          will be finalized once our data-deletion audit is complete.
+        </p>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
Implements #419 — public, no-login `/delete-account` page with deletion instructions.

- In-app steps (Profile → Delete account → confirm)
- Cascade disclosure (profile, matches, chats, meet-ups), irreversible/no-recovery warning, provisional retention note
- Tests: `apps/web/src/__tests__/delete-account.test.tsx` (4 passing)

Closes #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)