### PR TITLE
Finalise Community Code content aligned with Moderation policy (#461)

### DIFF
--- a/apps/web/src/__tests__/community-code.test.tsx
+++ b/apps/web/src/__tests__/community-code.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * Tests for task #461 — Finalise Community Code content aligned with Moderation policy
+ *
+ * Covers the Gherkin scenarios for Feature #439:
+ *   - Member reads the expected conduct (respect, authenticity, keeping safe)
+ *   - Member learns how to report a violation (in-app tools + support email only)
+ *   - Member learns the consequences (warning, suspension, permanent removal)
+ *     aligned with the removal / re-registration-prevention policy
+ *   - Reporting section avoids channels that do not exist
+ */
+import { render, screen, within } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => () => null,
+}));
+
+import { CommunityCodePage } from "@/routes/community-code";
+
+describe("#461 — Community Code conduct", () => {
+  it("renders without authentication with a single top-level heading", () => {
+    render(<CommunityCodePage />);
+
+    const headings = screen.getAllByRole("heading", { level: 1 });
+    expect(headings).toHaveLength(1);
+    expect(headings[0]).toHaveTextContent(/community code/i);
+  });
+
+  it("describes being respectful, being genuine, and keeping each other safe", () => {
+    render(<CommunityCodePage />);
+
+    // Be respectful
+    expect(screen.getByText(/be respectful/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/no harassment,\s*hate speech, discrimination, or bullying/i),
+    ).toBeInTheDocument();
+
+    // Be genuine / authenticity
+    expect(screen.getByText(/be genuine/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/use a real name and real details/i),
+    ).toBeInTheDocument();
+
+    // Keep each other safe
+    expect(screen.getByText(/keep each other safe/i)).toBeInTheDocument();
+    expect(screen.getByText(/meet in public places/i)).toBeInTheDocument();
+  });
+});
+
+describe("#461 — reporting a violation", () => {
+  it("points members to the in-app reporting tools and the support email", () => {
+    render(<CommunityCodePage />);
+
+    const section = within(screen.getByTestId("report-section"));
+    expect(section.getByText(/in-app\s+reporting tools/i)).toBeInTheDocument();
+
+    const link = section.getByRole("link", {
+      name: /hello@sipandspeak\.nl/i,
+    });
+    expect(link).toHaveAttribute("href", "mailto:hello@sipandspeak.nl");
+  });
+
+  it("names no reporting channel that does not exist", () => {
+    render(<CommunityCodePage />);
+
+    const section = screen.getByTestId("report-section");
+    // Only the in-app tools and the support email are live channels — no phone
+    // line, hotline, WhatsApp, Discord, social handles, or postal address.
+    expect(section.textContent).not.toMatch(
+      /phone|hotline|call us|whatsapp|telegram|discord|twitter|instagram|facebook|postal|hotline/i,
+    );
+  });
+});
+
+describe("#461 — consequences aligned with Moderation policy", () => {
+  it("describes a warning, suspension, or permanent removal", () => {
+    render(<CommunityCodePage />);
+
+    const text = screen.getByText(
+      /warning, suspension, or permanent\s+removal/i,
+    );
+    expect(text).toBeInTheDocument();
+  });
+
+  it("frames consequences at moderator discretion depending on severity", () => {
+    render(<CommunityCodePage />);
+
+    expect(
+      screen.getByText(/at our discretion and depending on\s+severity/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/routes/community-code.tsx
+++ b/apps/web/src/routes/community-code.tsx
@@ -43,7 +43,7 @@ export function CommunityCodePage() {
         </p>
       </section>
 
-      <section className="mb-6">
+      <section className="mb-6" data-testid="report-section">
         <h2 className="mb-2 text-xl font-semibold">Report problems</h2>
         <p>
           If someone makes you uncomfortable or breaks this code, use the in-app


### PR DESCRIPTION
## Summary

Finalises the Community Code content (Task #461, Feature #439) and adds a render test. This is a verify/complete-the-gap task — the page was already drafted in baa41f3.

### Verification performed
- **Conduct (AC2):** page states respect (no harassment/hate speech/discrimination/bullying), authenticity (real name, no impersonation), and keeping each other safe (meet in public, protect others' info, own judgement). ✅
- **Reporting (AC3):** references only live channels — in-app reporting tools (member `userFlag` creation mutation exists in `packages/api/src/contexts/moderation/moderation.ts`) and the support email `hello@sipandspeak.nl` (matches `delete-account.tsx`). No fictional channels. ✅
- **Consequences:** warning, suspension, or permanent removal at moderator discretion — aligns with the removal / re-registration-prevention (email blocklist) policy on `delete-account.tsx` and the moderation context (`StudentSuspended`, `StudentRemoved`, blocklist). ✅

No copy mismatches were found; content was already accurate. Only change: added `data-testid="report-section"` to scope the test.

### Changes
- `apps/web/src/routes/community-code.tsx` — add `data-testid` to reporting section.
- `apps/web/src/__tests__/community-code.test.tsx` — new render test (6 tests) covering all four Gherkin scenarios.

### Tests
- `bun run test` (web): 6/6 pass.
- `bun run check-types` (web): pass.

Closes #461