### PR TITLE
fix(native): distinguish "agree" from "acknowledge" in enrolment consent (#457)

### DIFF
--- a/apps/native/__tests__/enrolment-consent-wording.test.tsx
+++ b/apps/native/__tests__/enrolment-consent-wording.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * Tests for task #457 — enrolment consent wording distinguishes
+ * "agree" (Terms of Use, Community Code) from "acknowledge" (Privacy Statement).
+ */
+import { render, screen } from "@testing-library/react-native";
+import React from "react";
+
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ replace: jest.fn(), push: jest.fn() }),
+}));
+
+jest.mock("@/lib/auth-client", () => ({
+  authClient: {
+    emailOtp: { sendVerificationOtp: jest.fn() },
+    signIn: { emailOtp: jest.fn() },
+  },
+}));
+
+jest.mock("@/utils/trpc", () => ({
+  queryClient: { refetchQueries: jest.fn() },
+}));
+
+import EnrolmentScreen from "../app/enrolment";
+
+describe("#457 — enrolment consent wording", () => {
+  it("renders one consent sentence: agree to Terms of Use and Community Code, acknowledge Privacy Statement", () => {
+    render(<EnrolmentScreen />);
+
+    // Full composed sentence locks the agree-vs-acknowledge distinction so neither
+    // verb can drift onto the wrong document.
+    expect(
+      screen.getByText(
+        "By joining you agree to our Terms of Use and Community Code, and acknowledge our Privacy Statement.",
+      ),
+    ).toBeTruthy();
+  });
+
+  it("uses 'agree to' for the contractual documents", () => {
+    render(<EnrolmentScreen />);
+    expect(screen.getByText(/agree to our/)).toBeTruthy();
+  });
+
+  it("uses 'acknowledge' only for the Privacy Statement", () => {
+    render(<EnrolmentScreen />);
+    expect(screen.getByText(/, and acknowledge our/)).toBeTruthy();
+  });
+
+  it("keeps Terms of Use, Community Code, and Privacy Statement as discrete named documents", () => {
+    render(<EnrolmentScreen />);
+    expect(screen.getByText("Terms of Use")).toBeTruthy();
+    expect(screen.getByText("Community Code")).toBeTruthy();
+    expect(screen.getByText("Privacy Statement")).toBeTruthy();
+  });
+});

--- a/apps/native/app/enrolment.tsx
+++ b/apps/native/app/enrolment.tsx
@@ -409,7 +409,7 @@ export default function EnrolmentScreen() {
               <Text className="font-manrope text-[13px] text-brand-muted-foreground text-center leading-5">
                 By joining you agree to our{" "}
                 <Text className="underline" onPress={() => openLegal("/terms")}>
-                  Terms
+                  Terms of Use
                 </Text>{" "}
                 and{" "}
                 <Text


### PR DESCRIPTION
## What

Task #457 (Feature #440, AC2). Words the enrolment consent sentence so the agree-vs-acknowledge distinction is precise and unambiguous:

- Renamed the link label `Terms` → `Terms of Use` to match the legal document and the Feature #440 Gherkin/AC wording.
- The consent sentence now reads: "By joining you agree to our **Terms of Use** and **Community Code**, and acknowledge our **Privacy Statement**." — "agree to" governs the two contractual documents; "acknowledge" governs only the Privacy Statement.
- All three document names remain pressable links. Link-opening / graceful-failure logic is intentionally untouched (owned by sibling task #456).

## Tests

Added `apps/native/__tests__/enrolment-consent-wording.test.tsx` (4 cases) that render the enrolment screen and lock the full composed consent sentence, plus the agree/acknowledge verb governance and the three discrete named documents — guarding against copy drift.

- `bun run test` (native, this file): 4 passed
- `bun run check-types` (native): clean

## Gherkin coverage

- "Wording distinguishes agreement from acknowledgement" → covered by tests.
- "Each document remains reachable" → link names render as pressable; the actual browser-open behaviour is task #456's scope.

Closes #457

🤖 Generated with [Claude Code](https://claude.com/claude-code)