### PR TITLE
chore(legal): sub-processor audit for member data (#458)

### DIFF
--- a/apps/web/src/__tests__/privacy-processors.test.tsx
+++ b/apps/web/src/__tests__/privacy-processors.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * Tests for task #458 — Audit and confirm every external service that processes member data.
+ *
+ * This locks the processor audit (docs/legal/sub-processor-audit.md) against content
+ * drift: the Privacy Statement must keep naming every confirmed processor and state the
+ * transfer safeguard. Underpins Feature #437 AC3 (the statement names every processor).
+ *
+ * Covers:
+ *   - The email processor (Resend) is named and its data (email) disclosed
+ *   - The push chain (Expo, Apple, Google) is named
+ *   - The hosting location (own server, Netherlands) is stated
+ *   - The international-transfer safeguard (SCCs, GDPR Art. 46) is stated
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => () => null,
+}));
+
+import { PrivacyPage } from "@/routes/privacy";
+
+describe("#458 — privacy statement names every confirmed processor", () => {
+  it("names Resend as the sign-in email processor and discloses it receives the email address", () => {
+    render(<PrivacyPage />);
+
+    expect(screen.getByText(/Resend/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/one-time sign-in codes and\s+account emails/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/receive your email address/i)).toBeInTheDocument();
+  });
+
+  it("names the push chain — Expo, with Apple and Google push services", () => {
+    render(<PrivacyPage />);
+
+    expect(screen.getByText(/Expo/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Apple and Google push services/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/push notifications/i)).toBeInTheDocument();
+  });
+
+  it("states member data is hosted on an own server in the Netherlands", () => {
+    render(<PrivacyPage />);
+
+    expect(
+      screen.getByText(/our own server in the Netherlands/i),
+    ).toBeInTheDocument();
+  });
+
+  it("states the transfer safeguard for data leaving the EEA (SCCs, GDPR Art. 46)", () => {
+    render(<PrivacyPage />);
+
+    expect(
+      screen.getByText(/transferred outside the European Economic Area/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Standard Contractual Clauses/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Article 46/i)).toBeInTheDocument();
+  });
+});

