### PR TITLE
refactor: deepen aggregates, unit-of-work seam, meetup read model

### DIFF
--- a/apps/native/__tests__/onboarding-flow.test.ts
+++ b/apps/native/__tests__/onboarding-flow.test.ts
@@ -1,0 +1,52 @@
+import {
+  ONBOARDING_INTEREST_MIN,
+  validateOnboardingStep,
+  isOnboardingStepComplete,
+  type OnboardingCounts,
+} from "@/utils/onboarding-flow";
+
+const counts = (over: Partial<OnboardingCounts> = {}): OnboardingCounts => ({
+  spoken: 1,
+  learning: 1,
+  interests: ONBOARDING_INTEREST_MIN,
+  ...over,
+});
+
+describe("validateOnboardingStep", () => {
+  it("step 3 requires at least one spoken language", () => {
+    expect(validateOnboardingStep(3, counts({ spoken: 0 }))).toEqual({
+      ok: false,
+      error: "Add at least one language you speak.",
+    });
+    expect(validateOnboardingStep(3, counts({ spoken: 1 }))).toEqual({ ok: true });
+  });
+
+  it("step 4 requires at least one learning language", () => {
+    expect(validateOnboardingStep(4, counts({ learning: 0 }))).toEqual({
+      ok: false,
+      error: "Add at least one language to learn.",
+    });
+    expect(validateOnboardingStep(4, counts({ learning: 1 }))).toEqual({ ok: true });
+  });
+
+  it(`step 5 requires at least ${ONBOARDING_INTEREST_MIN} interests`, () => {
+    expect(validateOnboardingStep(5, counts({ interests: ONBOARDING_INTEREST_MIN - 1 }))).toEqual({
+      ok: false,
+      error: `Pick at least ${ONBOARDING_INTEREST_MIN} topics.`,
+    });
+    expect(validateOnboardingStep(5, counts({ interests: ONBOARDING_INTEREST_MIN }))).toEqual({
+      ok: true,
+    });
+  });
+
+  it("step 5 stays valid above the minimum (the max is UX guidance, not a hard gate)", () => {
+    expect(validateOnboardingStep(5, counts({ interests: 10 }))).toEqual({ ok: true });
+  });
+});
+
+describe("isOnboardingStepComplete", () => {
+  it("mirrors validateOnboardingStep's ok flag", () => {
+    expect(isOnboardingStepComplete(3, counts({ spoken: 0 }))).toBe(false);
+    expect(isOnboardingStepComplete(5, counts({ interests: ONBOARDING_INTEREST_MIN }))).toBe(true);
+  });
+});

--- a/apps/native/components/onboarding-modal.tsx
+++ b/apps/native/components/onboarding-modal.tsx
@@ -20,6 +20,12 @@ import { authClient } from "@/lib/auth-client";
 import { queryClient, trpc } from "@/utils/trpc";
 import { pickAndEncodeProfilePicture } from "@/utils/profile-picture";
 import { INTERESTS } from "@/utils/interest-labels";
+import {
+  ONBOARDING_INTEREST_MIN,
+  ONBOARDING_INTEREST_MAX,
+  validateOnboardingStep,
+  isOnboardingStepComplete,
+} from "@/utils/onboarding-flow";
 
 const GOLD = "#F2C94C";
 const MUTED_BORDER = "#D9C9BC";
