### PR TITLE
fix: prevent emptying a profile language category (#441)

### DIFF
--- a/apps/native/components/profile-modal.tsx
+++ b/apps/native/components/profile-modal.tsx
@@ -214,6 +214,22 @@ export function ProfileModal({ visible, onDismiss }: ProfileModalProps) {
   const savedInterests = profileQuery.data?.interests ?? [];
   const allSelectedLanguages = languages.map((l) => l.language);
 
+  // Each category must always retain at least one language (mirrors the
+  // onboarding invariant + the server guard in removeLanguage). Block the
+  // removal of the last one and explain why.
+  function handleRemoveLanguage(language: string, type: "spoken" | "learning") {
+    const remaining =
+      type === "spoken" ? spokenLanguages.length : learningLanguages.length;
+    if (remaining <= 1) {
+      Alert.alert(
+        "Keep at least one language",
+        "You should always have at least one language in this category",
+      );
+      return;
+    }
+    removeLangMutation.mutate({ language, type });
+  }
+
   return (
     <Modal
       visible={visible}
@@ -372,10 +388,7 @@ export function ProfileModal({ visible, onDismiss }: ProfileModalProps) {
                       </View>
                       <Pressable
                         onPress={() =>
-                          removeLangMutation.mutate({
-                            language: sl.language,
-                            type: "spoken",
-                          })
+                          handleRemoveLanguage(sl.language, "spoken")
                         }
                       >
                         <Text
@@ -481,10 +494,7 @@ export function ProfileModal({ visible, onDismiss }: ProfileModalProps) {
                       </View>
                       <Pressable
                         onPress={() =>
-                          removeLangMutation.mutate({
-                            language: ll.language,
-                            type: "learning",
-                          })
+                          handleRemoveLanguage(ll.language, "learning")
                         }
                       >
                         <Text

--- a/packages/api/src/contexts/identity/__tests__/onboarding-integration.test.ts
+++ b/packages/api/src/contexts/identity/__tests__/onboarding-integration.test.ts
@@ -98,3 +98,55 @@ describe("onboarding integration — submitProfile", () => {
     expect(capture.events.map((e) => e.name)).toContain("ProfileCompleted");
   });
 });
+
+describe("profile integration — removeLanguage min-one guard", () => {
+  beforeEach(() => {
+    resetDb();
+  });
+
+  it("rejects removing the last spoken language", async () => {
+    await seedUser({ name: "Ada", surname: "Lovelace" });
+    await db.insert(userLanguage).values([
+      { userId: USER_ID, language: "en", proficiency: "native", type: "spoken" },
+      { userId: USER_ID, language: "nl", proficiency: "beginner", type: "learning" },
+    ]);
+
+    const caller = appRouter.createCaller(buildSessionContext(USER_ID));
+    await expect(
+      caller.profile.removeLanguage({ language: "en", type: "spoken" }),
+    ).rejects.toThrow(/at least one language in this category/);
+
+    const remaining = await db.select().from(userLanguage);
+    expect(remaining.some((r) => r.language === "en" && r.type === "spoken")).toBe(true);
+  });
+
+  it("rejects removing the last learning language", async () => {
+    await seedUser({ name: "Ada", surname: "Lovelace" });
+    await db.insert(userLanguage).values([
+      { userId: USER_ID, language: "en", proficiency: "native", type: "spoken" },
+      { userId: USER_ID, language: "nl", proficiency: "beginner", type: "learning" },
+    ]);
+
+    const caller = appRouter.createCaller(buildSessionContext(USER_ID));
+    await expect(
+      caller.profile.removeLanguage({ language: "nl", type: "learning" }),
+    ).rejects.toThrow(/at least one language in this category/);
+  });
+
+  it("allows removing one when several remain in the category", async () => {
+    await seedUser({ name: "Ada", surname: "Lovelace" });
+    await db.insert(userLanguage).values([
+      { userId: USER_ID, language: "en", proficiency: "native", type: "spoken" },
+      { userId: USER_ID, language: "de", proficiency: "advanced", type: "spoken" },
+      { userId: USER_ID, language: "nl", proficiency: "beginner", type: "learning" },
+    ]);
+
+    const caller = appRouter.createCaller(buildSessionContext(USER_ID));
+    const result = await caller.profile.removeLanguage({ language: "de", type: "spoken" });
+    expect(result.success).toBe(true);
+
+    const remaining = await db.select().from(userLanguage);
+    expect(remaining.some((r) => r.language === "de")).toBe(false);
+    expect(remaining.filter((r) => r.type === "spoken")).toHaveLength(1);
+  });
+});

--- a/packages/api/src/contexts/identity/__tests__/onboarding-progression.test.ts
+++ b/packages/api/src/contexts/identity/__tests__/onboarding-progression.test.ts
@@ -84,6 +84,32 @@ describe("OnboardingProgression.assertCanSubmit", () => {
   });
 });
 
+describe("OnboardingProgression.assertCanRemoveLanguage", () => {
+  it("throws when removing the last language in a category", () => {
+    expect(() =>
+      OnboardingProgression.assertCanRemoveLanguage("spoken", 1),
+    ).toThrow(OnboardingRuleError);
+    expect(() =>
+      OnboardingProgression.assertCanRemoveLanguage("learning", 1),
+    ).toThrow(/at least one language in this category/);
+  });
+
+  it("throws defensively when the category is already empty", () => {
+    expect(() =>
+      OnboardingProgression.assertCanRemoveLanguage("spoken", 0),
+    ).toThrow(OnboardingRuleError);
+  });
+
+  it("passes when more than one language remains", () => {
+    expect(() =>
+      OnboardingProgression.assertCanRemoveLanguage("spoken", 2),
+    ).not.toThrow();
+    expect(() =>
+      OnboardingProgression.assertCanRemoveLanguage("learning", 5),
+    ).not.toThrow();
+  });
+});
+
 describe("OnboardingProgression.assertNoNativeSpokenLearningConflict", () => {
   it("passes when no overlap", () => {
     expect(() =>

--- a/packages/api/src/contexts/identity/onboarding-progression.ts
+++ b/packages/api/src/contexts/identity/onboarding-progression.ts
@@ -93,6 +93,24 @@ export const OnboardingProgression = {
   },
 
   /**
+   * Profile-edit guard: every category must always retain at least one
+   * language. Mirrors the onboarding invariant (`assertCanSubmit` requires ≥1
+   * spoken AND ≥1 learning) for post-onboarding edits.
+   *
+   * `remainingCount` is the number of languages currently of the given `type`
+   * (i.e. before the removal). Throws if removing the last one would empty the
+   * category.
+   */
+  assertCanRemoveLanguage(_type: "spoken" | "learning", remainingCount: number): void {
+    if (remainingCount <= 1) {
+      throw new OnboardingRuleError(
+        "BAD_REQUEST",
+        "You must have at least one language in this category",
+      );
+    }
+  },
+
+  /**
    * Reject any learning language that the Student also speaks natively.
    * Throws on conflict; returns silently otherwise.
    */

--- a/packages/api/src/contexts/identity/profile.ts
+++ b/packages/api/src/contexts/identity/profile.ts
@@ -630,6 +630,28 @@ export const profileRouter = router({
     .mutation(async ({ ctx, input }) => {
       const userId = ctx.session.user.id;
 
+      // Every category must always retain at least one language (mirrors the
+      // onboarding invariant). Only guard when the language actually exists in
+      // the category — removing a non-existent one is a harmless no-op.
+      const ofType = await db
+        .select()
+        .from(userLanguage)
+        .where(
+          and(eq(userLanguage.userId, userId), eq(userLanguage.type, input.type)),
+        );
+
+      const removingExisting = ofType.some((r) => r.language === input.language);
+      if (removingExisting) {
+        try {
+          OnboardingProgression.assertCanRemoveLanguage(input.type, ofType.length);
+        } catch (err) {
+          if (err instanceof OnboardingRuleError) {
+            throw new TRPCError({ code: err.code, message: err.message });
+          }
+          throw err;
+        }
+      }
+
       await db
         .delete(userLanguage)
         .where(


### PR DESCRIPTION
Closes #441

## Problem
Post-onboarding, a member could remove **all** spoken or **all** learning languages from their profile, violating the invariant (enforced at onboarding via `OnboardingProgression.assertCanSubmit()`) that every category retains ≥1 language. No guard existed in the UI or the mutation.

## Fix
Two layers, reusing the existing domain aggregate:

- **Domain** (`onboarding-progression.ts`): new `OnboardingProgression.assertCanRemoveLanguage(type, remainingCount)` that throws `OnboardingRuleError("BAD_REQUEST", ...)` when removing would empty the category. Sits next to `assertCanSubmit` / `assertNoNativeSpokenLearningConflict`.
- **Server** (`profile.ts` `removeLanguage`): counts the member's languages of that `type`; if the target language exists and it's the last one, maps the rule error to a `TRPCError`. Removing a non-existent language stays a harmless no-op.
- **Client** (`profile-modal.tsx`): new `handleRemoveLanguage` helper wired to both the spoken and learning "Remove" buttons. When only one language remains, shows `Alert.alert("Keep at least one language", "You should always have at least one language in this category")` and skips the mutation.

## Tests
- Unit: `assertCanRemoveLanguage` (last-one throws, empty throws, >1 passes).
- Integration (tRPC caller + pg-mem harness): rejects removing last spoken, rejects removing last learning, allows removing one of several.

## Verification
- `bun run test` — 4/4 packages pass (api: 197 tests, incl. new ones).
- `bun run check-types` — 3/3 successful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