--- a/docs/legal/sub-processor-audit.md
+++ b/docs/legal/sub-processor-audit.md
@@ -1,0 +1,45 @@
+# Sub-processor audit — member personal data
+
+**Owner:** Sander (xiduzo), solo PO / controller contact `hello@sipandspeak.nl`
+**Last updated:** 25 June 2026
+**Task:** #458 (Feature #437 — Privacy Statement) · **Underpins AC3** (the statement names every processor).
+
+## Purpose
+
+A confirmed, code-derived list of every external service that receives a member's
+personal data, so the Privacy Statement (`apps/web/src/routes/privacy.tsx`) can be
+truthful and complete. If a service here is not named on `/privacy`, members are
+misled about who handles their data. Keep this file and `privacy.tsx` in sync; this
+is the baseline the content tasks (#459/#460) consume.
+
+> Method: walked the auth, web sign-in, native push, payments and monitoring
+> integrations in the codebase (June 2026). Each row is backed by a real call site.
+
+## Confirmed processors (named in `/privacy`)
+
+| Service | Data shared | Purpose | Location | Transfer safeguard | Code evidence |
+| ------- | ----------- | ------- | -------- | ------------------ | ------------- |
+| **Resend** | Member email address | Sends one-time sign-in (OTP) codes and account emails | United States (outside EEA) | SCCs (GDPR Art. 46) | `packages/auth/src/index.ts` — `emailOTP.sendVerificationOTP` → `resend.emails.send({ from: env.RESEND_FROM, to: email, ... })`; client init `new Resend(env.RESEND_API_KEY)`. Triggered from `apps/web/src/components/sign-in-form.tsx` (`authClient.emailOtp.sendVerificationOtp`). |
+| **Expo** (Expo Push / EAS) | Device Expo push token + notification content | Delivers push notifications | United States (outside EEA) | SCCs (GDPR Art. 46) | `apps/native/lib/notifications.ts` — `getExpoPushTokenAsync({ projectId })`; registered in `apps/native/app/_layout.tsx` (`useDeviceTokenRegistration` → `trpc.profile.registerDeviceToken`). |
+| **Apple APNs** | Device push token | Underlying iOS push delivery (behind Expo) | United States (outside EEA) | SCCs (GDPR Art. 46) | Same push chain as Expo (iOS leg). Named on `/privacy` as "Apple … push services". |
+| **Google FCM** | Device push token | Underlying Android push delivery (behind Expo) | United States (outside EEA) | SCCs (GDPR Art. 46) | Same push chain as Expo (Android leg). Named on `/privacy` as "Google … push services". |
+| **Own server (hosting)** | All member data (email, name, profile, app content) | Primary hosting / database | Netherlands (EEA) | N/A — data stays in the EEA | Self-hosted (Dokploy). Stated on `/privacy`: "stored on our own server in the Netherlands". |
+
+## Flagged — processors that receive member data but are NOT yet named on `/privacy`
+
+These are out of the literal task scope (email/push/hosting) but the audit invariant
+is "every external service that receives member data must appear in the audit list".
+They are flagged here for the content tasks (#459/#460) to decide on, not fixed here.
+
+| Service | Data shared | Purpose | Location | Transfer safeguard | Code evidence | Action |
+| ------- | ----------- | ------- | -------- | ------------------ | ------------- | ------ |
+| **Polar** | Member email + name | Payments / customer record (created on user sign-up) | United States (outside EEA) | SCCs (GDPR Art. 46) | `packages/auth/src/lib/payments.ts` (`new Polar({ accessToken, server: "sandbox" })`); `packages/auth/src/index.ts` user-create hook → `polarClient.customers.create({ email: user.email, name: user.name })`. | **FLAG:** receives email+name, US-based, not on `/privacy`. Currently `server: "sandbox"` (not live). #459/#460 should add it or confirm it is inactive in production. |
+| **Sentry** | Crash/error events (may incidentally include device/user context) | Error & performance monitoring (native app) | EU region — `ingest.de.sentry.io` (Germany, EEA) | N/A — EU data residency | `apps/native/lib/sentry.ts` — `Sentry.init({ dsn: "https://…@o…ingest.de.sentry.io/…" })`. | **FLAG (minor):** EU-hosted so no transfer concern; consider naming for completeness. |
+
+## Notes
+
+- No analytics, tracking, or marketing-email provider is used (confirmed: no such
+  integration in the codebase; `/privacy` already states this).
+- Content-drift control: this file plus the "last updated" date and named owner on
+  `/privacy` are the discipline that keeps the processor list truthful. Update both
+  whenever a processor is added, removed, or changes region.


### PR DESCRIPTION
## What

Task #458 (Feature #437 — Privacy Statement). Audits, from the actual code, every external service that processes member data and records it so it cannot drift.

## Findings (confirmed processors)

| Service | Data | Location | Safeguard | Named on /privacy |
| --- | --- | --- | --- | --- |
| Resend | email address | US | SCCs (Art. 46) | yes |
| Expo + Apple APNs + Google FCM | device push token | US | SCCs (Art. 46) | yes |
| Own server | all member data | Netherlands (EEA) | N/A (in EEA) | yes |

### Flagged — receive member data but NOT named on /privacy
- **Polar** — payments; receives email + name; US; currently `server: "sandbox"`. For #459/#460 to add or confirm inactive in prod.
- **Sentry** — native crash monitoring; EU-hosted (`ingest.de.sentry.io`), so no transfer concern.

## Changes
- `docs/legal/sub-processor-audit.md` — the confirmed processor list (service, data, purpose, location, safeguard, code evidence) that #459/#460 consume.
- `apps/web/src/__tests__/privacy-processors.test.tsx` — render test asserting `/privacy` names each confirmed processor and the transfer safeguard. Underpins AC3. Does **not** edit `privacy.tsx` copy (that's #459/#460).

## Verification
- `bun run test` (web) — 4/4 pass.
- `bun run check-types` (web) — passes.

Closes #458