### PR TITLE
🚀 Feature #440: Enrolment legal links

### DIFF
--- a/apps/native/__tests__/enrolment-consent-wording.test.tsx
+++ b/apps/native/__tests__/enrolment-consent-wording.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * Tests for task #457 — enrolment consent wording distinguishes
+ * "agree" (Terms of Use, Community Code) from "acknowledge" (Privacy Statement).
+ */
+import { render, screen } from "@testing-library/react-native";
+import React from "react";
+
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ replace: jest.fn(), push: jest.fn() }),
+}));
+
+jest.mock("@/lib/auth-client", () => ({
+  authClient: {
+    emailOtp: { sendVerificationOtp: jest.fn() },
+    signIn: { emailOtp: jest.fn() },
+  },
+}));
+
+jest.mock("@/utils/trpc", () => ({
+  queryClient: { refetchQueries: jest.fn() },
+}));
+
+import EnrolmentScreen from "../app/enrolment";
+
+describe("#457 — enrolment consent wording", () => {
+  it("renders one consent sentence: agree to Terms of Use and Community Code, acknowledge Privacy Statement", () => {
+    render(<EnrolmentScreen />);
+
+    // Full composed sentence locks the agree-vs-acknowledge distinction so neither
+    // verb can drift onto the wrong document.
+    expect(
+      screen.getByText(
+        "By joining you agree to our Terms of Use and Community Code, and acknowledge our Privacy Statement.",
+      ),
+    ).toBeTruthy();
+  });
+
+  it("uses 'agree to' for the contractual documents", () => {
+    render(<EnrolmentScreen />);
+    expect(screen.getByText(/agree to our/)).toBeTruthy();
+  });
+
+  it("uses 'acknowledge' only for the Privacy Statement", () => {
+    render(<EnrolmentScreen />);
+    expect(screen.getByText(/, and acknowledge our/)).toBeTruthy();
+  });
+
+  it("keeps Terms of Use, Community Code, and Privacy Statement as discrete named documents", () => {
+    render(<EnrolmentScreen />);
+    expect(screen.getByText("Terms of Use")).toBeTruthy();
+    expect(screen.getByText("Community Code")).toBeTruthy();
+    expect(screen.getByText("Privacy Statement")).toBeTruthy();
+  });
+});

--- a/apps/native/__tests__/enrolment-legal-links.test.ts
+++ b/apps/native/__tests__/enrolment-legal-links.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Tests for task #456 — Open enrolment legal links in the device browser with
+ * graceful failure.
+ *
+ * Covers:
+ *   - Each link (Terms of Use, Community Code, Privacy Statement) opens its
+ *     canonical sipandspeak.nl URL, passed unchanged.
+ *   - A rejected openURL (offline page / no browser / no link handler) is
+ *     handled without throwing, so sign-up is never blocked or crashed.
+ */
+import { Linking } from "react-native";
+
+import { LEGAL_BASE_URL, openLegal } from "@/utils/open-legal";
+
+jest.mock("react-native", () => ({
+  Linking: { openURL: jest.fn() },
+}));
+
+const mockOpenURL = Linking.openURL as jest.Mock;
+
+describe("openLegal", () => {
+  beforeEach(() => {
+    mockOpenURL.mockReset();
+  });
+
+  it("uses the canonical https sipandspeak.nl origin", () => {
+    expect(LEGAL_BASE_URL).toBe("https://sipandspeak.nl");
+  });
+
+  it.each([
+    ["/terms", "https://sipandspeak.nl/terms"],
+    ["/community-code", "https://sipandspeak.nl/community-code"],
+    ["/privacy", "https://sipandspeak.nl/privacy"],
+  ])(
+    "opens %s at the correct canonical sipandspeak.nl URL",
+    async (path, expected) => {
+      mockOpenURL.mockResolvedValue(true);
+
+      await openLegal(path);
+
+      expect(mockOpenURL).toHaveBeenCalledTimes(1);
+      expect(mockOpenURL).toHaveBeenCalledWith(expected);
+    },
+  );
+
+  it("does not throw when the open is rejected (offline / no browser / no link handler)", async () => {
+    mockOpenURL.mockRejectedValue(new Error("No app can handle this URL"));
+
+    await expect(openLegal("/terms")).resolves.toBeUndefined();
+    // Still attempted at the canonical address even though it was rejected.
+    expect(mockOpenURL).toHaveBeenCalledWith("https://sipandspeak.nl/terms");
+  });
+
+  it("does not throw when openURL throws synchronously", async () => {
+    mockOpenURL.mockImplementation(() => {
+      throw new Error("boom");
+    });
+
+    await expect(openLegal("/privacy")).resolves.toBeUndefined();
+  });
+});