@@ -101,7 +107,7 @@ const STEP_SUBTITLES = [
   "So your buddy can spot you across the café.",
   "Languages you can hold a conversation in.",
   "We'll pair you with native speakers.",
-  "Pick 3–7. Seeds your first match.",
+  `Pick ${ONBOARDING_INTEREST_MIN}–${ONBOARDING_INTEREST_MAX}. Seeds your first match.`,
 ];
 
 export function OnboardingModal() {
@@ -129,6 +135,13 @@ export function OnboardingModal() {
   const [interests, setInterests] = useState<InterestValue[]>([]);
   const [pickerTarget, setPickerTarget] = useState<"spoken" | "learning" | null>(null);
   const [validationError, setValidationError] = useState<string | null>(null);
+
+  // Counts the wizard's gate rules (in @/utils/onboarding-flow) operate on.
+  const onboardingCounts = {
+    spoken: spokenLanguages.length,
+    learning: learningLanguages.length,
+    interests: interests.length,
+  };
 
   const needsFullOnboarding = onboardingStatus.data?.complete === false;
   const totalSteps = needsFullOnboarding ? 5 : 2;
@@ -214,28 +227,22 @@ export function OnboardingModal() {
   }
 
   function handleStep3Continue() {
-    if (spokenLanguages.length === 0) {
-      setValidationError("Add at least one language you speak.");
-      return;
-    }
+    const v = validateOnboardingStep(3, onboardingCounts);
+    if (!v.ok) { setValidationError(v.error); return; }
     setValidationError(null);
     setStep(4);
   }
 
   function handleStep4Continue() {
-    if (learningLanguages.length === 0) {
-      setValidationError("Add at least one language to learn.");
-      return;
-    }
+    const v = validateOnboardingStep(4, onboardingCounts);
+    if (!v.ok) { setValidationError(v.error); return; }
     setValidationError(null);
     setStep(5);
   }
 
   async function handleFinish() {
-    if (interests.length < 3) {
-      setValidationError("Pick at least 3 topics.");
-      return;
-    }
+    const v = validateOnboardingStep(5, onboardingCounts);
+    if (!v.ok) { setValidationError(v.error); return; }
     setValidationError(null);
     try {
       await upsertMutation.mutateAsync({ spokenLanguages, learningLanguages, interests });
@@ -554,7 +561,7 @@ export function OnboardingModal() {
                     <Text className="font-manrope text-[14px]" style={{ color: "#8A7570" }}>
                       {interests.length} picked
                     </Text>
-                    {interests.length >= 3 && (
+                    {isOnboardingStepComplete(5, onboardingCounts) && (
                       <Text className="font-manrope-semi text-[14px]" style={{ color: GOLD }}>ready ✓</Text>
                     )}
                   </View>
@@ -597,7 +604,7 @@ export function OnboardingModal() {
                   <>
                     <GoldButton
                       onPress={handleStep3Continue}
-                      disabled={spokenLanguages.length === 0}
+                      disabled={!isOnboardingStepComplete(3, onboardingCounts)}
                       label="Continue →"
                     />
                     <Pressable onPress={() => setStep(2)} className="items-center py-2.5">
@@ -609,7 +616,7 @@ export function OnboardingModal() {
                   <>
                     <GoldButton
                       onPress={handleStep4Continue}
-                      disabled={learningLanguages.length === 0}
+                      disabled={!isOnboardingStepComplete(4, onboardingCounts)}
                       label="Continue →"
                     />
                     <Pressable onPress={() => setStep(3)} className="items-center py-2.5">
@@ -622,7 +629,7 @@ export function OnboardingModal() {
                     <GoldButton
                       onPress={handleFinish}
                       loading={upsertMutation.isPending}
-                      disabled={interests.length < 3}
+                      disabled={!isOnboardingStepComplete(5, onboardingCounts)}
                       label="Finish — find matches →"
                     />
                     <Pressable onPress={() => setStep(4)} className="items-center py-2.5">

--- a/apps/native/utils/onboarding-flow.ts
+++ b/apps/native/utils/onboarding-flow.ts
@@ -1,0 +1,57 @@
+/**
+ * Onboarding wizard flow rules — the pure view-model logic behind
+ * `OnboardingModal`. The component owns React state and JSX; the *rules* for
+ * when a step may advance, and what error to show when it can't, live here so
+ * they are stated once and testable without rendering the modal.
+ *
+ * These are the wizard's own gates. They are deliberately STRICTER than the
+ * server's matching-eligibility rule (≥1 spoken, ≥1 learning, ≥1 interest,
+ * owned by `OnboardingProgression`): onboarding asks for 3–7 interests to seed
+ * a good first match. The server stays the source of truth for whether a
+ * profile is matchable; this module only governs the wizard UX.
+ */
+
+/** Interest-count bounds for the onboarding wizard ("Pick 3–7"). */
+export const ONBOARDING_INTEREST_MIN = 3;
+export const ONBOARDING_INTEREST_MAX = 7;
+
+/** The wizard steps that carry an advance-gate (1–2 are identity, gated separately). */
+export type GatedStep = 3 | 4 | 5;
+
+export type OnboardingCounts = {
+  spoken: number;
+  learning: number;
+  interests: number;
+};
+
+export type StepValidation = { ok: true } | { ok: false; error: string };
+
+/**
+ * Whether the wizard may advance from `step`, and the error to surface if not.
+ * Single source of truth for the per-step gates that were inlined across
+ * `handleStep3Continue` / `handleStep4Continue` / `handleFinish`.
+ */
+export function validateOnboardingStep(
+  step: GatedStep,
+  counts: OnboardingCounts,
+): StepValidation {
+  switch (step) {
+    case 3:
+      return counts.spoken > 0
+        ? { ok: true }
+        : { ok: false, error: "Add at least one language you speak." };
+    case 4:
+      return counts.learning > 0
+        ? { ok: true }
+        : { ok: false, error: "Add at least one language to learn." };
+    case 5:
+      return counts.interests >= ONBOARDING_INTEREST_MIN
+        ? { ok: true }
+        : { ok: false, error: `Pick at least ${ONBOARDING_INTEREST_MIN} topics.` };
+  }
+}
+
+/** Convenience for the CTA `disabled` props — true when the step's gate is satisfied. */
+export function isOnboardingStepComplete(step: GatedStep, counts: OnboardingCounts): boolean {
+  return validateOnboardingStep(step, counts).ok;
+}

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -60,3 +60,46 @@ and replaces `@sip-and-speak/db` with the test DB at import time, so router
 code uses it transparently. Helpers: `resetDb()` (restore the
 post-migration snapshot), `captureEvents()` (subscribe to `domainEvents`),
 `buildSessionContext(userId)` (produce a fake tRPC context).
+
+### MatchRequest aggregate
+
+The pure state machine for the Matching context, mirroring the Meetup
+aggregate. Lives at
+`packages/api/src/contexts/matching/match-request-aggregate.ts`. Each method
+takes a loaded snapshot + actor input and returns the next state plus the
+domain events to emit. Lifecycle:
+
+- `send` → `MatchRequestSent`
+- `accept` → `MatchRequestAccepted`, plus a StudentMatch to create
+- `decline` → `MatchRequestDeclined`
+- `withdraw` (pending → row hard-deleted; no event)
+- `unmatch` (→ `voided`, plus the StudentMatch to drop)
+
+`MatchRuleError` is its invariant-violation error; the tRPC router translates
+it into a `TRPCError` with the matching code.
+
+### Unit of work (`commitAndEmit`)
+
+`packages/api/src/unit-of-work.ts`. The single seam where persistence and
+event emission happen together: it runs a transition's writes in one
+transaction and emits the buffered domain events only after the transaction
+commits, so a rolled-back transition emits nothing. Both the Meetup and
+Matching routers persist through it. (The transactional rollback of the writes
+themselves is a Postgres guarantee; pg-mem does not emulate it — see ADR-0002.)
+
+### Meetup read model
+
+The query side of the Meetup Scheduling context:
+`packages/api/src/contexts/scheduling/meetup-read-model.ts`. Owns the
+multi-join read queries and view shaping (`listMeetupsForUser`,
+`getConfirmedMeetupsForUser`) that the `list` / `getConfirmed` procedures used
+to inline. The Meetup aggregate owns the write side; the read model owns the
+read side.
+
+### Onboarding wizard gates
+
+Client-side, `apps/native/utils/onboarding-flow.ts`. The onboarding wizard
+requires **3–7 interests** (plus ≥1 spoken and ≥1 learning language) to finish
+— deliberately STRICTER than the server's matching-eligibility rule (≥1
+interest, owned by OnboardingProgression). The server stays the source of truth
+for whether a profile is matchable; these gates govern only the wizard UX.

--- a/docs/adr/0004-messaging-access-checks-stay-split.md
+++ b/docs/adr/0004-messaging-access-checks-stay-split.md
@@ -1,0 +1,52 @@
+# ADR 0004 — Messaging access checks stay split (read vs write)
+
+- **Status**: Accepted
+- **Date**: 2026-06-26
+- **Context tags**: Conversation Practice / Messaging
+
+## Context
+
+The Messaging context guards conversation access in three places that look
+like duplication and invite a "unify into one `MessagingAccess` module"
+refactor:
+
+- `checkConversationAccess(conv, senderId)` — gate for **sending** a message.
+  Returns distinct errors: `CONVERSATION_NOT_FOUND`, `NOT_A_PARTICIPANT`,
+  `CONVERSATION_NOT_OPEN`. The router maps these to different tRPC codes
+  (`NOT_FOUND` vs `FORBIDDEN`).
+- `checkReadAccess(conv, readerId)` — gate for **reading** messages. Deliberately
+  collapses *every* failure (missing conversation, non-participant, suspended)
+  to a single `NOT_A_PARTICIPANT`, so a reader cannot probe whether a
+  conversation exists (#151).
+- The inline suspended/removed-sender guard in `messaging.ts` (`sendMessage`),
+  a single-callsite check.
+
+`messaging-utils.ts` already states the governing rule: *"only deep helpers
+worth extracting live here; shallow predicates have been inlined at their
+callsites."*
+
+## Decision
+
+Keep the read-access and write-access checks as **two separate functions**, and
+keep the suspended-sender guard inline. Do **not** merge them into a single
+`MessagingAccess` decision module.
+
+The two checks share shape but not semantics: write-access surfaces precise
+errors so the client can distinguish "gone" from "forbidden"; read-access
+intentionally obscures existence as a privacy property. A unified entry point
+would need a mode flag to reproduce both behaviours — that is *more* complex
+than the two six-line functions, and one slip would leak existence on the read
+path. The suspended-sender guard has one caller, so extracting it concentrates
+nothing.
+
+## Consequences
+
+- **Deletion test**: deleting a hypothetical merged module would not concentrate
+  complexity — there are only two callers and they require divergent behaviour.
+  The merge is shallow; the split is not.
+- A future architecture review will see the near-identical bodies and be tempted
+  to DRY them up. This ADR is the answer: the divergence is load-bearing (the
+  `NOT_A_PARTICIPANT`-for-everything collapse is a security choice, not an
+  oversight).
+- If a third access path appears that genuinely shares the *write* semantics,
+  revisit — two adapters make a real seam; one does not.

--- a/packages/api/src/__tests__/unit-of-work.test.ts
+++ b/packages/api/src/__tests__/unit-of-work.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Integration tests for the commitAndEmit unit-of-work seam. Uses the pg-mem
+ * harness to prove the two guarantees the seam exists for:
+ *   1. buffered events fire only after the transaction commits, and
+ *   2. a rolled-back transaction persists nothing and emits nothing.
+ */
+import "../__test-support__/harness";
+
+import { describe, it, expect, beforeEach } from "bun:test";
+
+import { db } from "@sip-and-speak/db";
+import { venue } from "@sip-and-speak/db/schema/scheduling";
+
+import { commitAndEmit } from "../unit-of-work";
+import { resetDb, captureEvents } from "../__test-support__/harness";
+
+describe("commitAndEmit", () => {
+  beforeEach(() => {
+    resetDb();
+  });
+
+  it("commits the writes and emits the buffered events", async () => {
+    const cap = captureEvents();
+    const id = await commitAndEmit(async (tx) => {
+      const [row] = await tx
+        .insert(venue)
+        .values({ name: "Seam Cafe", latitude: 51.4, longitude: 5.45, isActive: true })
+        .returning();
+      return {
+        result: row!.id,
+        events: [{ name: "MeetupProposed", payload: { meetupId: row!.id, proposerId: "x" } }],
+      };
+    });
+    cap.stop();
+
+    const rows = await db.select().from(venue);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.id).toBe(id);
+    expect(cap.events).toHaveLength(1);
+    expect(cap.events[0]!.name).toBe("MeetupProposed");
+    expect((cap.events[0]!.payload as { meetupId: string }).meetupId).toBe(id);
+  });
+
+  it("emits each buffered event in order", async () => {
+    const cap = captureEvents();
+    await commitAndEmit(async () => ({
+      result: undefined,
+      events: [
+        { name: "MatchRequestSent", payload: { n: 1 } },
+        { name: "MatchRequestAccepted", payload: { n: 2 } },
+      ],
+    }));
+    cap.stop();
+
+    expect(cap.events.map((e) => e.name)).toEqual([
+      "MatchRequestSent",
+      "MatchRequestAccepted",
+    ]);
+  });
+
+  it("emits nothing when the work throws", async () => {
+    // commitAndEmit's own guarantee: if the transaction callback throws, the
+    // promise rejects and the emit loop is never reached — so a failed
+    // transition can never leak a domain event. (Whether the *writes* roll back
+    // is a Postgres guarantee; pg-mem does not emulate ROLLBACK, so persistence
+    // is not asserted here — it holds in production.)
+    const cap = captureEvents();
+    await expect(
+      commitAndEmit(async (tx) => {
+        await tx
+          .insert(venue)
+          .values({ name: "Doomed Cafe", latitude: 1, longitude: 2, isActive: true });
+        // Throw before returning any events — the emit loop must never run.
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+    cap.stop();
+
+    expect(cap.events).toHaveLength(0);
+  });
+});

--- a/packages/api/src/contexts/matching/__tests__/match-request-aggregate.test.ts
+++ b/packages/api/src/contexts/matching/__tests__/match-request-aggregate.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect } from "bun:test";
+
+import {
+  MatchRequest,
+  MatchRuleError,
+  type MatchRequestSnapshot,
+} from "../match-request-aggregate";
+
+const NOW = new Date("2030-06-01T10:00:00Z");
+
+function pending(overrides: Partial<MatchRequestSnapshot> = {}): MatchRequestSnapshot {
+  return {
+    id: "mr-1",
+    requesterId: "u-A",
+    receiverId: "u-B",
+    status: "pending",
+    ...overrides,
+  };
+}
+
+describe("MatchRequest.send", () => {
+  const baseArgs = {
+    requesterId: "u-A",
+    requesterName: "Alice",
+    receiverId: "u-B",
+    receiverExists: true,
+    offeredLanguage: "en" as string | null,
+    targetedLanguage: "nl" as string | null,
+    hasActiveRequest: false,
+    now: NOW,
+  };
+
+  it("produces a pending row and a MatchRequestSent event", () => {
+    const { row, events } = MatchRequest.send(baseArgs);
+    expect(row).toEqual({ requesterId: "u-A", receiverId: "u-B", status: "pending" });
+    expect(events).toHaveLength(1);
+    expect(events[0]!.name).toBe("MatchRequestSent");
+    expect(events[0]!.payload).toMatchObject({
+      requesterId: "u-A",
+      requesterName: "Alice",
+      offeredLanguage: "en",
+      targetedLanguage: "nl",
+      receiverId: "u-B",
+      sentAt: NOW,
+    });
+  });
+
+  it("omits matchRequestId — the router grafts it on after insert", () => {
+    const { events } = MatchRequest.send(baseArgs);
+    expect(events[0]!.payload.matchRequestId).toBeUndefined();
+  });
+
+  it("rejects self-requests with BAD_REQUEST", () => {
+    expect(() => MatchRequest.send({ ...baseArgs, receiverId: "u-A" })).toThrow(MatchRuleError);
+    try {
+      MatchRequest.send({ ...baseArgs, receiverId: "u-A" });
+    } catch (e) {
+      expect((e as MatchRuleError).code).toBe("BAD_REQUEST");
+    }
+  });
+
+  it("rejects a missing receiver with NOT_FOUND", () => {
+    try {
+      MatchRequest.send({ ...baseArgs, receiverExists: false });
+      throw new Error("expected throw");
+    } catch (e) {
+      expect((e as MatchRuleError).code).toBe("NOT_FOUND");
+    }
+  });
+
+  it("rejects a duplicate active request with CONFLICT", () => {
+    try {
+      MatchRequest.send({ ...baseArgs, hasActiveRequest: true });
+      throw new Error("expected throw");
+    } catch (e) {
+      expect((e as MatchRuleError).code).toBe("CONFLICT");
+    }
+  });
+});
+
+describe("MatchRequest.accept", () => {
+  it("transitions to accepted and creates a match between requester and receiver", () => {
+    const { state, createMatch, events } = MatchRequest.accept(pending(), {
+      actorId: "u-B",
+      receiverName: "Bob",
+      now: NOW,
+    });
+    expect(state.status).toBe("accepted");
+    expect(createMatch).toEqual({ studentAId: "u-A", studentBId: "u-B" });
+    expect(events[0]!.name).toBe("MatchRequestAccepted");
+    expect(events[0]!.payload).toMatchObject({
+      matchRequestId: "mr-1",
+      requesterId: "u-A",
+      receiverId: "u-B",
+      receiverName: "Bob",
+      acceptedAt: NOW,
+    });
+  });
+
+  it("only the designated receiver may accept (FORBIDDEN)", () => {
+    try {
+      MatchRequest.accept(pending(), { actorId: "u-A", receiverName: "x", now: NOW });
+      throw new Error("expected throw");
+    } catch (e) {
+      expect((e as MatchRuleError).code).toBe("FORBIDDEN");
+    }
+  });
+
+  it("only pending requests can be accepted (BAD_REQUEST)", () => {
+    try {
+      MatchRequest.accept(pending({ status: "declined" }), {
+        actorId: "u-B",
+        receiverName: "x",
+        now: NOW,
+      });
+      throw new Error("expected throw");
+    } catch (e) {
+      expect((e as MatchRuleError).code).toBe("BAD_REQUEST");
+    }
+  });
+});
+
+describe("MatchRequest.decline", () => {
+  it("transitions to declined and emits MatchRequestDeclined", () => {
+    const { state, events } = MatchRequest.decline(pending(), { actorId: "u-B", now: NOW });
+    expect(state.status).toBe("declined");
+    expect(events[0]!.name).toBe("MatchRequestDeclined");
+    expect(events[0]!.payload).toMatchObject({
+      matchRequestId: "mr-1",
+      requesterId: "u-A",
+      receiverId: "u-B",
+      declinedAt: NOW,
+    });
+  });
+
+  it("only the receiver may decline (FORBIDDEN)", () => {
+    try {
+      MatchRequest.decline(pending(), { actorId: "u-A", now: NOW });
+      throw new Error("expected throw");
+    } catch (e) {
+      expect((e as MatchRuleError).code).toBe("FORBIDDEN");
+    }
+  });
+});
+
+describe("MatchRequest.withdraw", () => {
+  it("allows the sender to withdraw a pending request, with no events", () => {
+    const { delete: del, events } = MatchRequest.withdraw(pending(), { actorId: "u-A" });
+    expect(del).toBe(true);
+    expect(events).toEqual([]);
+  });
+
+  it("only the sender may withdraw (FORBIDDEN)", () => {
+    try {
+      MatchRequest.withdraw(pending(), { actorId: "u-B" });
+      throw new Error("expected throw");
+    } catch (e) {
+      expect((e as MatchRuleError).code).toBe("FORBIDDEN");
+    }
+  });
+
+  it("only pending invitations can be withdrawn (BAD_REQUEST)", () => {
+    try {
+      MatchRequest.withdraw(pending({ status: "accepted" }), { actorId: "u-A" });
+      throw new Error("expected throw");
+    } catch (e) {
+      expect((e as MatchRuleError).code).toBe("BAD_REQUEST");
+    }
+  });
+});
+
+describe("MatchRequest.unmatch", () => {
+  it("permits unmatching when a match exists", () => {
+    const { voidRequest, events } = MatchRequest.unmatch({
+      actorId: "u-A",
+      partnerId: "u-B",
+      matchExists: true,
+    });
+    expect(voidRequest).toBe(true);
+    expect(events).toEqual([]);
+  });
+
+  it("rejects unmatching yourself (BAD_REQUEST)", () => {
+    try {
+      MatchRequest.unmatch({ actorId: "u-A", partnerId: "u-A", matchExists: false });
+      throw new Error("expected throw");
+    } catch (e) {
+      expect((e as MatchRuleError).code).toBe("BAD_REQUEST");
+    }
+  });
+
+  it("rejects unmatching a non-partner (NOT_FOUND)", () => {
+    try {
+      MatchRequest.unmatch({ actorId: "u-A", partnerId: "u-B", matchExists: false });
+      throw new Error("expected throw");
+    } catch (e) {
+      expect((e as MatchRuleError).code).toBe("NOT_FOUND");
+    }
+  });
+});

--- a/packages/api/src/contexts/matching/match-request-aggregate.ts
+++ b/packages/api/src/contexts/matching/match-request-aggregate.ts
@@ -1,0 +1,224 @@
+/**
+ * MatchRequest aggregate — pure state machine for the Matching bounded context.
+ * Every transition takes a snapshot + actor input, validates the invariants,
+ * and returns the next persistent state plus the domain events the caller
+ * should emit after persistence succeeds.
+ *
+ * The aggregate owns no I/O: the router loads the snapshot from Drizzle, calls
+ * the relevant method, persists the result inside a unit of work, and emits the
+ * returned events. Before this aggregate existed the transition guards were
+ * inlined across five mutations in `matching.ts`; the lifecycle now lives in one
+ * place, the way the Meetup aggregate owns the meetup lifecycle.
+ *
+ * Lifecycle:
+ *
+ *   (none) ──send──▶ pending ──accept──▶ accepted  (+ creates a StudentMatch)
+ *                       │   ╲decline────▶ declined
+ *                       │    ╲withdraw──▶ (row hard-deleted)
+ *                    accepted ──unmatch─▶ voided    (+ drops the StudentMatch)
+ */
+
+export type MatchRequestStatus = "pending" | "accepted" | "declined" | "voided";
+
+export type MatchRequestSnapshot = {
+  id: string;
+  requesterId: string;
+  receiverId: string;
+  status: MatchRequestStatus;
+};
+
+/** The row shape persisted by `send` (id assigned by the DB). */
+export type NewMatchRequestRow = {
+  requesterId: string;
+  receiverId: string;
+  status: MatchRequestStatus;
+};
+
+/** Intent to create a StudentMatch when a request is accepted. */
+export type CreateMatch = {
+  studentAId: string;
+  studentBId: string;
+};
+
+export type MatchRequestEventName =
+  | "MatchRequestSent"
+  | "MatchRequestAccepted"
+  | "MatchRequestDeclined";
+
+export type DomainEventToEmit = {
+  name: MatchRequestEventName;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  payload: Record<string, any>;
+};
+
+export type RuleErrorCode = "BAD_REQUEST" | "FORBIDDEN" | "CONFLICT" | "NOT_FOUND";
+
+export class MatchRuleError extends Error {
+  constructor(public code: RuleErrorCode, message: string) {
+    super(message);
+    this.name = "MatchRuleError";
+  }
+}
+
+/** Receiver-only transitions (accept / decline) share this guard. */
+function assertReceiver(state: MatchRequestSnapshot, actorId: string, verb: string): void {
+  if (state.receiverId !== actorId) {
+    throw new MatchRuleError(
+      "FORBIDDEN",
+      `Only the designated receiver may ${verb} this request.`,
+    );
+  }
+}
+
+/** A request must be pending to be accepted / declined. */
+function assertPending(state: MatchRequestSnapshot, pastTense: string): void {
+  if (state.status !== "pending") {
+    throw new MatchRuleError("BAD_REQUEST", `Only pending requests can be ${pastTense}.`);
+  }
+}
+
+export const MatchRequest = {
+  /**
+   * Send a new request. Caller provides preconditions loaded from the DB
+   * (whether the receiver profile still exists, and whether an active request
+   * to the same receiver already exists). The emitted `MatchRequestSent` event
+   * lacks `matchRequestId` — the router fills it in once the insert returns.
+   */
+  send(args: {
+    requesterId: string;
+    requesterName: string;
+    receiverId: string;
+    receiverExists: boolean;
+    offeredLanguage: string | null;
+    targetedLanguage: string | null;
+    hasActiveRequest: boolean;
+    now: Date;
+  }): { row: NewMatchRequestRow; events: DomainEventToEmit[] } {
+    if (args.requesterId === args.receiverId) {
+      throw new MatchRuleError("BAD_REQUEST", "You cannot send a match request to yourself.");
+    }
+    if (!args.receiverExists) {
+      throw new MatchRuleError("NOT_FOUND", "This profile is no longer available.");
+    }
+    if (args.hasActiveRequest) {
+      throw new MatchRuleError("CONFLICT", "A match request to this candidate already exists.");
+    }
+
+    const row: NewMatchRequestRow = {
+      requesterId: args.requesterId,
+      receiverId: args.receiverId,
+      status: "pending",
+    };
+
+    const events: DomainEventToEmit[] = [
+      {
+        name: "MatchRequestSent",
+        payload: {
+          requesterId: args.requesterId,
+          requesterName: args.requesterName,
+          offeredLanguage: args.offeredLanguage,
+          targetedLanguage: args.targetedLanguage,
+          receiverId: args.receiverId,
+          sentAt: args.now,
+        },
+      },
+    ];
+
+    return { row, events };
+  },
+
+  /**
+   * Accept a pending request (receiver-only). Returns the next state plus the
+   * StudentMatch to create — both writes must land in the same unit of work,
+   * else an accepted request could be left with no match (or vice versa).
+   */
+  accept(
+    state: MatchRequestSnapshot,
+    args: { actorId: string; receiverName: string; now: Date },
+  ): { state: MatchRequestSnapshot; createMatch: CreateMatch; events: DomainEventToEmit[] } {
+    assertReceiver(state, args.actorId, "accept");
+    assertPending(state, "accepted");
+
+    const next: MatchRequestSnapshot = { ...state, status: "accepted" };
+    const createMatch: CreateMatch = {
+      studentAId: state.requesterId,
+      studentBId: args.actorId,
+    };
+    const events: DomainEventToEmit[] = [
+      {
+        name: "MatchRequestAccepted",
+        payload: {
+          matchRequestId: state.id,
+          requesterId: state.requesterId,
+          receiverId: args.actorId,
+          receiverName: args.receiverName,
+          acceptedAt: args.now,
+        },
+      },
+    ];
+
+    return { state: next, createMatch, events };
+  },
+
+  /** Decline a pending request (receiver-only). Declined requests may be re-sent. */
+  decline(
+    state: MatchRequestSnapshot,
+    args: { actorId: string; now: Date },
+  ): { state: MatchRequestSnapshot; events: DomainEventToEmit[] } {
+    assertReceiver(state, args.actorId, "decline");
+    assertPending(state, "declined");
+
+    const next: MatchRequestSnapshot = { ...state, status: "declined" };
+    const events: DomainEventToEmit[] = [
+      {
+        name: "MatchRequestDeclined",
+        payload: {
+          matchRequestId: state.id,
+          requesterId: state.requesterId,
+          receiverId: args.actorId,
+          declinedAt: args.now,
+        },
+      },
+    ];
+
+    return { state: next, events };
+  },
+
+  /**
+   * Withdraw a still-pending request (sender-only). The row is hard-deleted so
+   * the invite fully reverses; no event is emitted (the receiver was never
+   * notified of a "cancelled" request). Returns `delete: true` to signal the
+   * router to remove the row.
+   */
+  withdraw(
+    state: MatchRequestSnapshot,
+    args: { actorId: string },
+  ): { delete: true; events: DomainEventToEmit[] } {
+    if (state.requesterId !== args.actorId) {
+      throw new MatchRuleError("FORBIDDEN", "Only the sender may withdraw this invitation.");
+    }
+    if (state.status !== "pending") {
+      throw new MatchRuleError("BAD_REQUEST", "Only pending invitations can be withdrawn.");
+    }
+    return { delete: true, events: [] };
+  },
+
+  /**
+   * Unmatch an existing buddy. Voids the underlying request (keeps the pair out
+   * of discover) and signals the router to drop the StudentMatch — both writes
+   * belong in one unit of work. `matchExists` is the loaded precondition.
+   */
+  unmatch(args: {
+    actorId: string;
+    partnerId: string;
+    matchExists: boolean;
+  }): { voidRequest: true; events: DomainEventToEmit[] } {
+    if (args.actorId === args.partnerId) {
+      throw new MatchRuleError("BAD_REQUEST", "You cannot unmatch yourself.");
+    }
+    if (!args.matchExists) {
+      throw new MatchRuleError("NOT_FOUND", "You are not matched with this person.");
+    }
+    return { voidRequest: true, events: [] };
+  },
+};

--- a/packages/api/src/contexts/matching/matching.ts
+++ b/packages/api/src/contexts/matching/matching.ts
@@ -7,8 +7,37 @@ import { matchRequest, studentMatch } from "@sip-and-speak/db/schema/matching";
 import { meetup, attendanceReport } from "@sip-and-speak/db/schema/scheduling";
 import { user } from "@sip-and-speak/db/schema/auth";
 import { protectedProcedure, router } from "../../index";
-import { domainEvents } from "../../domain-events";
 import { buildExcludedUserIds, scoreCandidates } from "./matching-utils";
+import {
+  MatchRequest,
+  MatchRuleError,
+  type MatchRequestSnapshot,
+} from "./match-request-aggregate";
+import { commitAndEmit } from "../../unit-of-work";
+
+/** Convert aggregate rule violations into the right tRPC error code. */
+function toTrpcError(err: unknown): never {
+  if (err instanceof MatchRuleError) {
+    throw new TRPCError({ code: err.code, message: err.message });
+  }
+  throw err;
+}
+
+/** Load the MatchRequest snapshot the aggregate needs for status transitions. */
+async function loadMatchRequestSnapshot(
+  id: string,
+): Promise<MatchRequestSnapshot | null> {
+  const row = await db.query.matchRequest.findFirst({
+    where: eq(matchRequest.id, id),
+  });
+  if (!row) return null;
+  return {
+    id: row.id,
+    requesterId: row.requesterId,
+    receiverId: row.receiverId,
+    status: row.status,
+  };
+}
 
 // --- Router ---
 
@@ -398,78 +427,75 @@ export const matchingRouter = router({
     .mutation(async ({ ctx, input }) => {
       const requesterId = ctx.session.user.id;
 
-      if (requesterId === input.receiverId) {
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: "You cannot send a match request to yourself.",
-        });
-      }
+      // Load the preconditions the aggregate needs: receiver existence, a
+      // conflicting active request, and the requester's display name + offered/
+      // targeted languages for the MatchRequestSent payload.
+      const [receiverProfile, existing, requesterRow, requesterLanguages] =
+        await Promise.all([
+          db.query.languageProfile.findFirst({
+            where: eq(languageProfile.userId, input.receiverId),
+          }),
+          db.query.matchRequest.findFirst({
+            where: and(
+              eq(matchRequest.requesterId, requesterId),
+              eq(matchRequest.receiverId, input.receiverId),
+              // pending or accepted only — declined allows re-request
+              inArray(matchRequest.status, ["pending", "accepted"]),
+            ),
+          }),
+          db.select({ name: user.name }).from(user).where(eq(user.id, requesterId)).limit(1),
+          db
+            .select({ language: userLanguage.language, type: userLanguage.type })
+            .from(userLanguage)
+            .where(eq(userLanguage.userId, requesterId)),
+        ]);
 
-      // Check receiver exists
-      const receiverProfile = await db.query.languageProfile.findFirst({
-        where: eq(languageProfile.userId, input.receiverId),
-      });
-      if (!receiverProfile) {
-        throw new TRPCError({
-          code: "NOT_FOUND",
-          message: "This profile is no longer available.",
-        });
-      }
-
-      // Check for existing active request (pending or accepted only — declined allows re-request)
-      const existing = await db.query.matchRequest.findFirst({
-        where: and(
-          eq(matchRequest.requesterId, requesterId),
-          eq(matchRequest.receiverId, input.receiverId),
-          inArray(matchRequest.status, ["pending", "accepted"]),
-        ),
-      });
-      if (existing) {
-        throw new TRPCError({
-          code: "CONFLICT",
-          message: "A match request to this candidate already exists.",
-        });
-      }
-
-      const rows = await db
-        .insert(matchRequest)
-        .values({
+      let decision;
+      try {
+        decision = MatchRequest.send({
           requesterId,
+          requesterName: requesterRow[0]?.name ?? "Someone",
           receiverId: input.receiverId,
-          status: "pending",
-        })
-        .returning({ id: matchRequest.id });
-
-      const created = rows[0];
-      if (!created) {
-        throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Failed to create match request." });
+          receiverExists: receiverProfile != null,
+          offeredLanguage:
+            requesterLanguages.find((l) => l.type === "spoken")?.language ?? null,
+          targetedLanguage:
+            requesterLanguages.find((l) => l.type === "learning")?.language ?? null,
+          hasActiveRequest: existing != null,
+          now: new Date(),
+        });
+      } catch (err) {
+        toTrpcError(err);
       }
+
+      const matchRequestId = await commitAndEmit(async (tx) => {
+        const [created] = await tx
+          .insert(matchRequest)
+          .values(decision.row)
+          .returning({ id: matchRequest.id });
+        if (!created) {
+          throw new TRPCError({
+            code: "INTERNAL_SERVER_ERROR",
+            message: "Failed to create match request.",
+          });
+        }
+        return {
+          result: created.id,
+          // The aggregate cannot know the id until the row exists — graft it on.
+          events: decision.events.map((e) => ({
+            name: e.name,
+            payload: { ...e.payload, matchRequestId: created.id },
+          })),
+        };
+      });
 
       console.info("[MatchRequestSent]", {
-        matchRequestId: created.id,
+        matchRequestId,
         requesterId,
         receiverId: input.receiverId,
       });
 
-      const [requesterRow, requesterLanguages] = await Promise.all([
-        db.select({ name: user.name }).from(user).where(eq(user.id, requesterId)).limit(1),
-        db.select({ language: userLanguage.language, type: userLanguage.type }).from(userLanguage).where(eq(userLanguage.userId, requesterId)),
-      ]);
-      const requesterName = requesterRow[0]?.name ?? "Someone";
-      const offeredLanguage = requesterLanguages.find((l) => l.type === "spoken")?.language ?? null;
-      const targetedLanguage = requesterLanguages.find((l) => l.type === "learning")?.language ?? null;
-
-      domainEvents.emit("MatchRequestSent", {
-        matchRequestId: created.id,
-        requesterId,
-        requesterName,
-        offeredLanguage,
-        targetedLanguage,
-        receiverId: input.receiverId,
-        sentAt: new Date(),
-      });
-
-      return { matchRequestId: created.id, status: "pending" as const };
+      return { matchRequestId, status: "pending" as const };
     }),
 
   acceptMatchRequest: protectedProcedure
@@ -477,56 +503,51 @@ export const matchingRouter = router({
     .mutation(async ({ ctx, input }) => {
       const receiverId = ctx.session.user.id;
 
-      const request = await db.query.matchRequest.findFirst({
-        where: eq(matchRequest.id, input.matchRequestId),
-      });
-
-      if (!request) {
+      const existing = await loadMatchRequestSnapshot(input.matchRequestId);
+      if (!existing) {
         throw new TRPCError({ code: "NOT_FOUND", message: "Match request not found." });
       }
 
-      if (request.receiverId !== receiverId) {
-        throw new TRPCError({ code: "FORBIDDEN", message: "Only the designated receiver may accept this request." });
+      const [receiverRow] = await db
+        .select({ name: user.name })
+        .from(user)
+        .where(eq(user.id, receiverId))
+        .limit(1);
+
+      let decision;
+      try {
+        decision = MatchRequest.accept(existing, {
+          actorId: receiverId,
+          receiverName: receiverRow?.name ?? "Someone",
+          now: new Date(),
+        });
+      } catch (err) {
+        toTrpcError(err);
       }
 
-      if (request.status !== "pending") {
-        throw new TRPCError({ code: "BAD_REQUEST", message: "Only pending requests can be accepted." });
-      }
-
-      // Atomic: marking the request accepted and creating the match must both
-      // commit or both roll back, else we get an accepted request with no match
-      // (or an orphan match).
-      await db.transaction(async (tx) => {
+      // Marking the request accepted and creating the match commit together —
+      // the aggregate hands both writes to one unit of work, so we can never get
+      // an accepted request with no match (or an orphan match).
+      await commitAndEmit(async (tx) => {
         await tx
           .update(matchRequest)
-          .set({ status: "accepted" })
-          .where(eq(matchRequest.id, input.matchRequestId));
-
+          .set({ status: decision.state.status })
+          .where(eq(matchRequest.id, existing.id));
         await tx.insert(studentMatch).values({
-          studentAId: request.requesterId,
-          studentBId: receiverId,
-          matchRequestId: input.matchRequestId,
+          studentAId: decision.createMatch.studentAId,
+          studentBId: decision.createMatch.studentBId,
+          matchRequestId: existing.id,
         });
+        return { result: undefined, events: decision.events };
       });
 
       console.info("[MatchRequestAccepted]", {
-        matchRequestId: input.matchRequestId,
-        requesterId: request.requesterId,
+        matchRequestId: existing.id,
+        requesterId: existing.requesterId,
         receiverId,
       });
 
-      const [receiverRow] = await db.select({ name: user.name }).from(user).where(eq(user.id, receiverId)).limit(1);
-      const receiverName = receiverRow?.name ?? "Someone";
-
-      domainEvents.emit("MatchRequestAccepted", {
-        matchRequestId: input.matchRequestId,
-        requesterId: request.requesterId,
-        receiverId,
-        receiverName,
-        acceptedAt: new Date(),
-      });
-
-      return { status: "accepted" as const, matchedWithUserId: request.requesterId };
+      return { status: "accepted" as const, matchedWithUserId: existing.requesterId };
     }),
 
   declineMatchRequest: protectedProcedure
@@ -534,38 +555,33 @@ export const matchingRouter = router({
     .mutation(async ({ ctx, input }) => {
       const receiverId = ctx.session.user.id;
 
-      const request = await db.query.matchRequest.findFirst({
-        where: eq(matchRequest.id, input.matchRequestId),
-      });
-
-      if (!request) {
+      const existing = await loadMatchRequestSnapshot(input.matchRequestId);
+      if (!existing) {
         throw new TRPCError({ code: "NOT_FOUND", message: "Match request not found." });
       }
 
-      if (request.receiverId !== receiverId) {
-        throw new TRPCError({ code: "FORBIDDEN", message: "Only the designated receiver may decline this request." });
+      let decision;
+      try {
+        decision = MatchRequest.decline(existing, {
+          actorId: receiverId,
+          now: new Date(),
+        });
+      } catch (err) {
+        toTrpcError(err);
       }
 
-      if (request.status !== "pending") {
-        throw new TRPCError({ code: "BAD_REQUEST", message: "Only pending requests can be declined." });
-      }
-
-      await db
-        .update(matchRequest)
-        .set({ status: "declined" })
-        .where(eq(matchRequest.id, input.matchRequestId));
-
-      console.info("[MatchRequestDeclined]", {
-        matchRequestId: input.matchRequestId,
-        requesterId: request.requesterId,
-        receiverId,
+      await commitAndEmit(async (tx) => {
+        await tx
+          .update(matchRequest)
+          .set({ status: decision.state.status })
+          .where(eq(matchRequest.id, existing.id));
+        return { result: undefined, events: decision.events };
       });
 
-      domainEvents.emit("MatchRequestDeclined", {
-        matchRequestId: input.matchRequestId,
-        requesterId: request.requesterId,
+      console.info("[MatchRequestDeclined]", {
+        matchRequestId: existing.id,
+        requesterId: existing.requesterId,
         receiverId,
-        declinedAt: new Date(),
       });
 
       return { status: "declined" as const };
@@ -579,26 +595,26 @@ export const matchingRouter = router({
     .mutation(async ({ ctx, input }) => {
       const requesterId = ctx.session.user.id;
 
-      const request = await db.query.matchRequest.findFirst({
-        where: eq(matchRequest.id, input.matchRequestId),
-      });
-
-      if (!request) {
+      const existing = await loadMatchRequestSnapshot(input.matchRequestId);
+      if (!existing) {
         throw new TRPCError({ code: "NOT_FOUND", message: "Invitation not found." });
       }
-      if (request.requesterId !== requesterId) {
-        throw new TRPCError({ code: "FORBIDDEN", message: "Only the sender may withdraw this invitation." });
-      }
-      if (request.status !== "pending") {
-        throw new TRPCError({ code: "BAD_REQUEST", message: "Only pending invitations can be withdrawn." });
+
+      try {
+        MatchRequest.withdraw(existing, { actorId: requesterId });
+      } catch (err) {
+        toTrpcError(err);
       }
 
-      await db.delete(matchRequest).where(eq(matchRequest.id, input.matchRequestId));
+      await commitAndEmit(async (tx) => {
+        await tx.delete(matchRequest).where(eq(matchRequest.id, existing.id));
+        return { result: undefined, events: [] };
+      });
 
       console.info("[MatchRequestWithdrawn]", {
-        matchRequestId: input.matchRequestId,
+        matchRequestId: existing.id,
         requesterId,
-        receiverId: request.receiverId,
+        receiverId: existing.receiverId,
       });
 
       return { success: true as const };
@@ -610,10 +626,6 @@ export const matchingRouter = router({
     .input(z.object({ partnerId: z.string() }))
     .mutation(async ({ ctx, input }) => {
       const userId = ctx.session.user.id;
-
-      if (userId === input.partnerId) {
-        throw new TRPCError({ code: "BAD_REQUEST", message: "You cannot unmatch yourself." });
-      }
 
       const match = await db.query.studentMatch.findFirst({
         where: or(
@@ -628,20 +640,30 @@ export const matchingRouter = router({
         ),
       });
 
-      if (!match) {
-        throw new TRPCError({ code: "NOT_FOUND", message: "You are not matched with this person." });
+      try {
+        MatchRequest.unmatch({
+          actorId: userId,
+          partnerId: input.partnerId,
+          matchExists: match != null,
+        });
+      } catch (err) {
+        toTrpcError(err);
       }
 
-      await db
-        .update(matchRequest)
-        .set({ status: "voided" })
-        .where(eq(matchRequest.id, match.matchRequestId));
-      await db.delete(studentMatch).where(eq(studentMatch.id, match.id));
+      // Voiding the request and dropping the match commit together.
+      await commitAndEmit(async (tx) => {
+        await tx
+          .update(matchRequest)
+          .set({ status: "voided" })
+          .where(eq(matchRequest.id, match!.matchRequestId));
+        await tx.delete(studentMatch).where(eq(studentMatch.id, match!.id));
+        return { result: undefined, events: [] };
+      });
 
       console.info("[Unmatched]", {
         userId,
         partnerId: input.partnerId,
-        matchId: match.id,
+        matchId: match!.id,
       });
 
       return { success: true as const };

--- a/packages/api/src/contexts/scheduling/meetup-read-model.ts
+++ b/packages/api/src/contexts/scheduling/meetup-read-model.ts
@@ -1,0 +1,194 @@
+/**
+ * Meetup read model — the query side of the Meetup Scheduling context.
+ *
+ * The Meetup aggregate owns transitions (the write side). This module owns the
+ * read side: the multi-join queries and row-shaping that turn raw meetup rows
+ * plus their venue, the two participants, attendance reports, and messaging
+ * opt-in state into the view shapes the native app renders.
+ *
+ * Pulling these out of the router gives the shaping a small interface
+ * (`userId` [+ status]) over a large implementation (aliased self-joins on the
+ * user table, partner resolution, deleted-account placeholders, attendance and
+ * messaging enrichment) — and makes the shaping testable through the harness
+ * without driving the full tRPC procedure.
+ */
+import { and, eq, or, sql, gte, desc } from "drizzle-orm";
+import { db } from "@sip-and-speak/db";
+import { meetup, venue, attendanceReport } from "@sip-and-speak/db/schema/scheduling";
+import { getMessagingStateForUserMeetups } from "../conversation";
+
+export type MeetupListStatus = "pending" | "confirmed" | "declined" | "all";
+
+/**
+ * Meetups where the user is proposer or receiver, newest first, shaped from the
+ * user's perspective (the other party becomes `partner`). A pending proposal
+ * whose currently-proposed datetime has passed is hidden (#367).
+ */
+export async function listMeetupsForUser(userId: string, status: MeetupListStatus) {
+  const conditions = [
+    or(eq(meetup.proposerId, userId), eq(meetup.receiverId, userId)),
+  ];
+
+  if (status !== "all") {
+    conditions.push(eq(meetup.status, status));
+  }
+
+  // #367 — A pending proposal whose currently-proposed datetime has passed is
+  // dead: hide it so the "Waiting for reply" card clears. scheduledAt always
+  // reflects the latest round (counter-proposals overwrite it), so this guards
+  // against the current datetime, never a stale earlier round. Confirmed/
+  // declined rows are unaffected — they still surface in history regardless of
+  // date.
+  if (status === "pending") {
+    conditions.push(gte(meetup.scheduledAt, new Date()));
+  }
+
+  const rows = await db
+    .select({
+      meetup: meetup,
+      venue: {
+        id: venue.id,
+        name: venue.name,
+        photoUrl: venue.photoUrl,
+      },
+      proposer: {
+        id: sql<string>`proposer.id`.as("proposer_id_alias"),
+        name: sql<string>`proposer.name`.as("proposer_name"),
+        image: sql<string | null>`proposer.image`.as("proposer_image"),
+        deletedAt: sql<Date | null>`proposer.deleted_at`.as("proposer_deleted_at"),
+      },
+      receiver: {
+        id: sql<string>`receiver.id`.as("receiver_id_alias"),
+        name: sql<string>`receiver.name`.as("receiver_name"),
+        image: sql<string | null>`receiver.image`.as("receiver_image"),
+        deletedAt: sql<Date | null>`receiver.deleted_at`.as("receiver_deleted_at"),
+      },
+    })
+    .from(meetup)
+    .innerJoin(venue, eq(meetup.venueId, venue.id))
+    .innerJoin(
+      sql`"user" as proposer`,
+      sql`proposer.id = ${meetup.proposerId}`,
+    )
+    .innerJoin(
+      sql`"user" as receiver`,
+      sql`receiver.id = ${meetup.receiverId}`,
+    )
+    .where(and(...conditions))
+    .orderBy(desc(meetup.createdAt));
+
+  return rows.map((row) => {
+    const isProposer = row.meetup.proposerId === userId;
+    const partner = isProposer ? row.receiver : row.proposer;
+
+    const partnerDeleted = partner.deletedAt !== null;
+
+    return {
+      ...row.meetup,
+      isProposer,
+      venue: row.venue,
+      partner: {
+        id: partner.id,
+        // #447 — render deleted partners as an unavailable placeholder.
+        name: partnerDeleted ? "Deleted user" : partner.name,
+        image: partnerDeleted ? null : partner.image,
+      },
+      partnerDeleted,
+    };
+  });
+}
+
+/**
+ * Confirmed and completed meetups for the user, newest first, enriched with the
+ * user's own attendance report and the post-meetup messaging opt-in state. The
+ * partner is resolved per-row via a CASE join so a single self-join covers both
+ * proposer and receiver perspectives.
+ */
+export async function getConfirmedMeetupsForUser(userId: string) {
+  const [rows, myReports, messagingState] = await Promise.all([
+    db
+      .select({
+        meetup: meetup,
+        venue: {
+          id: venue.id,
+          name: venue.name,
+          description: venue.description,
+          photoUrl: venue.photoUrl,
+        },
+        partner: {
+          id: sql<string>`partner.id`.as("gc_partner_id"),
+          name: sql<string>`partner.name`.as("gc_partner_name"),
+          image: sql<string | null>`partner.image`.as("gc_partner_image"),
+          deletedAt: sql<Date | null>`partner.deleted_at`.as("gc_partner_deleted_at"),
+        },
+      })
+      .from(meetup)
+      .innerJoin(venue, eq(meetup.venueId, venue.id))
+      .innerJoin(
+        sql`"user" as partner`,
+        sql`partner.id = CASE WHEN ${meetup.proposerId} = ${userId} THEN ${meetup.receiverId} ELSE ${meetup.proposerId} END`,
+      )
+      .where(
+        and(
+          or(eq(meetup.status, "confirmed"), eq(meetup.status, "completed")),
+          or(eq(meetup.proposerId, userId), eq(meetup.receiverId, userId)),
+        ),
+      )
+      .orderBy(desc(meetup.scheduledAt)),
+    // #97 — Fetch this user's attendance reports
+    db
+      .select({
+        meetupId: attendanceReport.meetupId,
+        attended: attendanceReport.attended,
+        rating: attendanceReport.rating,
+      })
+      .from(attendanceReport)
+      .where(eq(attendanceReport.studentId, userId)),
+    // Conversation context owns its own data — Scheduling consumes the surface
+    getMessagingStateForUserMeetups(userId),
+  ]);
+
+  const myReportMap = new Map(myReports.map((r) => [r.meetupId, r]));
+  const now = new Date();
+
+  return rows.map((row) => {
+    const myReport = myReportMap.get(row.meetup.id);
+    const messaging =
+      messagingState.get(row.meetup.id) ?? { mine: null, partner: null, conversationId: null };
+    const partnerDeleted = row.partner.deletedAt !== null;
+    return {
+      meetupId: row.meetup.id,
+      scheduledAt: row.meetup.scheduledAt,
+      status: row.meetup.status,
+      isPast: row.meetup.scheduledAt <= now,
+      venue: row.venue,
+      // #447 — render deleted partners as an unavailable placeholder.
+      partner: {
+        id: row.partner.id,
+        name: partnerDeleted ? "Deleted user" : row.partner.name,
+        image: partnerDeleted ? null : row.partner.image,
+      },
+      partnerDeleted,
+      // #86 — Reschedule proposal state
+      reschedulePending: row.meetup.rescheduleProposerId !== null,
+      rescheduleIsFromMe: row.meetup.rescheduleProposerId === userId,
+      reschedule:
+        row.meetup.rescheduleProposerId !== null && row.meetup.rescheduleScheduledAt
+          ? {
+              venueId: row.meetup.rescheduleVenueId!,
+              scheduledAt: row.meetup.rescheduleScheduledAt,
+            }
+          : null,
+      // #97 — Attendance report state
+      hasReported: myReport !== undefined,
+      myAttendance: myReport?.attended ?? null,
+      myRating: myReport?.rating ?? null,
+      // Messaging opt-in state for post-meetup hero
+      optIn: {
+        mine: messaging.mine,
+        partner: messaging.partner,
+        conversationId: messaging.conversationId,
+      },
+    };
+  });
+}

--- a/packages/api/src/contexts/scheduling/meetup.ts
+++ b/packages/api/src/contexts/scheduling/meetup.ts
@@ -1,14 +1,12 @@
-import type { EventEmitter } from "events";
-import { and, eq, or, sql, count, gte, lt, inArray, desc } from "drizzle-orm";
+import { and, eq, or, sql, count, gte, lt, inArray } from "drizzle-orm";
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { db } from "@sip-and-speak/db";
 import { meetup, venue, attendanceReport } from "@sip-and-speak/db/schema/scheduling";
 import { studentMatch } from "@sip-and-speak/db/schema/matching";
-import { getMessagingStateForUserMeetups } from "../conversation";
 import { user } from "@sip-and-speak/db/schema/auth";
 import { protectedProcedure, router } from "../../index";
-import { domainEvents } from "../../domain-events";
+import { commitAndEmit, type BufferedEvent } from "../../unit-of-work";
 import {
   Meetup,
   MeetupRuleError,
@@ -16,6 +14,10 @@ import {
   type MeetupSnapshot,
   type VenueSnapshot,
 } from "./meetup-aggregate";
+import {
+  listMeetupsForUser,
+  getConfirmedMeetupsForUser,
+} from "./meetup-read-model";
 
 /**
  * Format a UTC Date as wall-clock parts in the given IANA timezone.
@@ -72,10 +74,7 @@ async function assertPartnerActive(partnerId: string): Promise<void> {
 }
 
 /**
- * Replay aggregate events through the global domain-events emitter. We dodge
- * the per-event generic by routing through the base `EventEmitter.emit`.
- *
- * For events that carry `scheduledAt` (Date), we also enrich the payload with
+ * For events that carry `scheduledAt` (Date), enrich the payload with
  * `date`/`time` strings formatted in the canonical zone so notification
  * builders can keep using string interpolation without timezone work.
  */
@@ -99,11 +98,19 @@ function enrichPayload(payload: Record<string, unknown>): Record<string, unknown
   return out;
 }
 
-function emit(events: DomainEventToEmit[], extraPayload: Record<string, unknown> = {}): void {
-  const emitter = domainEvents as unknown as EventEmitter;
-  for (const e of events) {
-    emitter.emit(e.name, enrichPayload({ ...e.payload, ...extraPayload }));
-  }
+/**
+ * Map aggregate events to buffered events, applying payload enrichment. The
+ * buffer is handed to `commitAndEmit`, which fires them only after the
+ * transaction commits — so a rolled-back transition emits nothing.
+ */
+function toBuffered(
+  events: DomainEventToEmit[],
+  extraPayload: Record<string, unknown> = {},
+): BufferedEvent[] {
+  return events.map((e) => ({
+    name: e.name,
+    payload: enrichPayload({ ...e.payload, ...extraPayload }),
+  }));
 }
 
 /** Load the venue snapshot the aggregate needs for proposal-style transitions. */
@@ -216,9 +223,13 @@ export const meetupRouter = router({
         toTrpcError(err);
       }
 
-      const [created] = await db.insert(meetup).values(decision.row).returning();
-      emit(decision.events, { meetupId: created!.id });
-      return created;
+      return commitAndEmit(async (tx) => {
+        const [created] = await tx.insert(meetup).values(decision.row).returning();
+        return {
+          result: created,
+          events: toBuffered(decision.events, { meetupId: created!.id }),
+        };
+      });
     }),
 
   /**
@@ -272,13 +283,14 @@ export const meetupRouter = router({
         } catch (err) {
           toTrpcError(err);
         }
-        const [updated] = await db
-          .update(meetup)
-          .set({ status: decision.state.status })
-          .where(eq(meetup.id, existing.id))
-          .returning();
-        emit(decision.events);
-        return updated;
+        return commitAndEmit(async (tx) => {
+          const [updated] = await tx
+            .update(meetup)
+            .set({ status: decision.state.status })
+            .where(eq(meetup.id, existing.id))
+            .returning();
+          return { result: updated, events: toBuffered(decision.events) };
+        });
       }
 
       // decline path
@@ -288,13 +300,14 @@ export const meetupRouter = router({
       } catch (err) {
         toTrpcError(err);
       }
-      const [updated] = await db
-        .update(meetup)
-        .set({ status: decision.state.status })
-        .where(eq(meetup.id, existing.id))
-        .returning();
-      emit(decision.events);
-      return updated;
+      return commitAndEmit(async (tx) => {
+        const [updated] = await tx
+          .update(meetup)
+          .set({ status: decision.state.status })
+          .where(eq(meetup.id, existing.id))
+          .returning();
+        return { result: updated, events: toBuffered(decision.events) };
+      });
     }),
 
   // #75 — Accept a pending proposal → confirm meetup, emit MeetupConfirmed
@@ -324,13 +337,14 @@ export const meetupRouter = router({
         toTrpcError(err);
       }
 
-      const [updated] = await db
-        .update(meetup)
-        .set({ status: decision.state.status })
-        .where(eq(meetup.id, existing.id))
-        .returning();
-      emit(decision.events);
-      return updated;
+      return commitAndEmit(async (tx) => {
+        const [updated] = await tx
+          .update(meetup)
+          .set({ status: decision.state.status })
+          .where(eq(meetup.id, existing.id))
+          .returning();
+        return { result: updated, events: toBuffered(decision.events) };
+      });
     }),
 
   // #77 — Decline a pending proposal → reset to Matched state, emit MeetupDeclined
@@ -350,13 +364,14 @@ export const meetupRouter = router({
         toTrpcError(err);
       }
 
-      const [updated] = await db
-        .update(meetup)
-        .set({ status: decision.state.status })
-        .where(eq(meetup.id, existing.id))
-        .returning();
-      emit(decision.events);
-      return updated;
+      return commitAndEmit(async (tx) => {
+        const [updated] = await tx
+          .update(meetup)
+          .set({ status: decision.state.status })
+          .where(eq(meetup.id, existing.id))
+          .returning();
+        return { result: updated, events: toBuffered(decision.events) };
+      });
     }),
 
   // #76 — Counter-propose: swap roles, update details, increment round, emit MeetupCounterProposed
@@ -391,19 +406,20 @@ export const meetupRouter = router({
       }
 
       const next = decision.state;
-      const [updated] = await db
-        .update(meetup)
-        .set({
-          proposerId: next.proposerId,
-          receiverId: next.receiverId,
-          venueId: next.venueId,
-          scheduledAt: next.scheduledAt,
-          round: next.round,
-        })
-        .where(eq(meetup.id, existing.id))
-        .returning();
-      emit(decision.events);
-      return updated;
+      return commitAndEmit(async (tx) => {
+        const [updated] = await tx
+          .update(meetup)
+          .set({
+            proposerId: next.proposerId,
+            receiverId: next.receiverId,
+            venueId: next.venueId,
+            scheduledAt: next.scheduledAt,
+            round: next.round,
+          })
+          .where(eq(meetup.id, existing.id))
+          .returning();
+        return { result: updated, events: toBuffered(decision.events) };
+      });
     }),
 
   list: protectedProcedure
@@ -415,79 +431,7 @@ export const meetupRouter = router({
       }),
     )
     .query(async ({ ctx, input }) => {
-      const userId = ctx.session.user.id;
-
-      const conditions = [
-        or(eq(meetup.proposerId, userId), eq(meetup.receiverId, userId)),
-      ];
-
-      if (input.status !== "all") {
-        conditions.push(eq(meetup.status, input.status));
-      }
-
-      // #367 — A pending proposal whose currently-proposed datetime has passed
-      // is dead: hide it so the "Waiting for reply" card clears. scheduledAt
-      // always reflects the latest round (counter-proposals overwrite it), so
-      // this guards against the current datetime, never a stale earlier round.
-      // Confirmed/declined rows are unaffected — they still surface in history
-      // regardless of date.
-      if (input.status === "pending") {
-        conditions.push(gte(meetup.scheduledAt, new Date()));
-      }
-
-      const rows = await db
-        .select({
-          meetup: meetup,
-          venue: {
-            id: venue.id,
-            name: venue.name,
-            photoUrl: venue.photoUrl,
-          },
-          proposer: {
-            id: sql<string>`proposer.id`.as("proposer_id_alias"),
-            name: sql<string>`proposer.name`.as("proposer_name"),
-            image: sql<string | null>`proposer.image`.as("proposer_image"),
-            deletedAt: sql<Date | null>`proposer.deleted_at`.as("proposer_deleted_at"),
-          },
-          receiver: {
-            id: sql<string>`receiver.id`.as("receiver_id_alias"),
-            name: sql<string>`receiver.name`.as("receiver_name"),
-            image: sql<string | null>`receiver.image`.as("receiver_image"),
-            deletedAt: sql<Date | null>`receiver.deleted_at`.as("receiver_deleted_at"),
-          },
-        })
-        .from(meetup)
-        .innerJoin(venue, eq(meetup.venueId, venue.id))
-        .innerJoin(
-          sql`"user" as proposer`,
-          sql`proposer.id = ${meetup.proposerId}`,
-        )
-        .innerJoin(
-          sql`"user" as receiver`,
-          sql`receiver.id = ${meetup.receiverId}`,
-        )
-        .where(and(...conditions))
-        .orderBy(desc(meetup.createdAt));
-
-      return rows.map((row) => {
-        const isProposer = row.meetup.proposerId === userId;
-        const partner = isProposer ? row.receiver : row.proposer;
-
-        const partnerDeleted = partner.deletedAt !== null;
-
-        return {
-          ...row.meetup,
-          isProposer,
-          venue: row.venue,
-          partner: {
-            id: partner.id,
-            // #447 — render deleted partners as an unavailable placeholder.
-            name: partnerDeleted ? "Deleted user" : partner.name,
-            image: partnerDeleted ? null : partner.image,
-          },
-          partnerDeleted,
-        };
-      });
+      return listMeetupsForUser(ctx.session.user.id, input.status);
     }),
 
   /**
@@ -610,13 +554,14 @@ export const meetupRouter = router({
         toTrpcError(err);
       }
 
-      const [updated] = await db
-        .update(meetup)
-        .set({ status: decision.state.status })
-        .where(eq(meetup.id, existing.id))
-        .returning();
-      emit(decision.events);
-      return updated;
+      return commitAndEmit(async (tx) => {
+        const [updated] = await tx
+          .update(meetup)
+          .set({ status: decision.state.status })
+          .where(eq(meetup.id, existing.id))
+          .returning();
+        return { result: updated, events: toBuffered(decision.events) };
+      });
     }),
 
   // #399 — Withdraw a still-pending proposal (proposer-only) → cancelled status,
@@ -639,103 +584,19 @@ export const meetupRouter = router({
         toTrpcError(err);
       }
 
-      const [updated] = await db
-        .update(meetup)
-        .set({ status: decision.state.status })
-        .where(eq(meetup.id, existing.id))
-        .returning();
-      emit(decision.events);
-      return updated;
+      return commitAndEmit(async (tx) => {
+        const [updated] = await tx
+          .update(meetup)
+          .set({ status: decision.state.status })
+          .where(eq(meetup.id, existing.id))
+          .returning();
+        return { result: updated, events: toBuffered(decision.events) };
+      });
     }),
 
   // Query confirmed meetups for the current user
   getConfirmed: protectedProcedure.query(async ({ ctx }) => {
-    const userId = ctx.session.user.id;
-
-    const [rows, myReports, messagingState] = await Promise.all([
-      db
-        .select({
-          meetup: meetup,
-          venue: {
-            id: venue.id,
-            name: venue.name,
-            description: venue.description,
-            photoUrl: venue.photoUrl,
-          },
-          partner: {
-            id: sql<string>`partner.id`.as("gc_partner_id"),
-            name: sql<string>`partner.name`.as("gc_partner_name"),
-            image: sql<string | null>`partner.image`.as("gc_partner_image"),
-            deletedAt: sql<Date | null>`partner.deleted_at`.as("gc_partner_deleted_at"),
-          },
-        })
-        .from(meetup)
-        .innerJoin(venue, eq(meetup.venueId, venue.id))
-        .innerJoin(
-          sql`"user" as partner`,
-          sql`partner.id = CASE WHEN ${meetup.proposerId} = ${userId} THEN ${meetup.receiverId} ELSE ${meetup.proposerId} END`,
-        )
-        .where(
-          and(
-            or(eq(meetup.status, "confirmed"), eq(meetup.status, "completed")),
-            or(eq(meetup.proposerId, userId), eq(meetup.receiverId, userId)),
-          ),
-        )
-        .orderBy(desc(meetup.scheduledAt)),
-      // #97 — Fetch this user's attendance reports
-      db
-        .select({
-          meetupId: attendanceReport.meetupId,
-          attended: attendanceReport.attended,
-          rating: attendanceReport.rating,
-        })
-        .from(attendanceReport)
-        .where(eq(attendanceReport.studentId, userId)),
-      // Conversation context owns its own data — Scheduling consumes the surface
-      getMessagingStateForUserMeetups(userId),
-    ]);
-
-    const myReportMap = new Map(myReports.map((r) => [r.meetupId, r]));
-    const now = new Date();
-
-    return rows.map((row) => {
-      const myReport = myReportMap.get(row.meetup.id);
-      const messaging = messagingState.get(row.meetup.id) ?? { mine: null, partner: null, conversationId: null };
-      const partnerDeleted = row.partner.deletedAt !== null;
-      return {
-        meetupId: row.meetup.id,
-        scheduledAt: row.meetup.scheduledAt,
-        status: row.meetup.status,
-        isPast: row.meetup.scheduledAt <= now,
-        venue: row.venue,
-        // #447 — render deleted partners as an unavailable placeholder.
-        partner: {
-          id: row.partner.id,
-          name: partnerDeleted ? "Deleted user" : row.partner.name,
-          image: partnerDeleted ? null : row.partner.image,
-        },
-        partnerDeleted,
-        // #86 — Reschedule proposal state
-        reschedulePending: row.meetup.rescheduleProposerId !== null,
-        rescheduleIsFromMe: row.meetup.rescheduleProposerId === userId,
-        reschedule: row.meetup.rescheduleProposerId !== null && row.meetup.rescheduleScheduledAt
-          ? {
-              venueId: row.meetup.rescheduleVenueId!,
-              scheduledAt: row.meetup.rescheduleScheduledAt,
-            }
-          : null,
-        // #97 — Attendance report state
-        hasReported: myReport !== undefined,
-        myAttendance: myReport?.attended ?? null,
-        myRating: myReport?.rating ?? null,
-        // Messaging opt-in state for post-meetup hero
-        optIn: {
-          mine: messaging.mine,
-          partner: messaging.partner,
-          conversationId: messaging.conversationId,
-        },
-      };
-    });
+    return getConfirmedMeetupsForUser(ctx.session.user.id);
   }),
 
   // #86 — Propose a reschedule for a confirmed meetup
@@ -770,17 +631,18 @@ export const meetupRouter = router({
       }
 
       const next = decision.state;
-      const [updated] = await db
-        .update(meetup)
-        .set({
-          rescheduleProposerId: next.rescheduleProposerId,
-          rescheduleVenueId: next.rescheduleVenueId,
-          rescheduleScheduledAt: next.rescheduleScheduledAt,
-        })
-        .where(eq(meetup.id, existing.id))
-        .returning();
-      emit(decision.events);
-      return updated;
+      return commitAndEmit(async (tx) => {
+        const [updated] = await tx
+          .update(meetup)
+          .set({
+            rescheduleProposerId: next.rescheduleProposerId,
+            rescheduleVenueId: next.rescheduleVenueId,
+            rescheduleScheduledAt: next.rescheduleScheduledAt,
+          })
+          .where(eq(meetup.id, existing.id))
+          .returning();
+        return { result: updated, events: toBuffered(decision.events) };
+      });
     }),
 
   // #91 — Accept a reschedule proposal → update meetup details, emit MeetupRescheduled, notify both
@@ -815,29 +677,30 @@ export const meetupRouter = router({
 
       const next = decision.state;
       // Atomic guard preserved — only commit if reschedule is still pending.
-      const [updated] = await db
-        .update(meetup)
-        .set({
-          venueId: next.venueId,
-          scheduledAt: next.scheduledAt,
-          rescheduleProposerId: null,
-          rescheduleVenueId: null,
-          rescheduleScheduledAt: null,
-        })
-        .where(
-          and(eq(meetup.id, existing.id), sql`${meetup.rescheduleProposerId} IS NOT NULL`),
-        )
-        .returning();
+      return commitAndEmit(async (tx) => {
+        const [updated] = await tx
+          .update(meetup)
+          .set({
+            venueId: next.venueId,
+            scheduledAt: next.scheduledAt,
+            rescheduleProposerId: null,
+            rescheduleVenueId: null,
+            rescheduleScheduledAt: null,
+          })
+          .where(
+            and(eq(meetup.id, existing.id), sql`${meetup.rescheduleProposerId} IS NOT NULL`),
+          )
+          .returning();
 
-      if (!updated) {
-        throw new TRPCError({
-          code: "CONFLICT",
-          message: "The reschedule proposal was already handled by another request",
-        });
-      }
+        if (!updated) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: "The reschedule proposal was already handled by another request",
+          });
+        }
 
-      emit(decision.events);
-      return updated;
+        return { result: updated, events: toBuffered(decision.events) };
+      });
     }),
 
   // #93 — Decline a reschedule proposal → retain original details, emit MeetupRescheduleDeclined, notify both
@@ -866,27 +729,28 @@ export const meetupRouter = router({
         toTrpcError(err);
       }
 
-      const [updated] = await db
-        .update(meetup)
-        .set({
-          rescheduleProposerId: null,
-          rescheduleVenueId: null,
-          rescheduleScheduledAt: null,
-        })
-        .where(
-          and(eq(meetup.id, existing.id), sql`${meetup.rescheduleProposerId} IS NOT NULL`),
-        )
-        .returning();
+      return commitAndEmit(async (tx) => {
+        const [updated] = await tx
+          .update(meetup)
+          .set({
+            rescheduleProposerId: null,
+            rescheduleVenueId: null,
+            rescheduleScheduledAt: null,
+          })
+          .where(
+            and(eq(meetup.id, existing.id), sql`${meetup.rescheduleProposerId} IS NOT NULL`),
+          )
+          .returning();
 
-      if (!updated) {
-        throw new TRPCError({
-          code: "CONFLICT",
-          message: "The reschedule proposal was already handled by another request",
-        });
-      }
+        if (!updated) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: "The reschedule proposal was already handled by another request",
+          });
+        }
 
-      emit(decision.events);
-      return updated;
+        return { result: updated, events: toBuffered(decision.events) };
+      });
     }),
 
   // #97 — Record each Student's attendance report independently
@@ -929,7 +793,7 @@ export const meetupRouter = router({
       // cross-context match promotion must all commit or all roll back. A
       // mid-sequence failure previously left the report recorded while the
       // meetup/match state stayed inconsistent.
-      const { created, promotedMatch } = await db.transaction(async (tx) => {
+      const created = await commitAndEmit(async (tx) => {
         const [created] = await tx
           .insert(attendanceReport)
           .values({
@@ -976,35 +840,37 @@ export const meetupRouter = router({
           }
         }
 
-        return { created, promotedMatch };
+        // Enrich AttendanceReported with the freshly-persisted report id.
+        const attendanceReportedIdx = decision.events.findIndex(
+          (e) => e.name === "AttendanceReported",
+        );
+        if (attendanceReportedIdx !== -1 && created) {
+          decision.events[attendanceReportedIdx]!.payload.reportId = created.id;
+          decision.events[attendanceReportedIdx]!.payload.reportedAt = created.reportedAt;
+        }
+        const events = toBuffered(decision.events);
+
+        if (promotedMatch) {
+          // #138 — Prompt both Students to opt in to messaging after a completed meetup
+          const [studentARow, studentBRow] = await Promise.all([
+            tx.select({ name: user.name }).from(user).where(eq(user.id, existing.proposerId)).limit(1),
+            tx.select({ name: user.name }).from(user).where(eq(user.id, existing.receiverId)).limit(1),
+          ]);
+          events.push({
+            name: "MessagingOptInPrompted",
+            payload: {
+              meetupId: input.meetupId,
+              studentAId: existing.proposerId,
+              studentAName: studentARow[0]?.name ?? "Your match",
+              studentBId: existing.receiverId,
+              studentBName: studentBRow[0]?.name ?? "Your match",
+              promptedAt: new Date(),
+            },
+          });
+        }
+
+        return { result: created, events };
       });
-
-      // Side effects fire only after the transaction commits.
-      // Enrich AttendanceReported with the freshly-persisted report id.
-      const attendanceReportedIdx = decision.events.findIndex(
-        (e) => e.name === "AttendanceReported",
-      );
-      if (attendanceReportedIdx !== -1 && created) {
-        decision.events[attendanceReportedIdx]!.payload.reportId = created.id;
-        decision.events[attendanceReportedIdx]!.payload.reportedAt = created.reportedAt;
-      }
-      emit(decision.events);
-
-      if (promotedMatch) {
-        const [studentARow, studentBRow] = await Promise.all([
-          db.select({ name: user.name }).from(user).where(eq(user.id, existing.proposerId)).limit(1),
-          db.select({ name: user.name }).from(user).where(eq(user.id, existing.receiverId)).limit(1),
-        ]);
-        // #138 — Prompt both Students to opt in to messaging after a completed meetup
-        domainEvents.emit("MessagingOptInPrompted", {
-          meetupId: input.meetupId,
-          studentAId: existing.proposerId,
-          studentAName: studentARow[0]?.name ?? "Your match",
-          studentBId: existing.receiverId,
-          studentBName: studentBRow[0]?.name ?? "Your match",
-          promptedAt: new Date(),
-        });
-      }
 
       return created;
     }),

--- a/packages/api/src/unit-of-work.ts
+++ b/packages/api/src/unit-of-work.ts
@@ -1,0 +1,48 @@
+import type { EventEmitter } from "events";
+import { db, type Db } from "@sip-and-speak/db";
+import { domainEvents } from "./domain-events";
+
+/**
+ * A domain event captured during a unit of work. Buffered while the
+ * transaction is open and emitted only after it commits, so listeners never
+ * observe state that was rolled back.
+ */
+export interface BufferedEvent {
+  name: string;
+  payload: Record<string, unknown>;
+}
+
+/** The Drizzle transaction handle, derived from the db's own `transaction` type. */
+export type Tx = Parameters<Parameters<Db["transaction"]>[0]>[0];
+
+/**
+ * Run `work` inside a single DB transaction, then emit its domain events only
+ * after the transaction commits.
+ *
+ * This is the one seam where the persist-then-emit ritual lives. Before it,
+ * every mutation wrote with the ambient `db` (autocommit) and then called
+ * `emit()` by hand — so a crash between the write and the emit left state
+ * persisted with its event lost, and a mutation that wrote twice was not
+ * atomic. Callers now hand back their rows plus the events to fire; the seam
+ * guarantees:
+ *
+ *   - all writes in `work` commit or roll back together (atomicity), and
+ *   - a rolled-back transaction emits nothing (state and events never diverge).
+ *
+ * It is also the single place a durable outbox or per-listener isolation would
+ * later slot in, without touching any caller.
+ */
+export async function commitAndEmit<T>(
+  work: (tx: Tx) => Promise<{ result: T; events: BufferedEvent[] }>,
+): Promise<T> {
+  const { result, events } = await db.transaction(async (tx) => work(tx));
+
+  // Emit only after the commit. We route through the base EventEmitter to dodge
+  // the typed-emitter's per-event generic — payloads are already fully built.
+  const emitter = domainEvents as unknown as EventEmitter;
+  for (const e of events) {
+    emitter.emit(e.name, e.payload);
+  }
+
+  return result;
+}


### PR DESCRIPTION
Implements the deepening candidates from the architecture review. Each turns a shallow seam into a deep one (small interface over real behaviour), with the rule living in one place and a test surface at that interface.

## What changed

| # | Deepening | Files | Tests |
|---|-----------|-------|-------|
| 1 | **MatchRequest aggregate** — Matching lifecycle (send/accept/decline/withdraw/unmatch) extracted into a pure state machine, mirroring the Meetup aggregate. Inline guards across 5 mutations now live in one place. | `match-request-aggregate.ts`, `matching.ts` | +16 |
| 2 | **`commitAndEmit` unit-of-work** — the one seam where persist + emit happen: writes in a single transaction, buffered events emitted only after commit. All 14 emit sites (Matching 3, Meetup 11) rewired. Fixes the non-atomic `unmatch` (update + delete were two autocommits). | `unit-of-work.ts`, `matching.ts`, `meetup.ts` | +3 |
| 3 | **Meetup read model** — the two heavy multi-join read queries (`list`, `getConfirmed`) + shaping moved out of the 1016-LOC router. | `meetup-read-model.ts`, `meetup.ts` | (integration) |
| 4 | **Onboarding interest rule** — centralized the wizard's "3–7" gate (was a magic number in 4 spots). | `onboarding-modal.tsx` | — |
| 5 | **Onboarding wizard view-model** — per-step advance gates extracted into a pure, tested module the component consumes. | `onboarding-flow.ts`, `onboarding-modal.tsx` | +5 |
| 6 | **MessagingAccess — declined.** Read/write access checks look like duplicates but diverge intentionally (read collapses errors to obscure existence). Merging would be shallow. Recorded as **ADR-0004**. | `docs/adr/0004-…md` | — |

## Notable findings (verified)
- **#2 was a latent correctness gap, not just cleanup.** `unmatch` did `update(matchRequest)` then `delete(studentMatch)` as separate autocommits; a crash between left a voided request with a live match. Now one transaction.
- **#4 was *not* the drift the review suspected.** The client's ≥3-interest gate is intentional onboarding UX ("Pick 3–7"), deliberately stricter than the server's ≥1 matching-eligibility rule. Documented rather than "fixed."
- pg-mem does not emulate transaction `ROLLBACK`, so the unit-of-work test asserts the JS contract (no events on throw); DB atomicity is a Postgres guarantee. Noted in the test + CONTEXT.md.

## Verification
- `@sip-and-speak/api`: **216 tests pass**, `tsc` clean.
- `native`: **207 tests pass**, `tsc` clean.
- `CONTEXT.md` updated with the new module names; ADR-0004 added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)