### PR TITLE
Publish & verify the /privacy route (#462)

### DIFF
--- a/apps/web/src/__tests__/privacy-route.test.tsx
+++ b/apps/web/src/__tests__/privacy-route.test.tsx
@@ -1,0 +1,34 @@
+/**
+ * Tests for task #462 — Publish the /privacy route and verify it is reachable.
+ *
+ * Covers Feature #437 AC1 reachability at the unit level (production
+ * reachability itself is a manual Dokploy deploy check):
+ *   - The page is registered at the "/privacy" path (createFileRoute("/privacy"))
+ *     so it is generated into the route tree and served at sipandspeak.nl/privacy.
+ *   - The deletion link resolves to /delete-account (Gherkin: "The deletion link
+ *     resolves from the published page").
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+
+// Capture the path passed to createFileRoute so we can assert the route is
+// registered at "/privacy" — the value that the router codegen reads to build
+// routeTree.gen.ts.
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: (path: string) => (_options: unknown) => ({ path }),
+}));
+
+import { PrivacyPage, Route } from "@/routes/privacy";
+
+describe("#462 — /privacy route registration & reachability", () => {
+  it("registers the privacy statement at the /privacy path", () => {
+    expect((Route as unknown as { path: string }).path).toBe("/privacy");
+  });
+
+  it("resolves the deletion link to the account-deletion page", () => {
+    render(<PrivacyPage />);
+
+    const link = screen.getByRole("link", { name: /delete your account/i });
+    expect(link.getAttribute("href")).toBe("/delete-account");
+  });
+});


### PR DESCRIPTION
## Summary

Publishes and verifies the `/privacy` route for Feature #437.

The route was already correctly registered — `createFileRoute("/privacy")` in `apps/web/src/routes/privacy.tsx` and present in `apps/web/src/routeTree.gen.ts` (confirmed unchanged after a clean `vite build` route-tree regen). It is discoverable via the Privacy Statement link in `terms.tsx`. The gap was test coverage for AC1 reachability, so this adds a focused route-registration test.

## Changes

- Add `apps/web/src/__tests__/privacy-route.test.tsx`:
  - asserts the page is registered at the `/privacy` path (the value the router codegen reads).
  - asserts the deletion link resolves to `/delete-account` (Gherkin: "The deletion link resolves from the published page").

## Verification

- `bun run test` (apps/web): 6 files, 58 tests pass (incl. 2 new).
- `bun run check-types` (apps/web): `vite build` + `tsc --noEmit` clean; route tree unchanged.

## NEEDS_INPUT — production reachability

Gherkin scenario "A prospective member opens the published Privacy Statement" and the DoD item "sipandspeak.nl/privacy reachable in production" require a **manual Dokploy redeploy** of the web app after this feature lands on `main`. That cannot be performed from CI/this worktree — confirm the live URL post-deploy.

Closes #462