--- a/apps/native/app/enrolment.tsx
+++ b/apps/native/app/enrolment.tsx
@@ -409,7 +409,7 @@ export default function EnrolmentScreen() {
               <Text className="font-manrope text-[13px] text-brand-muted-foreground text-center leading-5">
                 By joining you agree to our{" "}
                 <Text className="underline" onPress={() => openLegal("/terms")}>
-                  Terms
+                  Terms of Use
                 </Text>{" "}
                 and{" "}
                 <Text

--- a/apps/native/app/enrolment.tsx
+++ b/apps/native/app/enrolment.tsx
@@ -3,7 +3,6 @@ import { useRouter } from "expo-router";
 import { useEffect, useRef, useState } from "react";
 import {
   KeyboardAvoidingView,
-  Linking,
   Platform,
   Pressable,
   ScrollView,
@@ -16,12 +15,8 @@ import { useToast } from "heroui-native";
 import z from "zod";
 
 import { authClient } from "@/lib/auth-client";
+import { openLegal } from "@/utils/open-legal";
 import { queryClient } from "@/utils/trpc";
-
-const LEGAL_BASE_URL = "https://sipandspeak.nl";
-const openLegal = (path: string) => {
-  void Linking.openURL(`${LEGAL_BASE_URL}${path}`);
-};
 
 const OTP_RESEND_COOLDOWN = 60;
 const GOLD = "#F2C94C";
@@ -408,18 +403,30 @@ export default function EnrolmentScreen() {
 
               <Text className="font-manrope text-[13px] text-brand-muted-foreground text-center leading-5">
                 By joining you agree to our{" "}
-                <Text className="underline" onPress={() => openLegal("/terms")}>
+                <Text
+                  className="underline"
+                  onPress={() => {
+                    void openLegal("/terms");
+                  }}
+                >
                   Terms of Use
                 </Text>{" "}
                 and{" "}
                 <Text
                   className="underline"
-                  onPress={() => openLegal("/community-code")}
+                  onPress={() => {
+                    void openLegal("/community-code");
+                  }}
                 >
                   Community Code
                 </Text>
                 , and acknowledge our{" "}
-                <Text className="underline" onPress={() => openLegal("/privacy")}>
+                <Text
+                  className="underline"
+                  onPress={() => {
+                    void openLegal("/privacy");
+                  }}
+                >
                   Privacy Statement
                 </Text>
                 .

--- a/apps/native/utils/open-legal.ts
+++ b/apps/native/utils/open-legal.ts
@@ -1,0 +1,25 @@
+import { Linking } from "react-native";
+
+/** Canonical origin for the public Sip&Speak legal pages. */
+export const LEGAL_BASE_URL = "https://sipandspeak.nl";
+
+/**
+ * Open a legal document (e.g. "/terms", "/community-code", "/privacy") in the
+ * device's default browser.
+ *
+ * Best-effort by design: a missing browser/link handler, a rejected open, or an
+ * offline target page must never throw, crash the app, or block the enrolment
+ * (email / OTP) sign-up flow. The canonical `https://sipandspeak.nl/<path>` URL
+ * is always handed to the OS unchanged, so the browser opens at the correct
+ * address even when the page itself is unreachable.
+ */
+export async function openLegal(path: string): Promise<void> {
+  const url = `${LEGAL_BASE_URL}${path}`;
+  try {
+    await Linking.openURL(url);
+  } catch {
+    // Swallow: opening external reference content is non-critical and must not
+    // surface as an unhandled rejection or interrupt sign-up. No app state
+    // changes on failure — the prospective member stays on the enrolment screen.
+  }
+}


### PR DESCRIPTION
## Feature #440 — Prospective member can reach legal documents while joining

Enrolment screen links to Terms of Use, Community Code, and Privacy Statement on `sipandspeak.nl`, wording distinguishing "agree" (Terms, Community Code) from "acknowledge" (Privacy Statement). Link-opening hardened (`openLegal` util: await + try/catch) so an offline page or missing browser handler never crashes or blocks sign-up.

Closes #440
Closes #457
Closes #456

🤖 Generated with [Claude Code](https://claude.com/claude-code)
