### PR TITLE
🚀 Feature #438: Terms of Use

### DIFF
--- a/apps/web/src/__tests__/terms.test.tsx
+++ b/apps/web/src/__tests__/terms.test.tsx
@@ -18,6 +18,9 @@ vi.mock("@tanstack/react-router", () => ({
 }));
 
 import { TermsPage } from "@/routes/terms";
+import { PrivacyPage } from "@/routes/privacy";
+import { CommunityCodePage } from "@/routes/community-code";
+import { DeleteAccountPage } from "@/routes/delete-account";
 
 describe("#454 — Terms of Use content", () => {
   it("names the provider and offers a way to make contact", () => {
@@ -74,5 +77,37 @@ describe("#454 — Terms of Use content", () => {
       name: /privacy statement/i,
     });
     expect(privacyLink).toHaveAttribute("href", "/privacy");
+  });
+});
+
+describe("#455 — /terms cross-links resolve to live pages", () => {
+  it("exposes cross-links to the Privacy Statement, Community Code, and account deletion", () => {
+    render(<TermsPage />);
+
+    expect(
+      screen.getByRole("link", { name: /privacy statement/i }),
+    ).toHaveAttribute("href", "/privacy");
+    expect(
+      screen.getByRole("link", { name: /community code/i }),
+    ).toHaveAttribute("href", "/community-code");
+    expect(
+      screen.getByRole("link", { name: /delete your account/i }),
+    ).toHaveAttribute("href", "/delete-account");
+  });
+
+  // A cross-link only "resolves" if its target route module is real and the
+  // page actually renders. Importing and rendering each target guards against a
+  // link pointing at a route that exists in source but is missing or broken.
+  it("each cross-link target renders a real page rather than a missing page", () => {
+    const { unmount: unmountPrivacy } = render(<PrivacyPage />);
+    expect(screen.getAllByRole("heading", { level: 1 }).length).toBe(1);
+    unmountPrivacy();
+
+    const { unmount: unmountCommunity } = render(<CommunityCodePage />);
+    expect(screen.getAllByRole("heading", { level: 1 }).length).toBe(1);
+    unmountCommunity();
+
+    render(<DeleteAccountPage />);
+    expect(screen.getAllByRole("heading", { level: 1 }).length).toBe(1);
   });
 });

--- a/apps/web/src/__tests__/terms.test.tsx
+++ b/apps/web/src/__tests__/terms.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * Tests for task #454 — Finalise the Terms of Use content
+ *
+ * Covers the Feature #438 acceptance criteria / Gherkin scenarios:
+ *   - Member reads who provides the service and how to make contact
+ *   - Member reads their account responsibilities, acceptable use (Community
+ *     Code), and content ownership
+ *   - Member reads the "as is" disclaimer, Dutch governing law, change policy,
+ *     and last-updated date
+ *   - Provider identity is a populated real name, never a blank or company
+ *     placeholder (matches the Privacy Statement controller)
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => () => null,
+}));
+
+import { TermsPage } from "@/routes/terms";
+
+describe("#454 — Terms of Use content", () => {
+  it("names the provider and offers a way to make contact", () => {
+    render(<TermsPage />);
+
+    const heading = screen.getByRole("heading", { level: 1 });
+    expect(heading).toHaveTextContent(/terms of use/i);
+
+    // Provider identity is shown and matches the Privacy Statement controller.
+    expect(screen.getByText(/V\.J\.O\.C\./)).toBeInTheDocument();
+
+    const link = screen.getByRole("link", { name: /hello@sipandspeak\.nl/i });
+    expect(link).toHaveAttribute("href", "mailto:hello@sipandspeak.nl");
+  });
+
+  it("does not leave a blank or company placeholder for the provider", () => {
+    render(<TermsPage />);
+
+    expect(screen.queryByText(/\[Your full name\]/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/\[company\]/i)).not.toBeInTheDocument();
+  });
+
+  it("states account responsibilities, acceptable use, and content ownership", () => {
+    render(<TermsPage />);
+
+    expect(
+      screen.getByText(/responsible for activity under your account/i),
+    ).toBeInTheDocument();
+
+    const communityLink = screen.getByRole("link", { name: /community code/i });
+    expect(communityLink).toHaveAttribute("href", "/community-code");
+
+    expect(
+      screen.getByText(/keep ownership of the content you create/i),
+    ).toBeInTheDocument();
+  });
+
+  it("includes an as-is disclaimer, Dutch governing law, change policy, and last-updated date", () => {
+    render(<TermsPage />);
+
+    expect(screen.getByText(/without warranties/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/cannot be limited under\s+Dutch law/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/governed by Dutch law/i)).toBeInTheDocument();
+    expect(screen.getByText(/we may update these terms/i)).toBeInTheDocument();
+    expect(screen.getByText(/Last updated/i)).toBeInTheDocument();
+  });
+
+  it("links to the Privacy Statement", () => {
+    render(<TermsPage />);
+
+    const privacyLink = screen.getByRole("link", {
+      name: /privacy statement/i,
+    });
+    expect(privacyLink).toHaveAttribute("href", "/privacy");
+  });
+});

--- a/apps/web/src/routes/terms.tsx
+++ b/apps/web/src/routes/terms.tsx
@@ -6,8 +6,11 @@ export const Route = createFileRoute("/terms")({
 
 const SUPPORT_EMAIL = "hello@sipandspeak.nl";
 
-// TODO: replace with the provider's legal name (matches the Privacy Statement).
-const PROVIDER = "[Your full name]";
+// The provider is the same natural person as the controller named in the
+// Privacy Statement. We show initials here to match it (see privacy.tsx); the
+// full name and address are available on request. If a legal entity is formed
+// later, replace with its name in both places.
+const PROVIDER = "V.J.O.C.";
 
 const LAST_UPDATED = "25 June 2026";
 


### PR DESCRIPTION
## Feature #438 — Member can read the Terms of Use

Terms of Use at `/terms` under Epic #436: provider + contact, account responsibilities, acceptable use (links Community Code), content ownership, "as is" disclaimer, Dutch governing law/jurisdiction, change policy, last-updated date, link to `/privacy`. Cross-links to `/privacy` and `/community-code` verified to resolve.

Closes #438
Closes #454
Closes #455

🤖 Generated with [Claude Code](https://claude.com/claude-code)
