### PR TITLE
fix: soft-delete accounts instead of hard delete (#447, #446)

### DIFF
--- a/packages/api/src/contexts/identity/__tests__/account-deletion-integration.test.ts
+++ b/packages/api/src/contexts/identity/__tests__/account-deletion-integration.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Integration tests for soft-delete account behavior (#447/#446).
+ *
+ * Drives the real tRPC caller through the in-memory pg-mem harness to verify
+ * that deleting an account:
+ *   - retains the user row but scrubs PII and stamps `deletedAt`,
+ *   - cancels in-progress meetups (never silently cascade-deletes them),
+ *   - closes open conversations (history preserved),
+ *   - removes the user from the matching pool,
+ *   - revokes sessions / credentials / device tokens,
+ *   - notifies the partner via ProposalsCancelledByCascade,
+ *   - hides the deleted user from discover, and
+ *   - blocks the partner from acting on the meetup afterwards.
+ */
+import "../../../__test-support__/harness";
+
+import { describe, it, expect, beforeEach } from "bun:test";
+import { eq } from "drizzle-orm";
+
+import { db } from "@sip-and-speak/db";
+import { user, session, account } from "@sip-and-speak/db/schema/auth";
+import { languageProfile, userLanguage, userInterest, userDeviceToken } from "@sip-and-speak/db/schema/identity";
+import { venue, meetup } from "@sip-and-speak/db/schema/scheduling";
+import { conversation } from "@sip-and-speak/db/schema/conversation";
+import { matchRequest, studentMatch } from "@sip-and-speak/db/schema/matching";
+
+import { appRouter } from "../../../routers";
+import { resetDb, buildSessionContext, captureEvents } from "../../../__test-support__/harness";
+
+const A = "del-A"; // the account being deleted
+const B = "del-B"; // the partner
+
+const FUTURE_AT = new Date("2099-09-01T18:00:00Z");
+
+async function seedPairWithMeetup(): Promise<{ venueId: string; meetupId: string; conversationId: string }> {
+  await db.insert(user).values([
+    { id: A, name: "Alice", surname: "Anderson", email: "alice@example.com", image: "https://img/a.png", emailVerified: true, createdAt: new Date(), updatedAt: new Date() },
+    { id: B, name: "Bob", surname: "Baker", email: "bob@example.com", emailVerified: true, createdAt: new Date(), updatedAt: new Date() },
+  ]);
+  // Both are in the matching pool.
+  await db.insert(languageProfile).values([
+    { userId: A, onboardingComplete: true },
+    { userId: B, onboardingComplete: true },
+  ]);
+  await db.insert(userLanguage).values([
+    { userId: A, language: "en", type: "spoken" },
+    { userId: A, language: "nl", type: "learning" },
+    { userId: B, language: "nl", type: "spoken" },
+    { userId: B, language: "en", type: "learning" },
+  ]);
+  await db.insert(userInterest).values([
+    { userId: A, interest: "music" },
+    { userId: B, interest: "music" },
+  ]);
+  await db.insert(session).values({
+    id: "sess-A", token: "tok-A", userId: A,
+    expiresAt: new Date(Date.now() + 1000 * 60 * 60), createdAt: new Date(), updatedAt: new Date(),
+  });
+  await db.insert(account).values({
+    id: "acct-A", accountId: "acct-A", providerId: "credential", userId: A,
+    createdAt: new Date(), updatedAt: new Date(),
+  });
+  await db.insert(userDeviceToken).values({ userId: A, token: "device-A", platform: "ios" });
+
+  const [v] = await db.insert(venue).values({ name: "Cafe Del", latitude: 51.4, longitude: 5.45, isActive: true }).returning();
+  const [m] = await db.insert(meetup).values({
+    proposerId: A, receiverId: B, venueId: v!.id, scheduledAt: FUTURE_AT, status: "confirmed",
+  }).returning();
+  const [c] = await db.insert(conversation).values({
+    user1Id: A, user2Id: B, meetupId: m!.id, status: "open",
+  }).returning();
+  return { venueId: v!.id, meetupId: m!.id, conversationId: c!.id };
+}
+
+describe("account deletion — soft delete (#447/#446)", () => {
+  beforeEach(() => {
+    resetDb();
+  });
+
+  it("retains a scrubbed, soft-deleted user row instead of hard-deleting", async () => {
+    await seedPairWithMeetup();
+    const caller = appRouter.createCaller(buildSessionContext(A));
+
+    await caller.profile.deleteAccount();
+
+    const [row] = await db.select().from(user).where(eq(user.id, A));
+    expect(row).toBeDefined();
+    expect(row!.deletedAt).not.toBeNull();
+    expect(row!.studentStatus).toBe("removed");
+    expect(row!.name).toBe("Deleted user");
+    expect(row!.surname).toBeNull();
+    expect(row!.image).toBeNull();
+    expect(row!.email).not.toBe("alice@example.com");
+  });
+
+  it("cancels in-progress meetups and notifies the partner", async () => {
+    const { meetupId } = await seedPairWithMeetup();
+    const capture = captureEvents();
+    const caller = appRouter.createCaller(buildSessionContext(A));
+
+    await caller.profile.deleteAccount();
+    capture.stop();
+
+    const [m] = await db.select().from(meetup).where(eq(meetup.id, meetupId));
+    expect(m!.status).toBe("cancelled");
+
+    const cascade = capture.events.filter((e) => e.name === "ProposalsCancelledByCascade");
+    expect(cascade).toHaveLength(1);
+    const payload = cascade[0]!.payload as { targetId: string; peerIds: string[] };
+    expect(payload.targetId).toBe(A);
+    expect(payload.peerIds).toEqual([B]);
+  });
+
+  it("closes open conversations and revokes auth + matching eligibility", async () => {
+    const { conversationId } = await seedPairWithMeetup();
+    const caller = appRouter.createCaller(buildSessionContext(A));
+
+    await caller.profile.deleteAccount();
+
+    const [c] = await db.select().from(conversation).where(eq(conversation.id, conversationId));
+    expect(c!.status).toBe("closed");
+
+    expect(await db.select().from(session).where(eq(session.userId, A))).toHaveLength(0);
+    expect(await db.select().from(account).where(eq(account.userId, A))).toHaveLength(0);
+    expect(await db.select().from(userDeviceToken).where(eq(userDeviceToken.userId, A))).toHaveLength(0);
+
+    const [lp] = await db.select().from(languageProfile).where(eq(languageProfile.userId, A));
+    expect(lp!.onboardingComplete).toBe(false);
+  });
+
+  it("excludes the deleted user from discover", async () => {
+    await seedPairWithMeetup();
+    // B discovers A before deletion.
+    const before = await appRouter.createCaller(buildSessionContext(B)).matching.discover({});
+    expect(before.partners.map((p) => p.userId)).toContain(A);
+
+    await appRouter.createCaller(buildSessionContext(A)).profile.deleteAccount();
+
+    const after = await appRouter.createCaller(buildSessionContext(B)).matching.discover({});
+    expect(after.partners.map((p) => p.userId)).not.toContain(A);
+  });
+
+  it("blocks the partner from rescheduling/proposing against a deleted account", async () => {
+    const { venueId, meetupId } = await seedPairWithMeetup();
+    // Need a match so propose passes the match guard; deletion-guard must win first.
+    const [req] = await db.insert(matchRequest).values({ requesterId: A, receiverId: B, status: "accepted" }).returning();
+    await db.insert(studentMatch).values({ studentAId: A, studentBId: B, matchRequestId: req!.id, status: "matched" });
+
+    await appRouter.createCaller(buildSessionContext(A)).profile.deleteAccount();
+
+    const bCaller = appRouter.createCaller(buildSessionContext(B));
+    const expectedMsg = "Sorry, this user has deleted their account in the middle of the process";
+
+    await expect(
+      bCaller.meetup.proposeReschedule({ meetupId, venueId, scheduledAt: FUTURE_AT.toISOString() }),
+    ).rejects.toThrow(expectedMsg);
+
+    await expect(
+      bCaller.meetup.propose({ partnerId: A, venueId, scheduledAt: FUTURE_AT.toISOString() }),
+    ).rejects.toThrow(expectedMsg);
+  });
+});

--- a/packages/api/src/contexts/identity/profile.ts
+++ b/packages/api/src/contexts/identity/profile.ts
@@ -1,10 +1,12 @@
-import { and, eq, ne } from "drizzle-orm";
+import { and, eq, ne, or, inArray } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { db } from "@sip-and-speak/db";
 import { languageProfile, userLanguage, userInterest, userDeviceToken } from "@sip-and-speak/db/schema/identity";
 import { studentComment } from "@sip-and-speak/db/schema/moderation";
-import { user } from "@sip-and-speak/db/schema/auth";
+import { user, session, account } from "@sip-and-speak/db/schema/auth";
+import { meetup } from "@sip-and-speak/db/schema/scheduling";
+import { conversation } from "@sip-and-speak/db/schema/conversation";
 import { protectedProcedure, router } from "../../index";
 import { domainEvents } from "../../domain-events";
 import {
@@ -155,6 +157,98 @@ async function syncMatchingEligibility(userId: string): Promise<boolean> {
     .where(eq(languageProfile.userId, userId));
 
   return isEligible;
+}
+
+/**
+ * #447/#446 — Soft-delete an account.
+ *
+ * Hard-deleting the user row used to cascade away every meetup and conversation,
+ * which broke the *other* party's history and silently skipped the meetup
+ * `cancelled` transition. Instead we keep the row and:
+ *   1. Cancel in-progress meetups (pending/confirmed) and notify the partners
+ *      (reusing the `ProposalsCancelledByCascade` cascade the moderation context
+ *      already wires to push notifications).
+ *   2. Close open conversations (read-only, history preserved).
+ *   3. Remove the user from the matching pool.
+ *   4. Scrub PII and stamp `deletedAt` so every surface treats them as an
+ *      unavailable/placeholder user.
+ *   5. Revoke auth (sessions, credentials, device tokens) so the account can no
+ *      longer be accessed.
+ *
+ * Exported for integration testing.
+ */
+export async function softDeleteAccount(userId: string): Promise<void> {
+  const now = new Date();
+
+  // 1. Cancel in-progress meetups and collect the affected partners.
+  const activeMeetups = await db
+    .select({ id: meetup.id, proposerId: meetup.proposerId, receiverId: meetup.receiverId })
+    .from(meetup)
+    .where(
+      and(
+        or(eq(meetup.proposerId, userId), eq(meetup.receiverId, userId)),
+        inArray(meetup.status, ["pending", "confirmed"]),
+      ),
+    );
+
+  if (activeMeetups.length > 0) {
+    await db
+      .update(meetup)
+      .set({ status: "cancelled" })
+      .where(
+        and(
+          or(eq(meetup.proposerId, userId), eq(meetup.receiverId, userId)),
+          inArray(meetup.status, ["pending", "confirmed"]),
+        ),
+      );
+
+    const peerIds = [
+      ...new Set(
+        activeMeetups.map((m) => (m.proposerId === userId ? m.receiverId : m.proposerId)),
+      ),
+    ];
+    domainEvents.emit("ProposalsCancelledByCascade", { targetId: userId, peerIds });
+  }
+
+  // 2. Close any open conversations — history stays, but they become read-only.
+  await db
+    .update(conversation)
+    .set({ status: "closed" })
+    .where(
+      and(
+        or(eq(conversation.user1Id, userId), eq(conversation.user2Id, userId)),
+        eq(conversation.status, "open"),
+      ),
+    );
+
+  // 3. Drop out of the matching pool.
+  await db
+    .update(languageProfile)
+    .set({ onboardingComplete: false })
+    .where(eq(languageProfile.userId, userId));
+
+  // 4. Scrub PII and mark soft-deleted. The email is anonymized but kept unique
+  //    (the column has a unique constraint) so the original address can later
+  //    re-register.
+  await db
+    .update(user)
+    .set({
+      deletedAt: now,
+      studentStatus: "removed",
+      name: "Deleted user",
+      surname: null,
+      image: null,
+      email: `deleted+${userId}@deleted.invalid`,
+      emailVerified: false,
+    })
+    .where(eq(user.id, userId));
+
+  // 5. Revoke all access for the account.
+  await Promise.all([
+    db.delete(session).where(eq(session.userId, userId)),
+    db.delete(account).where(eq(account.userId, userId)),
+    db.delete(userDeviceToken).where(eq(userDeviceToken.userId, userId)),
+  ]);
 }
 
 const setIdentityProfileInput = z.object({
@@ -635,12 +729,13 @@ export const profileRouter = router({
       }));
     }),
 
-  // #5 — permanent account deletion. Every user-owned row cascades; the few
-  // audit references (authored comments, moderator/reschedule pointers) null out
-  // by design. The destructive client confirm is the guard, so no input here.
+  // #447/#446 — account deletion is a SOFT delete. We retain the user row so
+  // existing conversations and meetup history don't break or vanish for the
+  // other party; instead the row is scrubbed of PII and marked `deletedAt`.
+  // The destructive client confirm is the guard, so no input here.
   deleteAccount: protectedProcedure.mutation(async ({ ctx }) => {
     const userId = ctx.session.user.id;
-    await db.delete(user).where(eq(user.id, userId));
+    await softDeleteAccount(userId);
     console.info("[AccountDeleted]", { userId });
     return { success: true as const };
   }),

--- a/packages/api/src/contexts/matching/matching.ts
+++ b/packages/api/src/contexts/matching/matching.ts
@@ -1,4 +1,4 @@
-import { and, eq, ne, inArray, notInArray, or, sql } from "drizzle-orm";
+import { and, eq, ne, inArray, notInArray, or, sql, isNull } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { db } from "@sip-and-speak/db";
@@ -88,7 +88,7 @@ export const matchingRouter = router({
         .where(inArray(userInterest.userId, otherUserIds));
 
       // Fetch user info (name, image) for candidates — exclude suspended AND
-      // permanently removed Students (#100/#108)
+      // permanently removed Students (#100/#108) and soft-deleted accounts (#447)
       const allUsers = await db
         .select({ id: user.id, name: user.name, image: user.image })
         .from(user)
@@ -96,6 +96,7 @@ export const matchingRouter = router({
           and(
             inArray(user.id, otherUserIds),
             notInArray(user.studentStatus, ["suspended", "removed"]),
+            isNull(user.deletedAt),
           ),
         );
 

--- a/packages/api/src/contexts/scheduling/meetup.ts
+++ b/packages/api/src/contexts/scheduling/meetup.ts
@@ -50,6 +50,27 @@ function toTrpcError(err: unknown): never {
   throw err;
 }
 
+// #446 — Shown to the partner when they try to act on a meetup whose
+// counterparty has soft-deleted their account mid-process.
+export const PARTNER_DELETED_MESSAGE =
+  "Sorry, this user has deleted their account in the middle of the process";
+
+/**
+ * Guard a meetup action against a counterparty who no longer exists or has
+ * deleted their account. Throws the canonical partner-deleted error so the
+ * client can surface the dialog and block further reschedule/propose/counter.
+ */
+async function assertPartnerActive(partnerId: string): Promise<void> {
+  const [row] = await db
+    .select({ deletedAt: user.deletedAt })
+    .from(user)
+    .where(eq(user.id, partnerId))
+    .limit(1);
+  if (!row || row.deletedAt !== null) {
+    throw new TRPCError({ code: "CONFLICT", message: PARTNER_DELETED_MESSAGE });
+  }
+}
+
 /**
  * Replay aggregate events through the global domain-events emitter. We dodge
  * the per-event generic by routing through the base `EventEmitter.emit`.
@@ -147,6 +168,9 @@ export const meetupRouter = router({
     )
     .mutation(async ({ ctx, input }) => {
       const userId = ctx.session.user.id;
+
+      // #446 — refuse to propose to a partner who has deleted their account.
+      await assertPartnerActive(input.partnerId);
 
       const [[proposer], matchRows, pendingRows, venueRow] = await Promise.all([
         db.select({ studentStatus: user.studentStatus }).from(user).where(eq(user.id, userId)).limit(1),
@@ -350,6 +374,8 @@ export const meetupRouter = router({
       if (!existing) {
         throw new TRPCError({ code: "NOT_FOUND", message: "Meetup not found" });
       }
+      // #446 — block counter-proposing when the counterparty has deleted their account.
+      await assertPartnerActive(existing.proposerId === userId ? existing.receiverId : existing.proposerId);
       const newVenue = await loadVenueSnapshot(input.venueId);
 
       let decision;
@@ -421,11 +447,13 @@ export const meetupRouter = router({
             id: sql<string>`proposer.id`.as("proposer_id_alias"),
             name: sql<string>`proposer.name`.as("proposer_name"),
             image: sql<string | null>`proposer.image`.as("proposer_image"),
+            deletedAt: sql<Date | null>`proposer.deleted_at`.as("proposer_deleted_at"),
           },
           receiver: {
             id: sql<string>`receiver.id`.as("receiver_id_alias"),
             name: sql<string>`receiver.name`.as("receiver_name"),
             image: sql<string | null>`receiver.image`.as("receiver_image"),
+            deletedAt: sql<Date | null>`receiver.deleted_at`.as("receiver_deleted_at"),
           },
         })
         .from(meetup)
@@ -445,15 +473,19 @@ export const meetupRouter = router({
         const isProposer = row.meetup.proposerId === userId;
         const partner = isProposer ? row.receiver : row.proposer;
 
+        const partnerDeleted = partner.deletedAt !== null;
+
         return {
           ...row.meetup,
           isProposer,
           venue: row.venue,
           partner: {
             id: partner.id,
-            name: partner.name,
-            image: partner.image,
+            // #447 — render deleted partners as an unavailable placeholder.
+            name: partnerDeleted ? "Deleted user" : partner.name,
+            image: partnerDeleted ? null : partner.image,
           },
+          partnerDeleted,
         };
       });
     }),
@@ -634,6 +666,7 @@ export const meetupRouter = router({
             id: sql<string>`partner.id`.as("gc_partner_id"),
             name: sql<string>`partner.name`.as("gc_partner_name"),
             image: sql<string | null>`partner.image`.as("gc_partner_image"),
+            deletedAt: sql<Date | null>`partner.deleted_at`.as("gc_partner_deleted_at"),
           },
         })
         .from(meetup)
@@ -668,13 +701,20 @@ export const meetupRouter = router({
     return rows.map((row) => {
       const myReport = myReportMap.get(row.meetup.id);
       const messaging = messagingState.get(row.meetup.id) ?? { mine: null, partner: null, conversationId: null };
+      const partnerDeleted = row.partner.deletedAt !== null;
       return {
         meetupId: row.meetup.id,
         scheduledAt: row.meetup.scheduledAt,
         status: row.meetup.status,
         isPast: row.meetup.scheduledAt <= now,
         venue: row.venue,
-        partner: row.partner,
+        // #447 — render deleted partners as an unavailable placeholder.
+        partner: {
+          id: row.partner.id,
+          name: partnerDeleted ? "Deleted user" : row.partner.name,
+          image: partnerDeleted ? null : row.partner.image,
+        },
+        partnerDeleted,
         // #86 — Reschedule proposal state
         reschedulePending: row.meetup.rescheduleProposerId !== null,
         rescheduleIsFromMe: row.meetup.rescheduleProposerId === userId,
@@ -713,6 +753,8 @@ export const meetupRouter = router({
       if (!existing) {
         throw new TRPCError({ code: "NOT_FOUND", message: "Meetup not found" });
       }
+      // #446 — block rescheduling when the counterparty has deleted their account.
+      await assertPartnerActive(existing.proposerId === userId ? existing.receiverId : existing.proposerId);
       const venueRow = await loadVenueSnapshot(input.venueId);
 
       let decision;

--- a/packages/db/src/migrations/0021_soft_delete_user.sql
+++ b/packages/db/src/migrations/0021_soft_delete_user.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "user" ADD COLUMN "deleted_at" timestamp;

--- a/packages/db/src/migrations/meta/0021_snapshot.json
+++ b/packages/db/src/migrations/meta/0021_snapshot.json
@@ -1,0 +1,2170 @@
+{
+  "id": "55260775-7e49-4bd5-859e-918099970ecb",
+  "prevId": "e4912b77-2c0a-4f3e-9b88-7c1d2a6f0a55",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "surname": {
+          "name": "surname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "student_status": {
+          "name": "student_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attendance_report": {
+      "name": "attendance_report",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "meetup_id": {
+          "name": "meetup_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attended": {
+          "name": "attended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reported_at": {
+          "name": "reported_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "attendance_report_meetupId_idx": {
+          "name": "attendance_report_meetupId_idx",
+          "columns": [
+            {
+              "expression": "meetup_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "attendance_report_meetup_id_meetup_id_fk": {
+          "name": "attendance_report_meetup_id_meetup_id_fk",
+          "tableFrom": "attendance_report",
+          "columnsFrom": [
+            "meetup_id"
+          ],
+          "tableTo": "meetup",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "attendance_report_student_id_user_id_fk": {
+          "name": "attendance_report_student_id_user_id_fk",
+          "tableFrom": "attendance_report",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "attendance_report_meetup_student_unique": {
+          "name": "attendance_report_meetup_student_unique",
+          "columns": [
+            "meetup_id",
+            "student_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocked_email": {
+      "name": "blocked_email",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocked_at": {
+          "name": "blocked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "blocked_email_email_unique": {
+          "name": "blocked_email_email_unique",
+          "columns": [
+            "email"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation": {
+      "name": "conversation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user1_id": {
+          "name": "user1_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user2_id": {
+          "name": "user2_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meetup_id": {
+          "name": "meetup_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_user1_idx": {
+          "name": "conversation_user1_idx",
+          "columns": [
+            {
+              "expression": "user1_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "conversation_user2_idx": {
+          "name": "conversation_user2_idx",
+          "columns": [
+            {
+              "expression": "user2_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "conversation_meetupId_idx": {
+          "name": "conversation_meetupId_idx",
+          "columns": [
+            {
+              "expression": "meetup_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "conversation_user1_id_user_id_fk": {
+          "name": "conversation_user1_id_user_id_fk",
+          "tableFrom": "conversation",
+          "columnsFrom": [
+            "user1_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "conversation_user2_id_user_id_fk": {
+          "name": "conversation_user2_id_user_id_fk",
+          "tableFrom": "conversation",
+          "columnsFrom": [
+            "user2_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "conversation_meetup_id_meetup_id_fk": {
+          "name": "conversation_meetup_id_meetup_id_fk",
+          "tableFrom": "conversation",
+          "columnsFrom": [
+            "meetup_id"
+          ],
+          "tableTo": "meetup",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_presence": {
+      "name": "conversation_presence",
+      "schema": "",
+      "columns": {
+        "student_id": {
+          "name": "student_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_until": {
+          "name": "active_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "conversation_presence_studentId_idx": {
+          "name": "conversation_presence_studentId_idx",
+          "columns": [
+            {
+              "expression": "student_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "conversation_presence_student_id_user_id_fk": {
+          "name": "conversation_presence_student_id_user_id_fk",
+          "tableFrom": "conversation_presence",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "conversation_presence_conversation_id_conversation_id_fk": {
+          "name": "conversation_presence_conversation_id_conversation_id_fk",
+          "tableFrom": "conversation_presence",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "tableTo": "conversation",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversation_presence_student_conv_unique": {
+          "name": "conversation_presence_student_conv_unique",
+          "columns": [
+            "student_id",
+            "conversation_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.language_profile": {
+      "name": "language_profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "university": {
+          "name": "university",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "age": {
+          "name": "age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_complete": {
+          "name": "onboarding_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "language_profile_user_id_user_id_fk": {
+          "name": "language_profile_user_id_user_id_fk",
+          "tableFrom": "language_profile",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "language_profile_user_id_unique": {
+          "name": "language_profile_user_id_unique",
+          "columns": [
+            "user_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.match_request": {
+      "name": "match_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "requester_id": {
+          "name": "requester_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receiver_id": {
+          "name": "receiver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "match_request_requesterId_idx": {
+          "name": "match_request_requesterId_idx",
+          "columns": [
+            {
+              "expression": "requester_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "match_request_receiverId_idx": {
+          "name": "match_request_receiverId_idx",
+          "columns": [
+            {
+              "expression": "receiver_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "match_request_requester_id_user_id_fk": {
+          "name": "match_request_requester_id_user_id_fk",
+          "tableFrom": "match_request",
+          "columnsFrom": [
+            "requester_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "match_request_receiver_id_user_id_fk": {
+          "name": "match_request_receiver_id_user_id_fk",
+          "tableFrom": "match_request",
+          "columnsFrom": [
+            "receiver_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meetup": {
+      "name": "meetup",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "proposer_id": {
+          "name": "proposer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receiver_id": {
+          "name": "receiver_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "venue_id": {
+          "name": "venue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "reschedule_proposer_id": {
+          "name": "reschedule_proposer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reschedule_venue_id": {
+          "name": "reschedule_venue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reschedule_date": {
+          "name": "reschedule_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reschedule_time": {
+          "name": "reschedule_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "meetup_proposerId_idx": {
+          "name": "meetup_proposerId_idx",
+          "columns": [
+            {
+              "expression": "proposer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "meetup_receiverId_idx": {
+          "name": "meetup_receiverId_idx",
+          "columns": [
+            {
+              "expression": "receiver_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "meetup_date_idx": {
+          "name": "meetup_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "meetup_proposer_id_user_id_fk": {
+          "name": "meetup_proposer_id_user_id_fk",
+          "tableFrom": "meetup",
+          "columnsFrom": [
+            "proposer_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "meetup_receiver_id_user_id_fk": {
+          "name": "meetup_receiver_id_user_id_fk",
+          "tableFrom": "meetup",
+          "columnsFrom": [
+            "receiver_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "meetup_venue_id_venue_id_fk": {
+          "name": "meetup_venue_id_venue_id_fk",
+          "tableFrom": "meetup",
+          "columnsFrom": [
+            "venue_id"
+          ],
+          "tableTo": "venue",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "meetup_reschedule_proposer_id_user_id_fk": {
+          "name": "meetup_reschedule_proposer_id_user_id_fk",
+          "tableFrom": "meetup",
+          "columnsFrom": [
+            "reschedule_proposer_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "meetup_reschedule_venue_id_venue_id_fk": {
+          "name": "meetup_reschedule_venue_id_venue_id_fk",
+          "tableFrom": "meetup",
+          "columnsFrom": [
+            "reschedule_venue_id"
+          ],
+          "tableTo": "venue",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message": {
+      "name": "message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_conversationId_idx": {
+          "name": "message_conversationId_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "message_createdAt_idx": {
+          "name": "message_createdAt_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "message_conversation_id_conversation_id_fk": {
+          "name": "message_conversation_id_conversation_id_fk",
+          "tableFrom": "message",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "tableTo": "conversation",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "message_sender_id_user_id_fk": {
+          "name": "message_sender_id_user_id_fk",
+          "tableFrom": "message",
+          "columnsFrom": [
+            "sender_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message_read_status": {
+      "name": "message_read_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_read_conversationId_userId_idx": {
+          "name": "message_read_conversationId_userId_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "message_read_status_conversation_id_conversation_id_fk": {
+          "name": "message_read_status_conversation_id_conversation_id_fk",
+          "tableFrom": "message_read_status",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "tableTo": "conversation",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "message_read_status_user_id_user_id_fk": {
+          "name": "message_read_status_user_id_user_id_fk",
+          "tableFrom": "message_read_status",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messaging_opt_in": {
+      "name": "messaging_opt_in",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "meetup_id": {
+          "name": "meetup_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "nudge_sent_at": {
+          "name": "nudge_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "messaging_opt_in_meetupId_idx": {
+          "name": "messaging_opt_in_meetupId_idx",
+          "columns": [
+            {
+              "expression": "meetup_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "messaging_opt_in_meetup_id_meetup_id_fk": {
+          "name": "messaging_opt_in_meetup_id_meetup_id_fk",
+          "tableFrom": "messaging_opt_in",
+          "columnsFrom": [
+            "meetup_id"
+          ],
+          "tableTo": "meetup",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "messaging_opt_in_student_id_user_id_fk": {
+          "name": "messaging_opt_in_student_id_user_id_fk",
+          "tableFrom": "messaging_opt_in",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "messaging_opt_in_meetup_student_unique": {
+          "name": "messaging_opt_in_meetup_student_unique",
+          "columns": [
+            "meetup_id",
+            "student_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_comment": {
+      "name": "student_comment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "student_comment_targetId_idx": {
+          "name": "student_comment_targetId_idx",
+          "columns": [
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "student_comment_author_id_user_id_fk": {
+          "name": "student_comment_author_id_user_id_fk",
+          "tableFrom": "student_comment",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "student_comment_target_id_user_id_fk": {
+          "name": "student_comment_target_id_user_id_fk",
+          "tableFrom": "student_comment",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_match": {
+      "name": "student_match",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "student_a_id": {
+          "name": "student_a_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_b_id": {
+          "name": "student_b_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_request_id": {
+          "name": "match_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'matched'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "student_match_studentA_idx": {
+          "name": "student_match_studentA_idx",
+          "columns": [
+            {
+              "expression": "student_a_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "student_match_studentB_idx": {
+          "name": "student_match_studentB_idx",
+          "columns": [
+            {
+              "expression": "student_b_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "student_match_student_a_id_user_id_fk": {
+          "name": "student_match_student_a_id_user_id_fk",
+          "tableFrom": "student_match",
+          "columnsFrom": [
+            "student_a_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "student_match_student_b_id_user_id_fk": {
+          "name": "student_match_student_b_id_user_id_fk",
+          "tableFrom": "student_match",
+          "columnsFrom": [
+            "student_b_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "student_match_match_request_id_match_request_id_fk": {
+          "name": "student_match_match_request_id_match_request_id_fk",
+          "tableFrom": "student_match",
+          "columnsFrom": [
+            "match_request_id"
+          ],
+          "tableTo": "match_request",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_device_token": {
+      "name": "user_device_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_device_token_userId_token_idx": {
+          "name": "user_device_token_userId_token_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "user_device_token_user_id_user_id_fk": {
+          "name": "user_device_token_user_id_user_id_fk",
+          "tableFrom": "user_device_token",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_flag": {
+      "name": "user_flag",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moderator_id": {
+          "name": "moderator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_flag_reporter_idx": {
+          "name": "user_flag_reporter_idx",
+          "columns": [
+            {
+              "expression": "reporter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "user_flag_target_idx": {
+          "name": "user_flag_target_idx",
+          "columns": [
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "user_flag_status_idx": {
+          "name": "user_flag_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "user_flag_reporter_id_user_id_fk": {
+          "name": "user_flag_reporter_id_user_id_fk",
+          "tableFrom": "user_flag",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "user_flag_target_id_user_id_fk": {
+          "name": "user_flag_target_id_user_id_fk",
+          "tableFrom": "user_flag",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "user_flag_moderator_id_user_id_fk": {
+          "name": "user_flag_moderator_id_user_id_fk",
+          "tableFrom": "user_flag",
+          "columnsFrom": [
+            "moderator_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_interest": {
+      "name": "user_interest",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interest": {
+          "name": "interest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_interest_userId_idx": {
+          "name": "user_interest_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "user_interest_user_id_user_id_fk": {
+          "name": "user_interest_user_id_user_id_fk",
+          "tableFrom": "user_interest",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_interest_user_interest_unique": {
+          "name": "user_interest_user_interest_unique",
+          "columns": [
+            "user_id",
+            "interest"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_language": {
+      "name": "user_language",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proficiency": {
+          "name": "proficiency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_language_userId_idx": {
+          "name": "user_language_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "user_language_user_id_user_id_fk": {
+          "name": "user_language_user_id_user_id_fk",
+          "tableFrom": "user_language",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_language_user_language_type_unique": {
+          "name": "user_language_user_language_type_unique",
+          "columns": [
+            "user_id",
+            "language",
+            "type"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.venue": {
+      "name": "venue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "venue_name_idx": {
+          "name": "venue_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1778972299817,
       "tag": "0020_drop_redundant_blocked_email_index",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1778972299818,
+      "tag": "0021_soft_delete_user",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/auth.ts
+++ b/packages/db/src/schema/auth.ts
@@ -20,6 +20,10 @@ export const user = pgTable("user", {
   studentStatus: text("student_status", { enum: ["active", "suspended", "removed"] })
     .notNull()
     .default("active"),
+  // #447/#446 — Soft-delete marker. When set, the account is considered deleted:
+  // the row is retained (so history/joins survive) but PII is scrubbed, the user
+  // is excluded from matching, and meetup actions against them are rejected.
+  deletedAt: timestamp("deleted_at"),
 });
 
 export const session = pgTable(


### PR DESCRIPTION
Closes #447
Closes #446

## Problem
`deleteAccount` hard-deleted the user row, relying on DB `onDelete: cascade`. This broke the *other* party's experience: meetup partner inner-joins returned null/broke, chat history vanished, discover relied on implicit filtering, and in-progress meetups were silently cascade-deleted instead of transitioning to `cancelled` (no notification, no explanation).

## Approach — soft delete
The user row is now **retained** (so every join and history surface survives) but marked deleted and scrubbed.

### Schema migration
- Added a nullable `deleted_at timestamp` to the `user` table.
- Migration `0021_soft_delete_user.sql` (`ALTER TABLE "user" ADD COLUMN "deleted_at" timestamp;`) plus journal + snapshot entries.
- Note: `drizzle-kit generate` could not be used here — the committed `0020` snapshot has **pre-existing drift** on the `meetup` table (it predates the `0018` timezone migration), so the generator prompts an interactive `scheduled_at` rename resolution that would emit a destructive migration. The single additive `ADD COLUMN` was therefore hand-written and the snapshot chain extended by hand to preserve the status quo.

### `profile.deleteAccount` (#447 + #446)
Now a `softDeleteAccount(userId)` flow that:
1. Cancels `pending`/`confirmed` meetups → `cancelled`, emitting `ProposalsCancelledByCascade` (the existing moderation→notifications cascade) so partners get a push.
2. Closes `open` conversations (read-only, history preserved).
3. Drops the user from the matching pool (`languageProfile.onboardingComplete = false`).
4. Scrubs PII (name → "Deleted user", surname/image null, email anonymized-but-unique, emailVerified false) and stamps `deletedAt` + `studentStatus = "removed"`.
5. Revokes auth: deletes sessions, credentials (`account`), and device tokens.

### Discover / matching (#447)
- `matching.discover` candidate query now adds `isNull(user.deletedAt)`.

### Meetup guards (#446)
- `propose`, `counterPropose`, `proposeReschedule` now assert the counterparty is not deleted, throwing **"Sorry, this user has deleted their account in the middle of the process"** (TRPCError `CONFLICT`).

### Meetup list / getConfirmed (#447)
- Deleted partners render as an unavailable placeholder ("Deleted user", no image) and expose a `partnerDeleted` boolean so the client can show the dialog. The inner-join no longer breaks because the row is retained.

## Tests
New integration test `account-deletion-integration.test.ts` (pg-mem harness, real tRPC caller) covers: scrubbed/retained row, meetup cancellation + partner notification, conversation close + auth revocation + matching eligibility, discover exclusion, and partner action guards.

## Verification
- `cd packages/api && bun test` → **191 pass, 0 fail** (includes 5 new tests)
- `cd packages/db && bun test` → **6 pass**
- `cd packages/notifications && bun test` → **54 pass**
- `cd packages/auth && bun test` → **20 pass**
- `bun run test` (turbo, all four packages) → **4 successful**
- `cd packages/api && bunx tsc --noEmit` → clean
- `bun run check-types --filter=server --filter=web` → **3 successful** (server `tsc -b`, web `vite build && tsc --noEmit`)
- `lint`: no package implements a `lint` script in this repo (the turbo `lint` task has no backing scripts), so there was nothing to run.

## Uncertain / assumptions
- **Partner notification mechanism**: reused the existing `ProposalsCancelledByCascade` event (already wired to push notifications for moderation removals) rather than adding a new unconsumed `MeetupCancelledUserDeleted` event. The specific dialog text is delivered synchronously via the TRPCError guard when the partner acts.
- **Placeholder UI**: the API now scrubs the name to "Deleted user" and exposes `partnerDeleted`; native rendering of an explicit "[User no longer available]" treatment / dialog wiring was left to the client (additive, non-breaking contract).
- Self-deletion intentionally does **not** blocklist the email (unlike moderator removal), so the original address can re-register.

🤖 Generated with [Claude Code](https://claude.com/claude-code)