### PR TITLE
fix: use brand gold for conversation cards and language picker (#421)

### DIFF
--- a/apps/native/components/conversation-starters/card-deck.tsx
+++ b/apps/native/components/conversation-starters/card-deck.tsx
@@ -99,7 +99,7 @@ function DeckBrowser({
         accessibilityState={{ expanded: canTranslate ? showTranslation : false }}
         disabled={!canTranslate}
         onPress={toggleReveal}
-        className="w-full items-center justify-center rounded-3xl bg-muted px-6 py-12"
+        className="w-full items-center justify-center rounded-3xl bg-brand-gold px-6 py-12"
       >
         <Text
           testID="card-deck-text"

--- a/apps/native/components/conversation-starters/card-language-picker.tsx
+++ b/apps/native/components/conversation-starters/card-language-picker.tsx
@@ -65,7 +65,7 @@ export function CardLanguagePicker({
               accessibilityState={{ selected: isActive }}
               onPress={() => onSelect(language)}
               className={`flex-row items-center gap-3 rounded-2xl px-4 py-3 ${
-                isActive ? "bg-primary" : "bg-muted"
+                isActive ? "bg-primary" : "bg-brand-gold"
               }`}
             >
               <Text style={{ fontSize: 24 }}>{getLanguageFlag(language)}</Text>


### PR DESCRIPTION
Closes #421

## Summary

The conversation starter cards and the language picker rendered with the muted surface token `bg-muted` (`--color-brand-muted` = `#F5E6DA`, a warm cream that reads as dull grey/beige on device) instead of the brand yellow/gold used elsewhere in the app.

This swaps `bg-muted` for the existing `bg-brand-gold` class (`--color-brand-gold` = `#F2C94C`) on:

- `apps/native/components/conversation-starters/card-deck.tsx` — the starter card surface
- `apps/native/components/conversation-starters/card-language-picker.tsx` — the inactive language picker items

`bg-brand-gold` is the established class for the brand gold token — it is already used by the chat message bubbles (`app/chat/[conversationId].tsx`) and resolves to the same `#F2C94C` the Home hero cards apply inline via `GOLD` (`components/home/tokens.ts`).

## Contrast / state notes

- Card deck text uses `text-foreground` (`#2C1810`, dark brown) — high contrast on gold, matching the chat gold bubble which pairs gold with `text-brand-foreground`.
- The language picker active state keeps `bg-primary` (burnt orange) with white text; only the inactive base changed to gold, so the active/inactive distinction is preserved.

## Verification

- The native app has no `check-types` task in the monorepo (`turbo check-types --filter=native` runs 0 tasks; only web/server are typechecked). A raw `bunx tsc --noEmit` in `apps/native` produces only pre-existing `node_modules` (zod `esModuleInterop`) and `__tests__` (missing test-runner types) noise — zero errors in any app source/component file. The change is two className string literals, which cannot introduce type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)