### PR TITLE
feat(web): add email deletion-request section to /delete-account

### DIFF
--- a/apps/web/src/__tests__/delete-account.test.tsx
+++ b/apps/web/src/__tests__/delete-account.test.tsx
@@ -57,3 +57,28 @@ describe("#419 — public /delete-account instructions page", () => {
     ).toBeInTheDocument();
   });
 });
+
+describe("#423 — email fallback for members who cannot access the app", () => {
+  it("offers an email path to request deletion", () => {
+    render(<DeleteAccountPage />);
+
+    const link = screen.getByRole("link", {
+      name: /hello@sipandspeak\.nl/i,
+    });
+    expect(link).toHaveAttribute("href", "mailto:hello@sipandspeak.nl");
+  });
+
+  it("states the member must email from the address linked to their account", () => {
+    render(<DeleteAccountPage />);
+
+    expect(
+      screen.getByText(/from the address linked to your account/i),
+    ).toBeInTheDocument();
+  });
+
+  it("states the 30-day fulfillment window", () => {
+    render(<DeleteAccountPage />);
+
+    expect(screen.getByText(/within 30 days of a verified/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/routes/delete-account.tsx
+++ b/apps/web/src/routes/delete-account.tsx
@@ -11,6 +11,8 @@ const DELETED_DATA = [
   "Your meet-ups",
 ];
 
+const SUPPORT_EMAIL = "hello@sipandspeak.nl";
+
 export function DeleteAccountPage() {
   return (
     <main className="container mx-auto max-w-2xl px-4 py-8">
@@ -30,6 +32,29 @@ export function DeleteAccountPage() {
           <li>Tap Delete account.</li>
           <li>Confirm when prompted.</li>
         </ol>
+      </section>
+
+      <section className="mb-6">
+        <h2 className="mb-2 text-xl font-semibold">
+          Can&apos;t access the app? Request deletion by email
+        </h2>
+        <p className="mb-2">
+          If you can no longer sign in, you can ask us to delete your account and
+          data for you. Email{" "}
+          <a className="underline" href={`mailto:${SUPPORT_EMAIL}`}>
+            {SUPPORT_EMAIL}
+          </a>{" "}
+          to make a request.
+        </p>
+        <p className="mb-2">
+          Please email{" "}
+          <strong>from the address linked to your account</strong> so we can
+          verify the request is yours.
+        </p>
+        <p>
+          We will delete your account and data within 30 days of a verified
+          request.
+        </p>
       </section>
 
       <section className="mb-6">


### PR DESCRIPTION
Implements #423 — email fallback for members who cannot access the app.

- Adds a "Request deletion by email" section to `/delete-account` with a `mailto:hello@sipandspeak.nl` link
- States the 30-day fulfillment window and the "email from the address linked to your account" identity requirement
- Tests extended (7 passing total)

Closes #423

🤖 Generated with [Claude Code](https://claude.com/claude-code)