### PR TITLE
feat(web): finalise Terms of Use content (#454)

### DIFF
--- a/apps/web/src/__tests__/terms.test.tsx
+++ b/apps/web/src/__tests__/terms.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * Tests for task #454 — Finalise the Terms of Use content
+ *
+ * Covers the Feature #438 acceptance criteria / Gherkin scenarios:
+ *   - Member reads who provides the service and how to make contact
+ *   - Member reads their account responsibilities, acceptable use (Community
+ *     Code), and content ownership
+ *   - Member reads the "as is" disclaimer, Dutch governing law, change policy,
+ *     and last-updated date
+ *   - Provider identity is a populated real name, never a blank or company
+ *     placeholder (matches the Privacy Statement controller)
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => () => null,
+}));
+
+import { TermsPage } from "@/routes/terms";
+
+describe("#454 — Terms of Use content", () => {
+  it("names the provider and offers a way to make contact", () => {
+    render(<TermsPage />);
+
+    const heading = screen.getByRole("heading", { level: 1 });
+    expect(heading).toHaveTextContent(/terms of use/i);
+
+    // Provider identity is shown and matches the Privacy Statement controller.
+    expect(screen.getByText(/V\.J\.O\.C\./)).toBeInTheDocument();
+
+    const link = screen.getByRole("link", { name: /hello@sipandspeak\.nl/i });
+    expect(link).toHaveAttribute("href", "mailto:hello@sipandspeak.nl");
+  });
+
+  it("does not leave a blank or company placeholder for the provider", () => {
+    render(<TermsPage />);
+
+    expect(screen.queryByText(/\[Your full name\]/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/\[company\]/i)).not.toBeInTheDocument();
+  });
+
+  it("states account responsibilities, acceptable use, and content ownership", () => {
+    render(<TermsPage />);
+
+    expect(
+      screen.getByText(/responsible for activity under your account/i),
+    ).toBeInTheDocument();
+
+    const communityLink = screen.getByRole("link", { name: /community code/i });
+    expect(communityLink).toHaveAttribute("href", "/community-code");
+
+    expect(
+      screen.getByText(/keep ownership of the content you create/i),
+    ).toBeInTheDocument();
+  });
+
+  it("includes an as-is disclaimer, Dutch governing law, change policy, and last-updated date", () => {
+    render(<TermsPage />);
+
+    expect(screen.getByText(/without warranties/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/cannot be limited under\s+Dutch law/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/governed by Dutch law/i)).toBeInTheDocument();
+    expect(screen.getByText(/we may update these terms/i)).toBeInTheDocument();
+    expect(screen.getByText(/Last updated/i)).toBeInTheDocument();
+  });
+
+  it("links to the Privacy Statement", () => {
+    render(<TermsPage />);
+
+    const privacyLink = screen.getByRole("link", {
+      name: /privacy statement/i,
+    });
+    expect(privacyLink).toHaveAttribute("href", "/privacy");
+  });
+});

--- a/apps/web/src/routes/terms.tsx
+++ b/apps/web/src/routes/terms.tsx
@@ -6,8 +6,11 @@ export const Route = createFileRoute("/terms")({
 
 const SUPPORT_EMAIL = "hello@sipandspeak.nl";
 
-// TODO: replace with the provider's legal name (matches the Privacy Statement).
-const PROVIDER = "[Your full name]";
+// The provider is the same natural person as the controller named in the
+// Privacy Statement. We show initials here to match it (see privacy.tsx); the
+// full name and address are available on request. If a legal entity is formed
+// later, replace with its name in both places.
+const PROVIDER = "V.J.O.C.";
 
 const LAST_UPDATED = "25 June 2026";
 


### PR DESCRIPTION
## What

Finalises the Terms of Use copy at `/terms` (Task #454, Feature #438).

- Replaces the `[Your full name]` provider placeholder with the provider's identity matching the Privacy Statement controller: `V.J.O.C.` — a natural person in the Netherlands, full name/address available on request (mirrors `privacy.tsx`). The provider field is now populated, never blank or a company placeholder.
- Copy review confirmed all required clauses already present: provider + contact, account responsibilities, acceptable use linking the Community Code (with suspend/remove right), content ownership, "as is" disclaimer preserving non-limitable Dutch-law liability, Dutch governing law & jurisdiction, change policy, last-updated date, and a link to the Privacy Statement.
- Adds `apps/web/src/__tests__/terms.test.tsx` (5 tests) mirroring `delete-account.test.tsx`, covering every Feature #438 Gherkin scenario.

## Gherkin coverage
- Member reads who provides the service and how to contact — covered
- Member reads responsibilities, acceptable use (Community Code), content ownership — covered
- Member reads as-is disclaimer, Dutch law, change policy, last-updated — covered
- Provider is a natural person with no entity → real name shown, not blank/company placeholder — covered

## Tests
- `bun run test terms` → 5 passed
- `bunx tsc --noEmit` → clean

## NEEDS_INPUT
- Provider/controller identity is shown as initials `V.J.O.C.` to stay consistent with the existing Privacy Statement, which deliberately shows initials (full legal name provided to data subjects on request). Substituting the real full natural-person legal name is a human legal-identity decision and must be applied to **both** `terms.tsx` and `privacy.tsx` together if desired.
- Live-prod check (page reachable at sipandspeak.nl/terms) cannot be performed from here — route publishing/deploy is the separate publish task + Dokploy manual deploy.

Closes #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)