### PR TITLE
feat(web): finalize /delete-account retention note from audit

### DIFF
--- a/apps/web/src/__tests__/delete-account.test.tsx
+++ b/apps/web/src/__tests__/delete-account.test.tsx
@@ -49,12 +49,17 @@ describe("#419 — public /delete-account instructions page", () => {
     expect(screen.getByText(/no recovery/i)).toBeInTheDocument();
   });
 
-  it("notes data retention", () => {
+  it("states retained moderation records keep their history with identity removed", () => {
     render(<DeleteAccountPage />);
 
     expect(
-      screen.getByText(/retention note is provisional/i),
+      screen.getByText(/kept for the safety of the\s+community/i),
     ).toBeInTheDocument();
+    expect(screen.getByText(/your identity is removed/i)).toBeInTheDocument();
+    // The provisional placeholder must be gone once the audit is reflected.
+    expect(
+      screen.queryByText(/retention note is provisional/i),
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/apps/web/src/routes/delete-account.tsx
+++ b/apps/web/src/routes/delete-account.tsx
@@ -80,11 +80,17 @@ export function DeleteAccountPage() {
       </section>
 
       <section className="mb-6">
-        <h2 className="mb-2 text-xl font-semibold">Data retention</h2>
+        <h2 className="mb-2 text-xl font-semibold">What we keep</h2>
+        <p className="mb-2">
+          Some moderation records you created about other people — such as a
+          comment or a flag you raised — are kept for the safety of the
+          community, but your identity is removed so they can no longer be traced
+          back to you.
+        </p>
         <p>
-          Some limited records may be retained where required (for example, to
-          comply with legal obligations). This retention note is provisional and
-          will be finalized once our data-deletion audit is complete.
+          If your account was removed by a moderator (rather than deleted by
+          you), your institutional email address may be retained to prevent
+          re-registration.
         </p>
       </section>
     </main>


### PR DESCRIPTION
Implements #427 — replaces the provisional retention placeholder with audit-confirmed wording.

- Retained data now accurately described: moderation records you created are kept with your identity removed; institutional email retained only on moderator removal
- Removes the "provisional / pending audit" hedge
- Derived from `docs/account-data-deletion-audit.md` (#425); test updated

Closes #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)