### PR TITLE
fix: chat unread refresh, optimistic send, info button, compose height (#422, #444, #443, #442)

### DIFF
--- a/apps/native/app/chat/[conversationId].tsx
+++ b/apps/native/app/chat/[conversationId].tsx
@@ -76,6 +76,12 @@ export default function ChatScreen() {
             void queryClient.invalidateQueries({
               queryKey: trpc.chat.getMessages.queryOptions({ conversationId }).queryKey,
             });
+            // #422 — listEntries drives the chat-list yellow dot and the Chats
+            // tab badge; without this the unread indicators linger until the
+            // next refocus/refetch.
+            void queryClient.invalidateQueries({
+              queryKey: trpc.chat.listEntries.queryOptions().queryKey,
+            });
           },
         },
       );
@@ -124,11 +130,53 @@ export default function ChatScreen() {
 
   const sendMessage = useMutation(
     trpc.messaging.sendMessage.mutationOptions({
+      // #444 — optimistically append the pending message so it shows instantly
+      // instead of waiting for the 5s poll, then reconcile on settle.
+      onMutate: async (variables) => {
+        const messagesKey = trpc.chat.getMessages.queryOptions({
+          conversationId: variables.conversationId,
+        }).queryKey;
+        await queryClient.cancelQueries({ queryKey: messagesKey });
+        const previous = queryClient.getQueryData(messagesKey);
+        const optimisticMessage = {
+          id: `optimistic-${Date.now()}`,
+          conversationId: variables.conversationId,
+          senderId: currentUserId ?? "",
+          content: variables.content,
+          createdAt: new Date().toISOString(),
+          isUnread: false,
+        };
+        queryClient.setQueryData(messagesKey, (old) => {
+          if (!old) return old;
+          return {
+            ...old,
+            messages: [
+              ...old.messages,
+              optimisticMessage as (typeof old.messages)[number],
+            ],
+          };
+        });
+        return { previous, messagesKey };
+      },
       onSuccess: () => {
         setContent("");
         setSendError(null);
       },
-      onError: (err) => setSendError(err.message),
+      onError: (err, _variables, context) => {
+        // Roll back the optimistic message; the unsent text stays in the input.
+        if (context) {
+          queryClient.setQueryData(context.messagesKey, context.previous);
+        }
+        setSendError(err.message);
+      },
+      onSettled: (_data, _err, variables) => {
+        // Reconcile the optimistic row with the real server row.
+        void queryClient.invalidateQueries({
+          queryKey: trpc.chat.getMessages.queryOptions({
+            conversationId: variables.conversationId,
+          }).queryKey,
+        });
+      },
     }),
   );
 
@@ -188,6 +236,16 @@ export default function ChatScreen() {
           testID="chat-info-btn"
           accessibilityLabel="Conversation info"
           hitSlop={12}
+          // #443 — open the partner's profile (languages, interests, photo)
+          // via the existing /partner/[id] details screen.
+          onPress={() => {
+            if (!partner) return;
+            router.push({
+              pathname: "/partner/[id]",
+              params: { id: partner.id },
+            });
+          }}
+          disabled={!partner}
         >
           <Ionicons name="information-circle-outline" size={24} color="#6F605B" />
         </TouchableOpacity>
@@ -289,6 +347,9 @@ export default function ChatScreen() {
               <TextInput
                 testID="message-input"
                 className="text-brand-foreground font-manrope text-base py-2"
+                // #442 — cap the height so long/pasted messages scroll inside
+                // the textbox instead of growing past the screen.
+                style={{ maxHeight: 120 }}
                 placeholder="Type a message…"
                 placeholderTextColor="#6F605B"
                 multiline


### PR DESCRIPTION
Closes #422
Closes #444
Closes #443
Closes #442

Four related chat bugs, all in `apps/native/app/chat/[conversationId].tsx`, fixed together to avoid file conflicts.

## #422 — Unread indicators don't clear after opening a chat
The `markRead` `onSuccess` only invalidated `chat.getMessages`. Added `chat.listEntries` invalidation alongside it, so the chat-list yellow dot and the Chats-tab red badge (both driven by `entry.hasUnread`) refresh immediately instead of lingering until the next refocus/refetch.

## #444 — Sent messages take ~5s to appear
`sendMessage` had no cache update, so the thread waited for the 5s `refetchInterval` poll. Added an optimistic update: `onMutate` cancels in-flight `getMessages` queries, snapshots the cache, and appends a temporary message so it renders instantly. `onError` rolls back the optimistic row (and leaves the unsent text in the input); `onSettled` invalidates `getMessages` to reconcile the optimistic row with the real server row. Input still clears on success via `onSuccess`.

## #443 — Conversation info (ⓘ) button did nothing
The header `TouchableOpacity` (`testID="chat-info-btn"`) had no `onPress`. Wired it to navigate to the existing partner-profile route `/partner/[id]` (which already shows name, photo, languages, and interests via `matching.getPartnerProfile`) using `partner.id` from `listEntries`. Reused the existing screen rather than building a new sheet/modal. Button is `disabled` until the partner object is loaded.

Secondary note: `apps/native/app/chat/locked/[meetupId].tsx:188` has a raw, non-tappable `Ionicons` info icon. It sits in the locked/teaser preview (decorative, alongside `FAKE_BUBBLES`) and is not clearly meant to be interactive, so it was left as-is.

## #442 — Pasting a long message overflowed the screen
The compose `TextInput` is `multiline` with a `flex-1` parent and no height cap, so it grew unbounded. Added `style={{ maxHeight: 120 }}` so long/pasted text scrolls internally; the existing `flex-1` container constrains wrapped width. Short messages still render normally.

## Verification
- `bunx jest --no-coverage` (apps/native): **38 suites / 192 tests pass**, including the 6 chat suites (`compose-ui`, `conversation-history`, `mark-messages-as-read`, `read-unread-indicators`, `empty-conversation-state`, `push-suppression-presence`). `compose-ui` directly exercises the reworked send mutation.
- Typecheck: `bunx tsc --noEmit` reports **0 errors in the edited file**. (Native has no `check-types` task; a bare project-wide `tsc` surfaces only pre-existing noise — jest globals in `__tests__` and unrelated files like `onboarding-modal.tsx` — none introduced by this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)