### PR TITLE
feat(web): make /delete-account responsive and accessible

### DIFF
--- a/apps/web/src/__tests__/delete-account.test.tsx
+++ b/apps/web/src/__tests__/delete-account.test.tsx
@@ -87,3 +87,28 @@ describe("#423 — email fallback for members who cannot access the app", () => 
     expect(screen.getByText(/within 30 days of a verified/i)).toBeInTheDocument();
   });
 });
+
+describe("#420 — responsive & accessible deletion page", () => {
+  it("uses a single top-level heading", () => {
+    render(<DeleteAccountPage />);
+
+    expect(screen.getAllByRole("heading", { level: 1 })).toHaveLength(1);
+  });
+
+  it("organizes content under section sub-headings", () => {
+    render(<DeleteAccountPage />);
+
+    expect(
+      screen.getAllByRole("heading", { level: 2 }).length,
+    ).toBeGreaterThanOrEqual(4);
+  });
+
+  it("renders the email link as a keyboard-focusable anchor with a visible focus style", () => {
+    render(<DeleteAccountPage />);
+
+    const link = screen.getByRole("link", { name: /hello@sipandspeak\.nl/i });
+    expect(link.tagName).toBe("A");
+    expect(link).toHaveAttribute("href", "mailto:hello@sipandspeak.nl");
+    expect(link.className).toMatch(/focus-visible:ring/);
+  });
+});

--- a/apps/web/src/routes/delete-account.tsx
+++ b/apps/web/src/routes/delete-account.tsx
@@ -15,8 +15,8 @@ const SUPPORT_EMAIL = "hello@sipandspeak.nl";
 
 export function DeleteAccountPage() {
   return (
-    <main className="container mx-auto max-w-2xl px-4 py-8">
-      <h1 className="mb-4 text-2xl font-bold">
+    <main className="container mx-auto max-w-2xl break-words px-4 py-8 leading-relaxed">
+      <h1 className="mb-4 text-2xl font-bold sm:text-3xl">
         Delete your Sip &amp; Speak account and data
       </h1>
 
@@ -41,7 +41,10 @@ export function DeleteAccountPage() {
         <p className="mb-2">
           If you can no longer sign in, you can ask us to delete your account and
           data for you. Email{" "}
-          <a className="underline" href={`mailto:${SUPPORT_EMAIL}`}>
+          <a
+            className="rounded-sm underline underline-offset-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            href={`mailto:${SUPPORT_EMAIL}`}
+          >
             {SUPPORT_EMAIL}
           </a>{" "}
           to make a request.


### PR DESCRIPTION
Implements #420 — accessibility and responsive polish over the complete /delete-account page.

- Single semantic h1 with ordered h2 sections
- Email link is keyboard-focusable with a visible focus-visible ring
- Responsive heading, relaxed line-height, overflow-safe (break-words)
- Tests cover heading structure and focusable link (10 passing total)

Closes #420

🤖 Generated with [Claude Code](https://claude.com/claude-code)