### PR TITLE
test(web): publish /terms route + verify cross-links resolve (#455)

### DIFF
--- a/apps/web/src/__tests__/terms.test.tsx
+++ b/apps/web/src/__tests__/terms.test.tsx
@@ -18,6 +18,9 @@ vi.mock("@tanstack/react-router", () => ({
 }));
 
 import { TermsPage } from "@/routes/terms";
+import { PrivacyPage } from "@/routes/privacy";
+import { CommunityCodePage } from "@/routes/community-code";
+import { DeleteAccountPage } from "@/routes/delete-account";
 
 describe("#454 — Terms of Use content", () => {
   it("names the provider and offers a way to make contact", () => {
@@ -74,5 +77,37 @@ describe("#454 — Terms of Use content", () => {
       name: /privacy statement/i,
     });
     expect(privacyLink).toHaveAttribute("href", "/privacy");
+  });
+});
+
+describe("#455 — /terms cross-links resolve to live pages", () => {
+  it("exposes cross-links to the Privacy Statement, Community Code, and account deletion", () => {
+    render(<TermsPage />);
+
+    expect(
+      screen.getByRole("link", { name: /privacy statement/i }),
+    ).toHaveAttribute("href", "/privacy");
+    expect(
+      screen.getByRole("link", { name: /community code/i }),
+    ).toHaveAttribute("href", "/community-code");
+    expect(
+      screen.getByRole("link", { name: /delete your account/i }),
+    ).toHaveAttribute("href", "/delete-account");
+  });
+
+  // A cross-link only "resolves" if its target route module is real and the
+  // page actually renders. Importing and rendering each target guards against a
+  // link pointing at a route that exists in source but is missing or broken.
+  it("each cross-link target renders a real page rather than a missing page", () => {
+    const { unmount: unmountPrivacy } = render(<PrivacyPage />);
+    expect(screen.getAllByRole("heading", { level: 1 }).length).toBe(1);
+    unmountPrivacy();
+
+    const { unmount: unmountCommunity } = render(<CommunityCodePage />);
+    expect(screen.getAllByRole("heading", { level: 1 }).length).toBe(1);
+    unmountCommunity();
+
+    render(<DeleteAccountPage />);
+    expect(screen.getAllByRole("heading", { level: 1 }).length).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

Task #455 (Feature #438) — confirm the `/terms` route is published and its in-page cross-links resolve to live pages.

- **Route registered & served:** `apps/web/src/routes/terms.tsx` declares `createFileRoute("/terms")` and `/terms` is present in `apps/web/src/routeTree.gen.ts`. `bun run check-types` (vite build, which regenerates the route tree) succeeds with no diff to the generated tree — the page is built and served.
- **Cross-links verified:** the terms page links to `/privacy`, `/community-code`, and `/delete-account`; all three target route modules exist and render.
- **Tests:** extended `apps/web/src/__tests__/terms.test.tsx` with a #455 block asserting the three cross-link hrefs and that each target page renders a real page (not a missing page). Full web suite: 41 passing.

No production copy changed (content owned by #454).

## Gherkin coverage
- Terms page reachable — route registered + present in generated tree, build serves it.
- Cross-links resolve — render test asserts hrefs + each target page renders.
- Cross-link targets ship alongside — `/privacy` + `/community-code` modules imported and rendered in-test.

Closes #455

🤖 Generated with [Claude Code](https://claude.com/claude-code)