### PR TITLE
Publish and verify the /community-code route (#463)

### DIFF
--- a/apps/web/src/__tests__/community-code.test.tsx
+++ b/apps/web/src/__tests__/community-code.test.tsx
@@ -11,11 +11,18 @@
 import { render, screen, within } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 
+// Capture the path passed to createFileRoute so we can assert the route is
+// registered at the public `/community-code` address (task #463, AC1).
+const { createFileRouteMock } = vi.hoisted(() => ({
+  createFileRouteMock: vi.fn((_path: string) => () => null),
+}));
+
 vi.mock("@tanstack/react-router", () => ({
-  createFileRoute: () => () => null,
+  createFileRoute: createFileRouteMock,
 }));
 
 import { CommunityCodePage } from "@/routes/community-code";
+import { TermsPage } from "@/routes/terms";
 
 describe("#461 — Community Code conduct", () => {
   it("renders without authentication with a single top-level heading", () => {
@@ -88,5 +95,20 @@ describe("#461 — consequences aligned with Moderation policy", () => {
     expect(
       screen.getByText(/at our discretion and depending on\s+severity/i),
     ).toBeInTheDocument();
+  });
+});
+
+describe("#463 — /community-code route is published and discoverable", () => {
+  // Scenario: Member opens the Community Code page (route registration / AC1)
+  it("registers a file route at the public /community-code address", () => {
+    expect(createFileRouteMock).toHaveBeenCalledWith("/community-code");
+  });
+
+  // Scenario: Member reaches the Community Code from the Terms page
+  it("is linked from the Terms page", () => {
+    render(<TermsPage />);
+
+    const link = screen.getByRole("link", { name: /community code/i });
+    expect(link).toHaveAttribute("href", "/community-code");
   });
 });


### PR DESCRIPTION
## Summary

Task #463 — Publish and verify the `/community-code` route on the web app (Feature #439, Epic #436).

This is a verify/complete-the-gap task. The route was already drafted (commit baa41f3) and its content finalised by #461. Confirmed everything is in place and closed the one real test gap:

- `createFileRoute("/community-code")` is registered in `apps/web/src/routes/community-code.tsx`.
- `apps/web/src/routeTree.gen.ts` contains the generated `CommunityCodeRoute` entry (route tree builds cleanly via `vite build`).
- The page is linked from the Terms page (`apps/web/src/routes/terms.tsx`).

### Change
Extended `apps/web/src/__tests__/community-code.test.tsx` with a `#463` block asserting:
- the file route is registered at the public `/community-code` address (AC1, Gherkin: "Member opens the Community Code page");
- the page is discoverable from the Terms page (Gherkin: "Member reaches the Community Code from the Terms page").

### Verification
- `bun run test community-code` → 8 passed
- `bun run check-types` (vite build + tsc --noEmit) → green

### Not deployable from here
The Gherkin scenario "Community Code is reachable in production (sipandspeak.nl/community-code)" requires a manual Dokploy deploy and cannot be exercised from this environment.

Closes #463