### PR TITLE
fix(native): harden enrolment legal links with graceful failure (#456)

### DIFF
--- a/apps/native/__tests__/enrolment-legal-links.test.ts
+++ b/apps/native/__tests__/enrolment-legal-links.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Tests for task #456 — Open enrolment legal links in the device browser with
+ * graceful failure.
+ *
+ * Covers:
+ *   - Each link (Terms of Use, Community Code, Privacy Statement) opens its
+ *     canonical sipandspeak.nl URL, passed unchanged.
+ *   - A rejected openURL (offline page / no browser / no link handler) is
+ *     handled without throwing, so sign-up is never blocked or crashed.
+ */
+import { Linking } from "react-native";
+
+import { LEGAL_BASE_URL, openLegal } from "@/utils/open-legal";
+
+jest.mock("react-native", () => ({
+  Linking: { openURL: jest.fn() },
+}));
+
+const mockOpenURL = Linking.openURL as jest.Mock;
+
+describe("openLegal", () => {
+  beforeEach(() => {
+    mockOpenURL.mockReset();
+  });
+
+  it("uses the canonical https sipandspeak.nl origin", () => {
+    expect(LEGAL_BASE_URL).toBe("https://sipandspeak.nl");
+  });
+
+  it.each([
+    ["/terms", "https://sipandspeak.nl/terms"],
+    ["/community-code", "https://sipandspeak.nl/community-code"],
+    ["/privacy", "https://sipandspeak.nl/privacy"],
+  ])(
+    "opens %s at the correct canonical sipandspeak.nl URL",
+    async (path, expected) => {
+      mockOpenURL.mockResolvedValue(true);
+
+      await openLegal(path);
+
+      expect(mockOpenURL).toHaveBeenCalledTimes(1);
+      expect(mockOpenURL).toHaveBeenCalledWith(expected);
+    },
+  );
+
+  it("does not throw when the open is rejected (offline / no browser / no link handler)", async () => {
+    mockOpenURL.mockRejectedValue(new Error("No app can handle this URL"));
+
+    await expect(openLegal("/terms")).resolves.toBeUndefined();
+    // Still attempted at the canonical address even though it was rejected.
+    expect(mockOpenURL).toHaveBeenCalledWith("https://sipandspeak.nl/terms");
+  });
+
+  it("does not throw when openURL throws synchronously", async () => {
+    mockOpenURL.mockImplementation(() => {
+      throw new Error("boom");
+    });
+
+    await expect(openLegal("/privacy")).resolves.toBeUndefined();
+  });
+});

--- a/apps/native/app/enrolment.tsx
+++ b/apps/native/app/enrolment.tsx
@@ -3,7 +3,6 @@ import { useRouter } from "expo-router";
 import { useEffect, useRef, useState } from "react";
 import {
   KeyboardAvoidingView,
-  Linking,
   Platform,
   Pressable,
   ScrollView,
@@ -16,12 +15,8 @@ import { useToast } from "heroui-native";
 import z from "zod";
 
 import { authClient } from "@/lib/auth-client";
+import { openLegal } from "@/utils/open-legal";
 import { queryClient } from "@/utils/trpc";
-
-const LEGAL_BASE_URL = "https://sipandspeak.nl";
-const openLegal = (path: string) => {
-  void Linking.openURL(`${LEGAL_BASE_URL}${path}`);
-};
 
 const OTP_RESEND_COOLDOWN = 60;
 const GOLD = "#F2C94C";
@@ -408,18 +403,30 @@ export default function EnrolmentScreen() {
 
               <Text className="font-manrope text-[13px] text-brand-muted-foreground text-center leading-5">
                 By joining you agree to our{" "}
-                <Text className="underline" onPress={() => openLegal("/terms")}>
+                <Text
+                  className="underline"
+                  onPress={() => {
+                    void openLegal("/terms");
+                  }}
+                >
                   Terms of Use
                 </Text>{" "}
                 and{" "}
                 <Text
                   className="underline"
-                  onPress={() => openLegal("/community-code")}
+                  onPress={() => {
+                    void openLegal("/community-code");
+                  }}
                 >
                   Community Code
                 </Text>
                 , and acknowledge our{" "}
-                <Text className="underline" onPress={() => openLegal("/privacy")}>
+                <Text
+                  className="underline"
+                  onPress={() => {
+                    void openLegal("/privacy");
+                  }}
+                >
                   Privacy Statement
                 </Text>
                 .

--- a/apps/native/utils/open-legal.ts
+++ b/apps/native/utils/open-legal.ts
@@ -1,0 +1,25 @@
+import { Linking } from "react-native";
+
+/** Canonical origin for the public Sip&Speak legal pages. */
+export const LEGAL_BASE_URL = "https://sipandspeak.nl";
+
+/**
+ * Open a legal document (e.g. "/terms", "/community-code", "/privacy") in the
+ * device's default browser.
+ *
+ * Best-effort by design: a missing browser/link handler, a rejected open, or an
+ * offline target page must never throw, crash the app, or block the enrolment
+ * (email / OTP) sign-up flow. The canonical `https://sipandspeak.nl/<path>` URL
+ * is always handed to the OS unchanged, so the browser opens at the correct
+ * address even when the page itself is unreachable.
+ */
+export async function openLegal(path: string): Promise<void> {
+  const url = `${LEGAL_BASE_URL}${path}`;
+  try {
+    await Linking.openURL(url);
+  } catch {
+    // Swallow: opening external reference content is non-critical and must not
+    // surface as an unhandled rejection or interrupt sign-up. No app state
+    // changes on failure — the prospective member stays on the enrolment screen.
+  }
+}


### PR DESCRIPTION
## What

Hardens the enrolment screen legal links (Terms of Use, Community Code, Privacy Statement) so opening one in the device browser can never crash the app or block the email/OTP sign-up flow.

- Extracts the `openLegal` helper out of `enrolment.tsx` into `apps/native/utils/open-legal.ts` (mirrors `@/utils/email-name-extract`) so it is unit-testable.
- Replaces fire-and-forget `void Linking.openURL(...)` with `await Linking.openURL(...)` wrapped in try/catch. A rejected open (offline page, no browser, no link handler) or a synchronous throw is swallowed gracefully — no unhandled rejection, no crash, sign-up continues.
- Canonical `https://sipandspeak.nl/<path>` URLs (`/terms`, `/community-code`, `/privacy`) are passed unchanged, so the browser opens at the correct address even when the page is unreachable.

Does NOT touch the agree-vs-acknowledge consent wording (owned by sibling #457, already merged).

## Tests

`apps/native/__tests__/enrolment-legal-links.test.ts` — 6 passing:
- each link opens its correct canonical sipandspeak.nl URL
- canonical https origin is used
- rejected openURL resolves without throwing (offline / no browser / no handler)
- synchronous throw is handled without throwing

`bun run check-types` passes.

## Gherkin coverage
- Opens each legal document → covered (URL assertions)
- Legal page offline → covered (rejected open still attempted at canonical URL, no throw)
- No browser / link handler → covered (rejected/throwing open handled quietly)

Closes #456

🤖 Generated with [Claude Code](https://claude.com/claude-code)