### PR TITLE
refactor: round-3 deepening — read models, notification seam, meetup-flow view-model

### DIFF
--- a/apps/native/__tests__/meetup-flow.test.ts
+++ b/apps/native/__tests__/meetup-flow.test.ts
@@ -1,0 +1,250 @@
+import { addDays, startOfDay } from "date-fns";
+
+import { combineLocal, formatDayFull, toIsoDate } from "@/lib/dates";
+import {
+  ALL_SLOTS,
+  buildSuggestions,
+  freeSlotsFor,
+  isValidTimeFormat,
+  pickProposedScheduledAt,
+  timeFromDate,
+  validateProposedScheduledAt,
+  validateScheduledAt,
+  type ProposeSelection,
+  type Suggestion,
+} from "@/utils/meetup-flow";
+
+// A fixed device-local day used throughout. Assertions compare against the same
+// `combineLocal` / `toIsoDate` helpers the production code uses, so they hold
+// regardless of the machine timezone Jest runs in.
+const DATE = "2026-06-01";
+
+const sel = (over: Partial<ProposeSelection> = {}): ProposeSelection => ({
+  customMode: false,
+  customDateIso: "",
+  customTime: "",
+  selectedSuggestionIdx: null,
+  suggestions: [],
+  ...over,
+});
+
+describe("ALL_SLOTS", () => {
+  it("covers every half hour from 08:00 to 20:00 inclusive", () => {
+    expect(ALL_SLOTS).toHaveLength(25);
+    expect(ALL_SLOTS[0]).toBe("08:00");
+    expect(ALL_SLOTS[ALL_SLOTS.length - 1]).toBe("20:00");
+    expect(ALL_SLOTS).toContain("08:30");
+    expect(ALL_SLOTS).toContain("14:00");
+  });
+
+  it("only contains well-formed HH:MM strings", () => {
+    expect(ALL_SLOTS.every(isValidTimeFormat)).toBe(true);
+  });
+});
+
+describe("isValidTimeFormat", () => {
+  it("accepts two-digit HH:MM", () => {
+    expect(isValidTimeFormat("14:00")).toBe(true);
+    expect(isValidTimeFormat("08:30")).toBe(true);
+  });
+
+  it("rejects malformed shapes", () => {
+    expect(isValidTimeFormat("9:00")).toBe(false);
+    expect(isValidTimeFormat("14:0")).toBe(false);
+    expect(isValidTimeFormat("1400")).toBe(false);
+    expect(isValidTimeFormat("ab:cd")).toBe(false);
+    expect(isValidTimeFormat("")).toBe(false);
+  });
+
+  it("checks shape only, not range (combineLocal rejects impossible values)", () => {
+    expect(isValidTimeFormat("25:99")).toBe(true);
+    expect(combineLocal(DATE, "25:99")).toBeNull();
+  });
+});
+
+describe("timeFromDate", () => {
+  it("round-trips a combineLocal instant back to its wall-clock HH:MM", () => {
+    expect(timeFromDate(combineLocal(DATE, "14:00")!)).toBe("14:00");
+    expect(timeFromDate(combineLocal(DATE, "08:30")!)).toBe("08:30");
+  });
+});
+
+describe("buildSuggestions", () => {
+  it("offers +1/+2/+4 days at the fixed coffee times", () => {
+    const now = new Date("2026-06-01T09:00:00Z");
+    const out = buildSuggestions(now);
+    const base = startOfDay(now);
+
+    expect(out).toHaveLength(3);
+    expect(out.map((s) => s.time)).toEqual(["10:30", "14:00", "15:00"]);
+    expect(out.map((s) => s.hint)).toEqual(["your usual coffee slot", undefined, undefined]);
+    expect(out.map((s) => s.date)).toEqual([
+      toIsoDate(addDays(base, 1)),
+      toIsoDate(addDays(base, 2)),
+      toIsoDate(addDays(base, 4)),
+    ]);
+    expect(out.map((s) => s.weekday)).toEqual([
+      formatDayFull(addDays(base, 1)),
+      formatDayFull(addDays(base, 2)),
+      formatDayFull(addDays(base, 4)),
+    ]);
+  });
+
+  it("defaults to the current day and yields well-formed cards", () => {
+    const out = buildSuggestions();
+    expect(out).toHaveLength(3);
+    for (const s of out) {
+      expect(s.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      expect(isValidTimeFormat(s.time)).toBe(true);
+      expect(s.weekday.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("freeSlotsFor", () => {
+  it("returns every slot when nothing is blocked", () => {
+    expect(freeSlotsFor(DATE, [])).toEqual(ALL_SLOTS);
+  });
+
+  it("removes a slot blocked by a Date instant", () => {
+    const blocked = combineLocal(DATE, "10:30")!;
+    const free = freeSlotsFor(DATE, [blocked]);
+    expect(free).not.toContain("10:30");
+    expect(free).toContain("10:00");
+    expect(free).toHaveLength(ALL_SLOTS.length - 1);
+  });
+
+  it("accepts ISO strings as blocked instants too", () => {
+    const blocked = combineLocal(DATE, "14:00")!.toISOString();
+    expect(freeSlotsFor(DATE, [blocked])).not.toContain("14:00");
+  });
+
+  it("ignores unparseable blocked entries", () => {
+    expect(freeSlotsFor(DATE, ["not-a-date"])).toEqual(ALL_SLOTS);
+  });
+
+  it("does not block a slot whose collision is on a different day", () => {
+    const otherDay = combineLocal("2026-06-02", "10:30")!;
+    expect(freeSlotsFor(DATE, [otherDay])).toContain("10:30");
+  });
+
+  it("returns an empty list when the date itself is malformed", () => {
+    expect(freeSlotsFor("nonsense", [])).toEqual([]);
+  });
+});
+
+describe("pickProposedScheduledAt", () => {
+  it("resolves a valid custom date + time", () => {
+    const got = pickProposedScheduledAt(
+      sel({ customMode: true, customDateIso: DATE, customTime: "14:00" }),
+    );
+    expect(got?.getTime()).toBe(combineLocal(DATE, "14:00")!.getTime());
+  });
+
+  it("returns null for a custom selection missing the date", () => {
+    expect(
+      pickProposedScheduledAt(sel({ customMode: true, customDateIso: "", customTime: "14:00" })),
+    ).toBeNull();
+  });
+
+  it("returns null for a custom selection with a malformed time", () => {
+    expect(
+      pickProposedScheduledAt(sel({ customMode: true, customDateIso: DATE, customTime: "2pm" })),
+    ).toBeNull();
+  });
+
+  it("resolves the chosen suggestion in suggested mode", () => {
+    const suggestions: Suggestion[] = [
+      { date: DATE, time: "10:30", weekday: "Monday" },
+      { date: DATE, time: "14:00", weekday: "Monday" },
+    ];
+    const got = pickProposedScheduledAt(sel({ selectedSuggestionIdx: 1, suggestions }));
+    expect(got?.getTime()).toBe(combineLocal(DATE, "14:00")!.getTime());
+  });
+
+  it("returns null when no suggestion is selected", () => {
+    expect(pickProposedScheduledAt(sel({ selectedSuggestionIdx: null }))).toBeNull();
+  });
+
+  it("returns null when the selected index is out of range", () => {
+    const suggestions: Suggestion[] = [{ date: DATE, time: "10:30", weekday: "Monday" }];
+    expect(pickProposedScheduledAt(sel({ selectedSuggestionIdx: 5, suggestions }))).toBeNull();
+  });
+});
+
+describe("validateProposedScheduledAt", () => {
+  const NOW_BEFORE = new Date("2020-01-01T00:00:00Z");
+  const NOW_AFTER = new Date("2030-01-01T00:00:00Z");
+
+  it("rejects an incomplete custom selection with the custom-path copy", () => {
+    expect(
+      validateProposedScheduledAt(sel({ customMode: true, customDateIso: "", customTime: "" })),
+    ).toEqual({ ok: false, error: "Please pick a date and time (HH:MM)" });
+  });
+
+  it("rejects an empty suggested selection with the suggested-path copy", () => {
+    expect(
+      validateProposedScheduledAt(sel({ customMode: false, selectedSuggestionIdx: null })),
+    ).toEqual({ ok: false, error: "Please pick a suggested time" });
+  });
+
+  it("rejects a resolved-but-past instant", () => {
+    expect(
+      validateProposedScheduledAt(
+        sel({ customMode: true, customDateIso: DATE, customTime: "14:00" }),
+        NOW_AFTER,
+      ),
+    ).toEqual({ ok: false, error: "The selected date and time must be in the future" });
+  });
+
+  it("accepts a resolved future custom instant", () => {
+    const result = validateProposedScheduledAt(
+      sel({ customMode: true, customDateIso: DATE, customTime: "14:00" }),
+      NOW_BEFORE,
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.scheduledAt.getTime()).toBe(combineLocal(DATE, "14:00")!.getTime());
+    }
+  });
+
+  it("accepts a resolved future suggested instant", () => {
+    const suggestions: Suggestion[] = [{ date: DATE, time: "10:30", weekday: "Monday" }];
+    const result = validateProposedScheduledAt(
+      sel({ selectedSuggestionIdx: 0, suggestions }),
+      NOW_BEFORE,
+    );
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe("validateScheduledAt", () => {
+  const NOW_BEFORE = new Date("2020-01-01T00:00:00Z");
+  const NOW_AFTER = new Date("2030-01-01T00:00:00Z");
+
+  it("rejects an unparseable date/time", () => {
+    expect(validateScheduledAt("", "")).toEqual({
+      ok: false,
+      error: "Enter a valid date and time",
+    });
+    expect(validateScheduledAt(DATE, "99")).toEqual({
+      ok: false,
+      error: "Enter a valid date and time",
+    });
+  });
+
+  it("rejects a past instant", () => {
+    expect(validateScheduledAt(DATE, "14:00", NOW_AFTER)).toEqual({
+      ok: false,
+      error: "Date and time must be in the future",
+    });
+  });
+
+  it("accepts a future instant and returns the resolved date", () => {
+    const result = validateScheduledAt(DATE, "14:00", NOW_BEFORE);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.scheduledAt.getTime()).toBe(combineLocal(DATE, "14:00")!.getTime());
+    }
+  });
+});

--- a/apps/native/components/meetup-flow-modal.tsx
+++ b/apps/native/components/meetup-flow-modal.tsx
@@ -1,6 +1,5 @@
 import DateTimePicker from "@react-native-community/datetimepicker";
 import { useMutation, useQueries, useQuery } from "@tanstack/react-query";
-import { addDays, startOfDay } from "date-fns";
 import { Spinner } from "heroui-native";
 import { useMemo, useState } from "react";
 import {
@@ -20,15 +19,20 @@ import { MeetupConfirmedModal } from "@/components/meetup-confirmed-modal";
 import {
   combineLocal,
   dayBoundsIso,
-  formatDayFull,
   formatDayTime,
   formatLongDate,
   formatLongDayDate,
   formatTime,
-  isFuture,
   toDate,
   toIsoDate,
 } from "@/lib/dates";
+import {
+  buildSuggestions,
+  freeSlotsFor,
+  timeFromDate,
+  validateProposedScheduledAt,
+  validateScheduledAt,
+} from "@/utils/meetup-flow";
 import { trpc, queryClient } from "@/utils/trpc";
 
 const GOLD = "#F2C94C";
@@ -41,37 +45,8 @@ export type MeetupFlowMode =
   | { type: "respond"; meetupId?: string }
   | { type: "reschedule"; meetupId: string; currentVenueId: string; currentScheduledAt: Date | string };
 
-// ── shared helpers ────────────────────────────────────────────────────────────
-
-/** All bookable half-hour slots from 08:00 to 20:00 (wall-clock in device tz). */
-const ALL_SLOTS = Array.from({ length: 25 }, (_, i) => {
-  const totalMinutes = 8 * 60 + i * 30;
-  const h = String(Math.floor(totalMinutes / 60)).padStart(2, "0");
-  const m = String(totalMinutes % 60).padStart(2, "0");
-  return `${h}:${m}`;
-});
-
-type Suggestion = { date: string; time: string; weekday: string; hint?: string };
-
-function timeFromDate(d: Date): string {
-  return formatTime(d);
-}
-
-function buildSuggestions(): Suggestion[] {
-  const today = startOfDay(new Date());
-  const offsets = [1, 2, 4];
-  const times = ["10:30", "14:00", "15:00"];
-  const hints = ["your usual coffee slot", undefined, undefined];
-  return offsets.map((off, i) => {
-    const d = addDays(today, off);
-    return {
-      date: toIsoDate(d),
-      time: times[i] ?? "10:30",
-      weekday: formatDayFull(d),
-      hint: hints[i],
-    };
-  });
-}
+// ── presentational sub-components ──────────────────────────────────────────────
+// Pure date/slot/validation logic lives in `@/utils/meetup-flow`.
 
 function GoldButton({
   onPress, disabled, label, loading, testID,
@@ -186,18 +161,6 @@ function VenuePicker({
   );
 }
 
-/** Given a list of blocked UTC instants (Date|string), return the HH:MM slots
- *  on `date` (local) that don't collide. Used to render the slot picker. */
-function freeSlotsFor(date: string, blocked: Array<Date | string>): string[] {
-  const blockedMs = new Set(
-    blocked.map((b) => toDate(b)?.getTime()).filter((n): n is number => typeof n === "number"),
-  );
-  return ALL_SLOTS.filter((slot) => {
-    const at = combineLocal(date, slot);
-    return at !== null && !blockedMs.has(at.getTime());
-  });
-}
-
 // ── propose content ───────────────────────────────────────────────────────────
 
 export function ProposeContent({
@@ -253,26 +216,22 @@ export function ProposeContent({
     }),
   );
 
-  function pickedScheduledAt(): Date | null {
-    if (customMode) {
-      if (!customDateIso || !customTime.match(/^\d{2}:\d{2}$/)) return null;
-      return combineLocal(customDateIso, customTime);
-    }
-    if (selectedSuggestionIdx === null) return null;
-    const s = suggestions[selectedSuggestionIdx];
-    return s ? combineLocal(s.date, s.time) : null;
-  }
-
   function handleSubmit() {
     setError(null);
     if (!selectedVenueId) { setError("Please pick a venue"); return; }
-    const dt = pickedScheduledAt();
-    if (!dt) {
-      setError(customMode ? "Please pick a date and time (HH:MM)" : "Please pick a suggested time");
-      return;
-    }
-    if (!isFuture(dt)) { setError("The selected date and time must be in the future"); return; }
-    proposeMutation.mutate({ partnerId, venueId: selectedVenueId, scheduledAt: dt.toISOString() });
+    const result = validateProposedScheduledAt({
+      customMode,
+      customDateIso,
+      customTime,
+      selectedSuggestionIdx,
+      suggestions,
+    });
+    if (!result.ok) { setError(result.error); return; }
+    proposeMutation.mutate({
+      partnerId,
+      venueId: selectedVenueId,
+      scheduledAt: result.scheduledAt.toISOString(),
+    });
   }
 
   const venues = venuesQuery.data ?? [];
@@ -595,13 +554,12 @@ export function RespondContent({
   function handleCounterSubmit() {
     setError(null);
     if (!selectedVenueId) { setError("Please select a location"); return; }
-    const proposed = combineLocal(date, time);
-    if (!proposed) { setError("Enter a valid date and time"); return; }
-    if (!isFuture(proposed)) { setError("Date and time must be in the future"); return; }
+    const result = validateScheduledAt(date, time);
+    if (!result.ok) { setError(result.error); return; }
     counterMutation.mutate({
       meetupId: activeMeetupId!,
       venueId: selectedVenueId,
-      scheduledAt: proposed.toISOString(),
+      scheduledAt: result.scheduledAt.toISOString(),
     });
   }
 
@@ -818,10 +776,9 @@ function RescheduleContent({
   function handleSubmit() {
     setError(null);
     if (!venueId) { setError("Please select a location"); return; }
-    const proposed = combineLocal(date, time);
-    if (!proposed) { setError("Enter a valid date and time"); return; }
-    if (!isFuture(proposed)) { setError("Date and time must be in the future"); return; }
-    rescheduleMutation.mutate({ meetupId, venueId, scheduledAt: proposed.toISOString() });
+    const result = validateScheduledAt(date, time);
+    if (!result.ok) { setError(result.error); return; }
+    rescheduleMutation.mutate({ meetupId, venueId, scheduledAt: result.scheduledAt.toISOString() });
   }
 
   return (

--- a/apps/native/utils/meetup-flow.ts
+++ b/apps/native/utils/meetup-flow.ts
@@ -1,0 +1,159 @@
+/**
+ * Meetup scheduling flow rules — the pure view-model logic behind
+ * `MeetupFlowModal` (propose / respond-counter / reschedule). The component owns
+ * React state, queries, mutations and JSX; the *rules* for which half-hour slots
+ * are bookable, what times to suggest, how a date + time resolve to a concrete
+ * instant, and whether that instant may be submitted, live here so they are
+ * stated once and testable without rendering the modal.
+ *
+ * Mirrors the pattern in `onboarding-flow.ts`: pure functions + explicit result
+ * types, consumed by the component. These are CLIENT-side conveniences — the
+ * server stays the source of truth for matching eligibility, round limits, and
+ * real slot availability. The component reads server flags (`canCounterPropose`)
+ * and queries (`getAvailableSlots`) directly; this module only does the local
+ * date/slot/validation math.
+ */
+import { addDays, startOfDay } from "date-fns";
+
+import {
+  combineLocal,
+  formatDayFull,
+  formatTime,
+  isFuture,
+  toDate,
+  toIsoDate,
+} from "@/lib/dates";
+
+/** All bookable half-hour slots from 08:00 to 20:00 (wall-clock in device tz). */
+export const ALL_SLOTS = Array.from({ length: 25 }, (_, i) => {
+  const totalMinutes = 8 * 60 + i * 30;
+  const h = String(Math.floor(totalMinutes / 60)).padStart(2, "0");
+  const m = String(totalMinutes % 60).padStart(2, "0");
+  return `${h}:${m}`;
+});
+
+/** A pre-baked "suggested time" card: a device-local day + wall-clock time. */
+export type Suggestion = { date: string; time: string; weekday: string; hint?: string };
+
+/**
+ * Result of resolving + guarding a chosen date/time. Mirrors the
+ * `{ ok: true } | { ok: false; error }` shape used across `onboarding-flow.ts`;
+ * on success it also carries the resolved UTC instant, ready for `.toISOString()`.
+ */
+export type ScheduleValidation =
+  | { ok: true; scheduledAt: Date }
+  | { ok: false; error: string };
+
+/** Wall-clock "HH:MM" of an instant, in the device timezone. */
+export function timeFromDate(d: Date): string {
+  return formatTime(d);
+}
+
+/**
+ * Whether `time` is a well-formed "HH:MM" string (two digits each). This checks
+ * SHAPE only, not range — `combineLocal` is what rejects impossible values.
+ */
+export function isValidTimeFormat(time: string): boolean {
+  return /^\d{2}:\d{2}$/.test(time);
+}
+
+/** The three default suggested slots: +1/+2/+4 days at 10:30/14:00/15:00. */
+export function buildSuggestions(now: Date = new Date()): Suggestion[] {
+  const today = startOfDay(now);
+  const offsets = [1, 2, 4];
+  const times = ["10:30", "14:00", "15:00"];
+  const hints = ["your usual coffee slot", undefined, undefined];
+  return offsets.map((off, i) => {
+    const d = addDays(today, off);
+    return {
+      date: toIsoDate(d),
+      time: times[i] ?? "10:30",
+      weekday: formatDayFull(d),
+      hint: hints[i],
+    };
+  });
+}
+
+/**
+ * Given a list of blocked UTC instants (Date|string), return the HH:MM slots on
+ * `date` (local) that don't collide. Used to render the slot picker. Unparseable
+ * blocked entries are ignored.
+ */
+export function freeSlotsFor(date: string, blocked: Array<Date | string>): string[] {
+  const blockedMs = new Set(
+    blocked.map((b) => toDate(b)?.getTime()).filter((n): n is number => typeof n === "number"),
+  );
+  return ALL_SLOTS.filter((slot) => {
+    const at = combineLocal(date, slot);
+    return at !== null && !blockedMs.has(at.getTime());
+  });
+}
+
+/**
+ * The propose-flow date/time selection — exactly the state the modal's
+ * "Plan a sip" screen holds when the user submits.
+ */
+export type ProposeSelection = {
+  customMode: boolean;
+  customDateIso: string;
+  customTime: string;
+  selectedSuggestionIdx: number | null;
+  suggestions: Suggestion[];
+};
+
+/**
+ * Resolve the instant a propose-flow submission would use, or null when the
+ * selection is incomplete (custom date/time missing or malformed, or no
+ * suggestion picked). Pure extraction of the old inline `pickedScheduledAt`.
+ */
+export function pickProposedScheduledAt(sel: ProposeSelection): Date | null {
+  if (sel.customMode) {
+    if (!sel.customDateIso || !isValidTimeFormat(sel.customTime)) return null;
+    return combineLocal(sel.customDateIso, sel.customTime);
+  }
+  if (sel.selectedSuggestionIdx === null) return null;
+  const s = sel.suggestions[sel.selectedSuggestionIdx];
+  return s ? combineLocal(s.date, s.time) : null;
+}
+
+/**
+ * Validate a propose-flow submission: the chosen instant must resolve and be in
+ * the future. Error copy matches the two paths (custom vs suggested), preserving
+ * the messages that were inlined in `handleSubmit`.
+ */
+export function validateProposedScheduledAt(
+  sel: ProposeSelection,
+  now: Date = new Date(),
+): ScheduleValidation {
+  const dt = pickProposedScheduledAt(sel);
+  if (!dt) {
+    return {
+      ok: false,
+      error: sel.customMode
+        ? "Please pick a date and time (HH:MM)"
+        : "Please pick a suggested time",
+    };
+  }
+  if (!isFuture(dt, now)) {
+    return { ok: false, error: "The selected date and time must be in the future" };
+  }
+  return { ok: true, scheduledAt: dt };
+}
+
+/**
+ * Validate a counter-propose / reschedule submission from a raw date + time. The
+ * instant must parse and be in the future. Shared by both flows, whose inline
+ * guards were identical.
+ */
+export function validateScheduledAt(
+  date: string,
+  time: string,
+  now: Date = new Date(),
+): ScheduleValidation {
+  const proposed = combineLocal(date, time);
+  if (!proposed) return { ok: false, error: "Enter a valid date and time" };
+  if (!isFuture(proposed, now)) {
+    return { ok: false, error: "Date and time must be in the future" };
+  }
+  return { ok: true, scheduledAt: proposed };
+}

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -103,3 +103,62 @@ requires **3–7 interests** (plus ≥1 spoken and ≥1 learning language) to fi
 — deliberately STRICTER than the server's matching-eligibility rule (≥1
 interest, owned by OnboardingProgression). The server stays the source of truth
 for whether a profile is matchable; these gates govern only the wizard UX.
+
+### Matching read model
+
+The query side of the Matching context:
+`packages/api/src/contexts/matching/matching-read-model.ts` (`getRankedCandidates`).
+Owns partner discovery — the candidate queries, exclusion-list construction,
+onboarding/suspension/deleted-account filtering, per-user grouping of languages
+and interests, staging into the pure `scoreCandidates` ranker, and cursor
+pagination — that the `discover` procedure used to inline. The MatchRequest
+aggregate owns the write side; this owns the read side. (Mirrors the Meetup
+read model.)
+
+### Conversation read model
+
+The query side of the Conversation context:
+`packages/api/src/contexts/conversation/chat-read-model.ts`
+(`listConversationsForUser`, `unreadCountForUser`, `listEntriesForUser`). Owns
+the inbox multi-table joins and view shaping (partner self-join, `messagingOptIn`
+and `attendanceReport` enrichment, locked-phase derivation, per-partner dedupe,
+phase-rank sort) the `listConversations` / `unreadCount` / `listEntries`
+procedures used to inline. Access control stays in the router and stays split —
+the read model contains **zero** access logic (see ADR-0004).
+
+### Profile read model
+
+The query side of the Identity context:
+`packages/api/src/contexts/identity/profile-read-model.ts` (`getProfileForUser`).
+Owns the four-table profile assembly (`languageProfile` + `userLanguage` +
+`userInterest` + whitelisted identity fields) the `getMyProfile` procedure used
+to inline. The write side — `softDeleteAccount`, `syncMatchingEligibility`,
+identity/language/interest mutations — stays in the router; it was already
+well-localized.
+
+### Notification dispatch seam
+
+`packages/notifications/src/recipe.ts`. `dispatch` is a thin orchestrator over
+two pure transforms and two adapters:
+
+- `toDeliveryMessages(recipes, tokensByRecipient)` — pure; flattens recipes ×
+  device tokens into the messages to send.
+- `staleTokenIds(tickets, tokenIds)` — pure; selects `DeviceNotRegistered`
+  tokens to prune.
+- `TokenStore` (`getTokenStore` / `setTokenStore`) — the device-token seam,
+  mirroring the `Delivery` seam. `DbTokenStore` defers its `@sip-and-speak/db`
+  import to call time, so importing the module does not trigger env validation;
+  `InMemoryTokenStore` is the test double. Together with `InMemoryDelivery` this
+  lets notification tests run with **no** `mock.module` (resolves the ADR-0002
+  mock-leak follow-up).
+
+### Meetup flow view-model
+
+Client-side, `apps/native/utils/meetup-flow.ts`. Pure transition/validation/date
+helpers for the propose / counter-propose / reschedule flows
+(`validateProposedScheduledAt`, `validateScheduledAt`, `buildSuggestions`,
+`freeSlotsFor`, `pickProposedScheduledAt`, `isValidTimeFormat`), extracted from
+the `MeetupFlowModal` render body so the rules are testable in isolation —
+mirroring `onboarding-flow.ts`. Server-driven rules (`canCounterPropose`, round
+limits, available slots) stay server-owned; the modal keeps its state and
+mutations.

--- a/packages/api/src/contexts/conversation/__tests__/chat-read-model.test.ts
+++ b/packages/api/src/contexts/conversation/__tests__/chat-read-model.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Integration tests for the chat read model (query side of the Conversation
+ * context). Uses the in-memory pg-mem harness to seed conversations, messages,
+ * and read-status rows, then asserts the list/unread shaping the chat router
+ * delegates to — without driving the full tRPC procedure.
+ */
+import "../../../__test-support__/harness";
+
+import { describe, it, expect, beforeEach } from "bun:test";
+
+import { db } from "@sip-and-speak/db";
+import { user } from "@sip-and-speak/db/schema/auth";
+import {
+  conversation,
+  message,
+  messageReadStatus,
+} from "@sip-and-speak/db/schema/conversation";
+
+import { resetDb } from "../../../__test-support__/harness";
+import { listConversationsForUser, unreadCountForUser } from "../chat-read-model";
+
+const T1 = new Date("2026-01-01T10:00:00Z");
+const T2 = new Date("2026-01-02T10:00:00Z");
+const T3 = new Date("2026-01-03T10:00:00Z");
+
+async function seedUsers(ids: string[]): Promise<void> {
+  await db.insert(user).values(
+    ids.map((id) => ({
+      id,
+      name: id,
+      email: `${id}@example.com`,
+      emailVerified: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })),
+  );
+}
+
+describe("chat read model — listConversationsForUser", () => {
+  beforeEach(() => {
+    resetDb();
+  });
+
+  it("returns open conversations newest-activity-first, with partner + unread state", async () => {
+    await seedUsers(["alice", "bob", "carol"]);
+    await db.insert(conversation).values([
+      { id: "conv-bob", user1Id: "alice", user2Id: "bob", createdAt: T1 },
+      // alice is user2 here — partner resolution must still pick the other party.
+      { id: "conv-carol", user1Id: "carol", user2Id: "alice", createdAt: T1 },
+    ]);
+    await db.insert(message).values([
+      { conversationId: "conv-bob", senderId: "bob", content: "hi from bob", createdAt: T1 },
+      { conversationId: "conv-carol", senderId: "carol", content: "hi from carol", createdAt: T2 },
+    ]);
+
+    const result = await listConversationsForUser("alice");
+
+    // Sorted by last-message desc: carol (T2) before bob (T1).
+    expect(result.map((c) => c.id)).toEqual(["conv-carol", "conv-bob"]);
+    expect(result[0]!.partner).toEqual({ id: "carol", name: "carol", image: null });
+    expect(result[1]!.partner).toEqual({ id: "bob", name: "bob", image: null });
+    // No read record for alice → both unread.
+    expect(result[0]!.hasUnread).toBe(true);
+    expect(result[1]!.hasUnread).toBe(true);
+  });
+
+  it("clears hasUnread once lastReadAt is at/after the last message", async () => {
+    await seedUsers(["alice", "bob"]);
+    await db.insert(conversation).values({ id: "conv-bob", user1Id: "alice", user2Id: "bob", createdAt: T1 });
+    await db.insert(message).values({ conversationId: "conv-bob", senderId: "bob", content: "hi", createdAt: T1 });
+    await db.insert(messageReadStatus).values({ conversationId: "conv-bob", userId: "alice", lastReadAt: T2 });
+
+    const [conv] = await listConversationsForUser("alice");
+    expect(conv!.hasUnread).toBe(false);
+  });
+
+  it("excludes suspended conversations (#157)", async () => {
+    await seedUsers(["alice", "bob", "carol"]);
+    await db.insert(conversation).values([
+      { id: "conv-open", user1Id: "alice", user2Id: "bob", status: "open", createdAt: T1 },
+      { id: "conv-suspended", user1Id: "alice", user2Id: "carol", status: "suspended", createdAt: T1 },
+    ]);
+
+    const result = await listConversationsForUser("alice");
+    expect(result.map((c) => c.id)).toEqual(["conv-open"]);
+  });
+});
+
+describe("chat read model — unreadCountForUser", () => {
+  beforeEach(() => {
+    resetDb();
+  });
+
+  it("counts only conversations whose last message the user has not read", async () => {
+    await seedUsers(["alice", "bob", "carol"]);
+    await db.insert(conversation).values([
+      { id: "conv-unread", user1Id: "alice", user2Id: "bob", createdAt: T1 },
+      { id: "conv-read", user1Id: "alice", user2Id: "carol", createdAt: T1 },
+      // No messages — must never count.
+      { id: "conv-empty", user1Id: "alice", user2Id: "bob", createdAt: T1 },
+    ]);
+    await db.insert(message).values([
+      { conversationId: "conv-unread", senderId: "bob", content: "unread", createdAt: T2 },
+      { conversationId: "conv-read", senderId: "carol", content: "read", createdAt: T1 },
+    ]);
+    // alice has read conv-read through T3 (after its last message).
+    await db.insert(messageReadStatus).values({ conversationId: "conv-read", userId: "alice", lastReadAt: T3 });
+
+    expect(await unreadCountForUser("alice")).toEqual({ count: 1 });
+  });
+});

--- a/packages/api/src/contexts/conversation/chat-read-model.ts
+++ b/packages/api/src/contexts/conversation/chat-read-model.ts
@@ -1,0 +1,329 @@
+/**
+ * Chat read model — the query side of the Conversation context.
+ *
+ * The chat router owns the write side and the access checks (which stay split
+ * by design — read collapses every failure to NOT_A_PARTICIPANT to hide
+ * existence, write surfaces precise errors; see ADR-0004). This module owns the
+ * read side: the multi-table joins and row-shaping that turn raw conversation,
+ * message, read-status, meetup, venue, attendance, and messaging-opt-in rows
+ * into the view shapes the native app's chat list and inbox render.
+ *
+ * Pulling these out of the router gives the shaping a small interface (`userId`)
+ * over a large implementation (partner resolution, last-message / unread
+ * enrichment, locked-meetup phase derivation, and per-partner dedupe) — and
+ * makes the shaping testable through the harness without driving the full tRPC
+ * procedure.
+ */
+import { and, desc, eq, or, inArray, sql } from "drizzle-orm";
+import { db } from "@sip-and-speak/db";
+import { conversation, message, messageReadStatus, messagingOptIn } from "@sip-and-speak/db/schema/conversation";
+import { meetup, venue, attendanceReport } from "@sip-and-speak/db/schema/scheduling";
+import { user } from "@sip-and-speak/db/schema/auth";
+import { deriveLockedPhase, keptEntryKeysByPartner } from "./messaging-utils";
+
+/**
+ * Open conversations the user is part of, each enriched with the partner, the
+ * last message, and the viewer's unread state, sorted by most recent activity.
+ * Suspended conversations are excluded (#157).
+ */
+export async function listConversationsForUser(userId: string) {
+  // Get all open conversations the user is part of (#157 — suspended excluded)
+  const conversations = await db
+    .select()
+    .from(conversation)
+    .where(
+      and(
+        eq(conversation.status, "open"),
+        or(
+          eq(conversation.user1Id, userId),
+          eq(conversation.user2Id, userId),
+        ),
+      ),
+    );
+
+  const results = await Promise.all(
+    conversations.map(async (conv) => {
+      const partnerId =
+        conv.user1Id === userId ? conv.user2Id : conv.user1Id;
+
+      const partner = await db
+        .select({ id: user.id, name: user.name, image: user.image })
+        .from(user)
+        .where(eq(user.id, partnerId))
+        .limit(1);
+
+      const lastMessage = await db
+        .select()
+        .from(message)
+        .where(eq(message.conversationId, conv.id))
+        .orderBy(desc(message.createdAt))
+        .limit(1);
+
+      const readStatus = await db
+        .select()
+        .from(messageReadStatus)
+        .where(
+          and(
+            eq(messageReadStatus.conversationId, conv.id),
+            eq(messageReadStatus.userId, userId),
+          ),
+        )
+        .limit(1);
+
+      const lastMsg = lastMessage[0] ?? null;
+      const readEntry = readStatus[0];
+      const hasUnread =
+        lastMsg !== null &&
+        (readEntry === undefined ||
+          lastMsg.createdAt > readEntry.lastReadAt);
+
+      return {
+        id: conv.id,
+        partner: partner[0] ?? null,
+        lastMessage: lastMsg,
+        hasUnread,
+        createdAt: conv.createdAt,
+      };
+    }),
+  );
+
+  // Sort by last message date descending (most recent first)
+  return results.sort((a, b) => {
+    const aTime = a.lastMessage?.createdAt?.getTime() ?? a.createdAt.getTime();
+    const bTime = b.lastMessage?.createdAt?.getTime() ?? b.createdAt.getTime();
+    return bTime - aTime;
+  });
+}
+
+/**
+ * Number of conversations (in any status) whose last message the user has not
+ * yet read. A conversation with no messages never counts.
+ */
+export async function unreadCountForUser(userId: string) {
+  // Get all conversations the user is part of
+  const conversations = await db
+    .select({ id: conversation.id })
+    .from(conversation)
+    .where(
+      or(
+        eq(conversation.user1Id, userId),
+        eq(conversation.user2Id, userId),
+      ),
+    );
+
+  if (conversations.length === 0) {
+    return { count: 0 };
+  }
+
+  let unreadCount = 0;
+
+  for (const conv of conversations) {
+    const lastMsg = await db
+      .select({ createdAt: message.createdAt })
+      .from(message)
+      .where(eq(message.conversationId, conv.id))
+      .orderBy(desc(message.createdAt))
+      .limit(1);
+
+    const lastEntry = lastMsg[0];
+    if (!lastEntry) continue;
+
+    const readStatus = await db
+      .select({ lastReadAt: messageReadStatus.lastReadAt })
+      .from(messageReadStatus)
+      .where(
+        and(
+          eq(messageReadStatus.conversationId, conv.id),
+          eq(messageReadStatus.userId, userId),
+        ),
+      )
+      .limit(1);
+
+    const readEntry = readStatus[0];
+    if (readEntry === undefined || lastEntry.createdAt > readEntry.lastReadAt) {
+      unreadCount++;
+    }
+  }
+
+  return { count: unreadCount };
+}
+
+/**
+ * The unified inbox: open conversations (enriched like {@link
+ * listConversationsForUser}) plus "locked" cards for confirmed/completed/
+ * not_attended meetups that have no open conversation yet, each tagged with its
+ * messaging phase. Collapsed to one row per partner, with locked cards floated
+ * above open chats in phase order.
+ */
+export async function listEntriesForUser(userId: string) {
+  const now = new Date();
+
+  const [openConversations, lockedMeetups, myReports, optIns] = await Promise.all([
+    db
+      .select({
+        id: conversation.id,
+        user1Id: conversation.user1Id,
+        user2Id: conversation.user2Id,
+        meetupId: conversation.meetupId,
+        createdAt: conversation.createdAt,
+      })
+      .from(conversation)
+      .where(
+        and(
+          eq(conversation.status, "open"),
+          or(eq(conversation.user1Id, userId), eq(conversation.user2Id, userId)),
+        ),
+      ),
+    db
+      .select({
+        meetup: meetup,
+        venue: { id: venue.id, name: venue.name, photoUrl: venue.photoUrl },
+        partner: {
+          id: sql<string>`partner.id`.as("le_partner_id"),
+          name: sql<string>`partner.name`.as("le_partner_name"),
+          image: sql<string | null>`partner.image`.as("le_partner_image"),
+        },
+      })
+      .from(meetup)
+      .innerJoin(venue, eq(meetup.venueId, venue.id))
+      .innerJoin(
+        sql`"user" as partner`,
+        sql`partner.id = CASE WHEN ${meetup.proposerId} = ${userId} THEN ${meetup.receiverId} ELSE ${meetup.proposerId} END`,
+      )
+      .where(
+        and(
+          inArray(meetup.status, ["confirmed", "completed", "not_attended"]),
+          or(eq(meetup.proposerId, userId), eq(meetup.receiverId, userId)),
+        ),
+      ),
+    db
+      .select({ meetupId: attendanceReport.meetupId })
+      .from(attendanceReport)
+      .where(eq(attendanceReport.studentId, userId)),
+    db
+      .select({
+        meetupId: messagingOptIn.meetupId,
+        studentId: messagingOptIn.studentId,
+        response: messagingOptIn.response,
+      })
+      .from(messagingOptIn)
+      .innerJoin(meetup, eq(meetup.id, messagingOptIn.meetupId))
+      .where(or(eq(meetup.proposerId, userId), eq(meetup.receiverId, userId))),
+  ]);
+
+  const myReportSet = new Set(myReports.map((r) => r.meetupId));
+  const optInByMeetup = new Map<
+    string,
+    { mine: "accept" | "decline" | null; partner: "accept" | "decline" | null }
+  >();
+  for (const row of optIns) {
+    const entry = optInByMeetup.get(row.meetupId) ?? { mine: null, partner: null };
+    if (row.studentId === userId) entry.mine = row.response;
+    else entry.partner = row.response;
+    optInByMeetup.set(row.meetupId, entry);
+  }
+
+  const conversationByMeetup = new Map(
+    openConversations
+      .filter((c) => c.meetupId !== null)
+      .map((c) => [c.meetupId as string, c]),
+  );
+
+  // Open entries — enrich each conversation with partner/lastMessage/hasUnread
+  const openEntries = await Promise.all(
+    openConversations.map(async (conv) => {
+      const partnerId = conv.user1Id === userId ? conv.user2Id : conv.user1Id;
+      const [partner, lastMessageRows, readStatusRows] = await Promise.all([
+        db
+          .select({ id: user.id, name: user.name, image: user.image })
+          .from(user)
+          .where(eq(user.id, partnerId))
+          .limit(1),
+        db
+          .select()
+          .from(message)
+          .where(eq(message.conversationId, conv.id))
+          .orderBy(desc(message.createdAt))
+          .limit(1),
+        db
+          .select({ lastReadAt: messageReadStatus.lastReadAt })
+          .from(messageReadStatus)
+          .where(
+            and(
+              eq(messageReadStatus.conversationId, conv.id),
+              eq(messageReadStatus.userId, userId),
+            ),
+          )
+          .limit(1),
+      ]);
+
+      const lastMessage = lastMessageRows[0] ?? null;
+      const lastReadAt = readStatusRows[0]?.lastReadAt ?? null;
+      const hasUnread =
+        lastMessage !== null &&
+        (lastReadAt === null || lastMessage.createdAt > lastReadAt);
+
+      return {
+        kind: "open" as const,
+        id: conv.id,
+        conversationId: conv.id,
+        meetupId: conv.meetupId,
+        partner: partner[0] ?? null,
+        lastMessage,
+        hasUnread,
+        sortAt: lastMessage?.createdAt ?? conv.createdAt,
+      };
+    }),
+  );
+
+  // Locked entries — confirmed/completed/not_attended meetups without an open conversation
+  const lockedEntries = lockedMeetups
+    .filter((row) => !conversationByMeetup.has(row.meetup.id))
+    .map((row) => {
+      const meetupAt = row.meetup.scheduledAt;
+      const optIn = optInByMeetup.get(row.meetup.id) ?? { mine: null, partner: null };
+      const phase = deriveLockedPhase({
+        meetupStatus: row.meetup.status as "confirmed" | "completed" | "not_attended",
+        meetupAt,
+        now,
+        hasMyAttendanceReport: myReportSet.has(row.meetup.id),
+        myOptIn: optIn.mine,
+        partnerOptIn: optIn.partner,
+      });
+      return {
+        kind: "locked" as const,
+        id: row.meetup.id,
+        meetupId: row.meetup.id,
+        partner: row.partner,
+        venue: row.venue,
+        meetupAt: meetupAt.toISOString(),
+        phase,
+        sortAt: meetupAt,
+      };
+    });
+
+  // Collapse to one row per partner so a user met more than once isn't repeated.
+  const keptKeys = keptEntryKeysByPartner([...lockedEntries, ...openEntries]);
+  const keepEntry = (entry: { kind: "open" | "locked"; id: string }) =>
+    keptKeys.has(`${entry.kind}-${entry.id}`);
+
+  // Locked entries float above open chats: pre-meet (soonest first), then post-meet awaiting,
+  // then declined. Open chats below, ordered by most recent activity.
+  const phaseRank: Record<string, number> = {
+    scheduled: 0,
+    awaiting_attendance: 1,
+    awaiting_partner_attendance: 2,
+    awaiting_my_optin: 3,
+    awaiting_partner_optin: 4,
+    declined: 5,
+  };
+  const sortedLocked = lockedEntries.filter(keepEntry).sort((a, b) => {
+    const r = (phaseRank[a.phase] ?? 99) - (phaseRank[b.phase] ?? 99);
+    if (r !== 0) return r;
+    return a.sortAt.getTime() - b.sortAt.getTime();
+  });
+  const sortedOpen = openEntries.filter(keepEntry).sort(
+    (a, b) => b.sortAt.getTime() - a.sortAt.getTime(),
+  );
+  return [...sortedLocked, ...sortedOpen].map(({ sortAt: _omit, ...rest }) => rest);
+}

--- a/packages/api/src/contexts/conversation/chat.ts
+++ b/packages/api/src/contexts/conversation/chat.ts
@@ -1,89 +1,24 @@
-import { and, desc, eq, lt, or, inArray, sql } from "drizzle-orm";
+import { and, desc, eq, lt, or } from "drizzle-orm";
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { db } from "@sip-and-speak/db";
 import { conversation, message, messageReadStatus, messagingOptIn } from "@sip-and-speak/db/schema/conversation";
-import { meetup, venue, attendanceReport } from "@sip-and-speak/db/schema/scheduling";
-import { user } from "@sip-and-speak/db/schema/auth";
+import { meetup } from "@sip-and-speak/db/schema/scheduling";
 import {
   checkReadAccess,
   computeIsUnread,
   computeMarkReadAt,
-  deriveLockedPhase,
-  keptEntryKeysByPartner,
 } from "./messaging-utils";
+import {
+  listConversationsForUser,
+  listEntriesForUser,
+  unreadCountForUser,
+} from "./chat-read-model";
 import { protectedProcedure, router } from "../../index";
 
 export const chatRouter = router({
   listConversations: protectedProcedure.query(async ({ ctx }) => {
-    const userId = ctx.session.user.id;
-
-    // Get all open conversations the user is part of (#157 — suspended excluded)
-    const conversations = await db
-      .select()
-      .from(conversation)
-      .where(
-        and(
-          eq(conversation.status, "open"),
-          or(
-            eq(conversation.user1Id, userId),
-            eq(conversation.user2Id, userId),
-          ),
-        ),
-      );
-
-    const results = await Promise.all(
-      conversations.map(async (conv) => {
-        const partnerId =
-          conv.user1Id === userId ? conv.user2Id : conv.user1Id;
-
-        const partner = await db
-          .select({ id: user.id, name: user.name, image: user.image })
-          .from(user)
-          .where(eq(user.id, partnerId))
-          .limit(1);
-
-        const lastMessage = await db
-          .select()
-          .from(message)
-          .where(eq(message.conversationId, conv.id))
-          .orderBy(desc(message.createdAt))
-          .limit(1);
-
-        const readStatus = await db
-          .select()
-          .from(messageReadStatus)
-          .where(
-            and(
-              eq(messageReadStatus.conversationId, conv.id),
-              eq(messageReadStatus.userId, userId),
-            ),
-          )
-          .limit(1);
-
-        const lastMsg = lastMessage[0] ?? null;
-        const readEntry = readStatus[0];
-        const hasUnread =
-          lastMsg !== null &&
-          (readEntry === undefined ||
-            lastMsg.createdAt > readEntry.lastReadAt);
-
-        return {
-          id: conv.id,
-          partner: partner[0] ?? null,
-          lastMessage: lastMsg,
-          hasUnread,
-          createdAt: conv.createdAt,
-        };
-      }),
-    );
-
-    // Sort by last message date descending (most recent first)
-    return results.sort((a, b) => {
-      const aTime = a.lastMessage?.createdAt?.getTime() ?? a.createdAt.getTime();
-      const bTime = b.lastMessage?.createdAt?.getTime() ?? b.createdAt.getTime();
-      return bTime - aTime;
-    });
+    return listConversationsForUser(ctx.session.user.id);
   }),
 
   getMessages: protectedProcedure
@@ -262,228 +197,11 @@ export const chatRouter = router({
     }),
 
   unreadCount: protectedProcedure.query(async ({ ctx }) => {
-    const userId = ctx.session.user.id;
-
-    // Get all conversations the user is part of
-    const conversations = await db
-      .select({ id: conversation.id })
-      .from(conversation)
-      .where(
-        or(
-          eq(conversation.user1Id, userId),
-          eq(conversation.user2Id, userId),
-        ),
-      );
-
-    if (conversations.length === 0) {
-      return { count: 0 };
-    }
-
-    let unreadCount = 0;
-
-    for (const conv of conversations) {
-      const lastMsg = await db
-        .select({ createdAt: message.createdAt })
-        .from(message)
-        .where(eq(message.conversationId, conv.id))
-        .orderBy(desc(message.createdAt))
-        .limit(1);
-
-      const lastEntry = lastMsg[0];
-      if (!lastEntry) continue;
-
-      const readStatus = await db
-        .select({ lastReadAt: messageReadStatus.lastReadAt })
-        .from(messageReadStatus)
-        .where(
-          and(
-            eq(messageReadStatus.conversationId, conv.id),
-            eq(messageReadStatus.userId, userId),
-          ),
-        )
-        .limit(1);
-
-      const readEntry = readStatus[0];
-      if (readEntry === undefined || lastEntry.createdAt > readEntry.lastReadAt) {
-        unreadCount++;
-      }
-    }
-
-    return { count: unreadCount };
+    return unreadCountForUser(ctx.session.user.id);
   }),
 
   listEntries: protectedProcedure.query(async ({ ctx }) => {
-    const userId = ctx.session.user.id;
-    const now = new Date();
-
-    const [openConversations, lockedMeetups, myReports, optIns] = await Promise.all([
-      db
-        .select({
-          id: conversation.id,
-          user1Id: conversation.user1Id,
-          user2Id: conversation.user2Id,
-          meetupId: conversation.meetupId,
-          createdAt: conversation.createdAt,
-        })
-        .from(conversation)
-        .where(
-          and(
-            eq(conversation.status, "open"),
-            or(eq(conversation.user1Id, userId), eq(conversation.user2Id, userId)),
-          ),
-        ),
-      db
-        .select({
-          meetup: meetup,
-          venue: { id: venue.id, name: venue.name, photoUrl: venue.photoUrl },
-          partner: {
-            id: sql<string>`partner.id`.as("le_partner_id"),
-            name: sql<string>`partner.name`.as("le_partner_name"),
-            image: sql<string | null>`partner.image`.as("le_partner_image"),
-          },
-        })
-        .from(meetup)
-        .innerJoin(venue, eq(meetup.venueId, venue.id))
-        .innerJoin(
-          sql`"user" as partner`,
-          sql`partner.id = CASE WHEN ${meetup.proposerId} = ${userId} THEN ${meetup.receiverId} ELSE ${meetup.proposerId} END`,
-        )
-        .where(
-          and(
-            inArray(meetup.status, ["confirmed", "completed", "not_attended"]),
-            or(eq(meetup.proposerId, userId), eq(meetup.receiverId, userId)),
-          ),
-        ),
-      db
-        .select({ meetupId: attendanceReport.meetupId })
-        .from(attendanceReport)
-        .where(eq(attendanceReport.studentId, userId)),
-      db
-        .select({
-          meetupId: messagingOptIn.meetupId,
-          studentId: messagingOptIn.studentId,
-          response: messagingOptIn.response,
-        })
-        .from(messagingOptIn)
-        .innerJoin(meetup, eq(meetup.id, messagingOptIn.meetupId))
-        .where(or(eq(meetup.proposerId, userId), eq(meetup.receiverId, userId))),
-    ]);
-
-    const myReportSet = new Set(myReports.map((r) => r.meetupId));
-    const optInByMeetup = new Map<
-      string,
-      { mine: "accept" | "decline" | null; partner: "accept" | "decline" | null }
-    >();
-    for (const row of optIns) {
-      const entry = optInByMeetup.get(row.meetupId) ?? { mine: null, partner: null };
-      if (row.studentId === userId) entry.mine = row.response;
-      else entry.partner = row.response;
-      optInByMeetup.set(row.meetupId, entry);
-    }
-
-    const conversationByMeetup = new Map(
-      openConversations
-        .filter((c) => c.meetupId !== null)
-        .map((c) => [c.meetupId as string, c]),
-    );
-
-    // Open entries — enrich each conversation with partner/lastMessage/hasUnread
-    const openEntries = await Promise.all(
-      openConversations.map(async (conv) => {
-        const partnerId = conv.user1Id === userId ? conv.user2Id : conv.user1Id;
-        const [partner, lastMessageRows, readStatusRows] = await Promise.all([
-          db
-            .select({ id: user.id, name: user.name, image: user.image })
-            .from(user)
-            .where(eq(user.id, partnerId))
-            .limit(1),
-          db
-            .select()
-            .from(message)
-            .where(eq(message.conversationId, conv.id))
-            .orderBy(desc(message.createdAt))
-            .limit(1),
-          db
-            .select({ lastReadAt: messageReadStatus.lastReadAt })
-            .from(messageReadStatus)
-            .where(
-              and(
-                eq(messageReadStatus.conversationId, conv.id),
-                eq(messageReadStatus.userId, userId),
-              ),
-            )
-            .limit(1),
-        ]);
-
-        const lastMessage = lastMessageRows[0] ?? null;
-        const lastReadAt = readStatusRows[0]?.lastReadAt ?? null;
-        const hasUnread =
-          lastMessage !== null &&
-          (lastReadAt === null || lastMessage.createdAt > lastReadAt);
-
-        return {
-          kind: "open" as const,
-          id: conv.id,
-          conversationId: conv.id,
-          meetupId: conv.meetupId,
-          partner: partner[0] ?? null,
-          lastMessage,
-          hasUnread,
-          sortAt: lastMessage?.createdAt ?? conv.createdAt,
-        };
-      }),
-    );
-
-    // Locked entries — confirmed/completed/not_attended meetups without an open conversation
-    const lockedEntries = lockedMeetups
-      .filter((row) => !conversationByMeetup.has(row.meetup.id))
-      .map((row) => {
-        const meetupAt = row.meetup.scheduledAt;
-        const optIn = optInByMeetup.get(row.meetup.id) ?? { mine: null, partner: null };
-        const phase = deriveLockedPhase({
-          meetupStatus: row.meetup.status as "confirmed" | "completed" | "not_attended",
-          meetupAt,
-          now,
-          hasMyAttendanceReport: myReportSet.has(row.meetup.id),
-          myOptIn: optIn.mine,
-          partnerOptIn: optIn.partner,
-        });
-        return {
-          kind: "locked" as const,
-          id: row.meetup.id,
-          meetupId: row.meetup.id,
-          partner: row.partner,
-          venue: row.venue,
-          meetupAt: meetupAt.toISOString(),
-          phase,
-          sortAt: meetupAt,
-        };
-      });
-
-    // Collapse to one row per partner so a user met more than once isn't repeated.
-    const keptKeys = keptEntryKeysByPartner([...lockedEntries, ...openEntries]);
-    const keepEntry = (entry: { kind: "open" | "locked"; id: string }) =>
-      keptKeys.has(`${entry.kind}-${entry.id}`);
-
-    // Locked entries float above open chats: pre-meet (soonest first), then post-meet awaiting,
-    // then declined. Open chats below, ordered by most recent activity.
-    const phaseRank: Record<string, number> = {
-      scheduled: 0,
-      awaiting_attendance: 1,
-      awaiting_partner_attendance: 2,
-      awaiting_my_optin: 3,
-      awaiting_partner_optin: 4,
-      declined: 5,
-    };
-    const sortedLocked = lockedEntries.filter(keepEntry).sort((a, b) => {
-      const r = (phaseRank[a.phase] ?? 99) - (phaseRank[b.phase] ?? 99);
-      if (r !== 0) return r;
-      return a.sortAt.getTime() - b.sortAt.getTime();
-    });
-    const sortedOpen = openEntries.filter(keepEntry).sort(
-      (a, b) => b.sortAt.getTime() - a.sortAt.getTime(),
-    );
-    return [...sortedLocked, ...sortedOpen].map(({ sortAt: _omit, ...rest }) => rest);
+    return listEntriesForUser(ctx.session.user.id);
   }),
 
   markRead: protectedProcedure

--- a/packages/api/src/contexts/identity/__tests__/profile-read-model.test.ts
+++ b/packages/api/src/contexts/identity/__tests__/profile-read-model.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Integration test for the Identity read model (getProfileForUser), driven by
+ * the in-memory pg-mem harness so the multi-table assembly is verified against
+ * real queries rather than mocks. Mirrors the Meetup read model's coverage.
+ */
+import "../../../__test-support__/harness";
+
+import { describe, it, expect, beforeEach } from "bun:test";
+
+import { db } from "@sip-and-speak/db";
+import { user } from "@sip-and-speak/db/schema/auth";
+import { languageProfile, userLanguage, userInterest } from "@sip-and-speak/db/schema/identity";
+
+import { getProfileForUser } from "../profile-read-model";
+import { resetDb } from "../../../__test-support__/harness";
+
+const USER_ID = "u-prof";
+
+async function seedUser(
+  overrides: { name?: string; surname?: string | null; image?: string | null; email?: string } = {},
+) {
+  await db.insert(user).values({
+    id: USER_ID,
+    name: overrides.name ?? "Ada",
+    surname: overrides.surname ?? "Lovelace",
+    image: overrides.image ?? null,
+    email: overrides.email ?? "prof@example.com",
+    emailVerified: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+}
+
+describe("identity read model — getProfileForUser", () => {
+  beforeEach(() => {
+    resetDb();
+  });
+
+  it("assembles the full profile shape for an onboarded student", async () => {
+    await seedUser();
+    await db.insert(languageProfile).values({
+      userId: USER_ID,
+      bio: "Hi there",
+      university: "Cambridge",
+      onboardingComplete: true,
+    });
+    await db.insert(userLanguage).values([
+      { userId: USER_ID, language: "en", proficiency: "native", type: "spoken" },
+      { userId: USER_ID, language: "nl", proficiency: "beginner", type: "learning" },
+    ]);
+    await db.insert(userInterest).values([
+      { userId: USER_ID, interest: "modern_art" },
+      { userId: USER_ID, interest: "jazz_music" },
+    ]);
+
+    const result = await getProfileForUser(USER_ID);
+
+    expect(result.profile?.bio).toBe("Hi there");
+    expect(result.profile?.university).toBe("Cambridge");
+    expect(result.profile?.onboardingComplete).toBe(true);
+    expect(result.languages).toHaveLength(2);
+    expect(result.interests).toHaveLength(2);
+    expect(result.identity).toEqual({
+      name: "Ada",
+      surname: "Lovelace",
+      image: null,
+      email: "prof@example.com",
+    });
+  });
+
+  it("returns profile: null and empty collections before onboarding", async () => {
+    await seedUser();
+
+    const result = await getProfileForUser(USER_ID);
+
+    expect(result.profile).toBeNull();
+    expect(result.languages).toEqual([]);
+    expect(result.interests).toEqual([]);
+    expect(result.identity?.name).toBe("Ada");
+  });
+
+  it("returns identity: null for an unknown user", async () => {
+    const result = await getProfileForUser("nobody");
+
+    expect(result.profile).toBeNull();
+    expect(result.languages).toEqual([]);
+    expect(result.interests).toEqual([]);
+    expect(result.identity).toBeNull();
+  });
+
+  it("exposes only the whitelisted identity fields", async () => {
+    await seedUser({ image: "https://example.com/ada.png" });
+
+    const result = await getProfileForUser(USER_ID);
+
+    expect(Object.keys(result.identity ?? {}).sort()).toEqual(
+      ["email", "image", "name", "surname"].sort(),
+    );
+    expect(result.identity?.image).toBe("https://example.com/ada.png");
+  });
+});

--- a/packages/api/src/contexts/identity/profile-read-model.ts
+++ b/packages/api/src/contexts/identity/profile-read-model.ts
@@ -1,0 +1,45 @@
+/**
+ * Identity read model — the query side of the Identity context.
+ *
+ * The Identity write side (profile mutations, language/interest edits, account
+ * deletion) lives in `profile.ts` and owns its invariants. This module owns the
+ * read side: the parallel cross-table fetch and row-shaping that assemble a
+ * Student's own profile — the language profile, their spoken/learning languages,
+ * their interests, and the identity fields (name, surname, image, email) — into
+ * the single view shape the native app renders.
+ *
+ * Pulling the assembly out of the router gives the shaping a small interface
+ * (`userId`) over a multi-table read, and makes it testable through the harness
+ * without driving the full tRPC procedure. Mirrors the Meetup read model.
+ */
+import { eq } from "drizzle-orm";
+import { db } from "@sip-and-speak/db";
+import { languageProfile, userLanguage, userInterest } from "@sip-and-speak/db/schema/identity";
+import { user } from "@sip-and-speak/db/schema/auth";
+
+/**
+ * The signed-in Student's own profile: the language profile row (or null before
+ * onboarding), every spoken/learning language, every interest, and the identity
+ * fields. Assembled from four parallel reads keyed on `userId`.
+ */
+export async function getProfileForUser(userId: string) {
+  const [profile, languages, interests, identity] = await Promise.all([
+    db.query.languageProfile.findFirst({
+      where: eq(languageProfile.userId, userId),
+    }),
+    db.select().from(userLanguage).where(eq(userLanguage.userId, userId)),
+    db.select().from(userInterest).where(eq(userInterest.userId, userId)),
+    db
+      .select({ name: user.name, surname: user.surname, image: user.image, email: user.email })
+      .from(user)
+      .where(eq(user.id, userId))
+      .limit(1),
+  ]);
+
+  return {
+    profile: profile ?? null,
+    languages,
+    interests,
+    identity: identity[0] ?? null,
+  };
+}

--- a/packages/api/src/contexts/identity/profile.ts
+++ b/packages/api/src/contexts/identity/profile.ts
@@ -14,6 +14,7 @@ import {
   OnboardingRuleError,
   type OnboardingSnapshot,
 } from "./onboarding-progression";
+import { getProfileForUser } from "./profile-read-model";
 
 /**
  * Load the cross-table snapshot the OnboardingProgression aggregate needs.
@@ -286,29 +287,11 @@ export const profileRouter = router({
       return { success: true };
     }),
 
-  getMyProfile: protectedProcedure.query(async ({ ctx }) => {
-    const userId = ctx.session.user.id;
-
-    const [profile, languages, interests, identity] = await Promise.all([
-      db.query.languageProfile.findFirst({
-        where: eq(languageProfile.userId, userId),
-      }),
-      db.select().from(userLanguage).where(eq(userLanguage.userId, userId)),
-      db.select().from(userInterest).where(eq(userInterest.userId, userId)),
-      db
-        .select({ name: user.name, surname: user.surname, image: user.image, email: user.email })
-        .from(user)
-        .where(eq(user.id, userId))
-        .limit(1),
-    ]);
-
-    return {
-      profile: profile ?? null,
-      languages,
-      interests,
-      identity: identity[0] ?? null,
-    };
-  }),
+  // Read assembly lives in the Identity read model (mirrors the Meetup read
+  // model): the multi-table fetch + shaping for the Student's own profile.
+  getMyProfile: protectedProcedure.query(({ ctx }) =>
+    getProfileForUser(ctx.session.user.id),
+  ),
 
   upsertProfile: protectedProcedure
     .input(upsertProfileInput)

--- a/packages/api/src/contexts/matching/__tests__/matching-read-model.test.ts
+++ b/packages/api/src/contexts/matching/__tests__/matching-read-model.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Integration tests for the Matching read model (`getRankedCandidates`). Uses
+ * the in-memory pg-mem harness to seed students + languages and exercises the
+ * candidate query → grouping → scoring → pagination path directly, without
+ * driving the full tRPC `discover` procedure.
+ */
+import "../../../__test-support__/harness";
+
+import { describe, it, expect, beforeEach } from "bun:test";
+
+import { db } from "@sip-and-speak/db";
+import { user } from "@sip-and-speak/db/schema/auth";
+import { languageProfile, userLanguage } from "@sip-and-speak/db/schema/identity";
+
+import { getRankedCandidates } from "../matching-read-model";
+import { resetDb } from "../../../__test-support__/harness";
+
+// Caller speaks Dutch, learns English — the perspective every case ranks against.
+const ME = "u-me";
+
+type SeedOpts = {
+  spoken: string[];
+  learning: string[];
+  onboardingComplete?: boolean;
+  studentStatus?: "active" | "suspended" | "removed";
+  deletedAt?: Date | null;
+};
+
+async function seedStudent(id: string, opts: SeedOpts): Promise<void> {
+  await db.insert(user).values({
+    id,
+    name: id,
+    email: `${id}@example.com`,
+    emailVerified: true,
+    studentStatus: opts.studentStatus ?? "active",
+    deletedAt: opts.deletedAt ?? null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+  await db.insert(languageProfile).values({
+    userId: id,
+    onboardingComplete: opts.onboardingComplete ?? true,
+  });
+  const langs = [
+    ...opts.spoken.map((language) => ({ userId: id, language, type: "spoken" as const })),
+    ...opts.learning.map((language) => ({ userId: id, language, type: "learning" as const })),
+  ];
+  if (langs.length > 0) {
+    await db.insert(userLanguage).values(langs);
+  }
+}
+
+const seedMe = () => seedStudent(ME, { spoken: ["nl"], learning: ["en"] });
+
+describe("matching read model — getRankedCandidates", () => {
+  beforeEach(() => {
+    resetDb();
+  });
+
+  it("returns complementary partners with compatible languages and omits non-complementary ones", async () => {
+    await seedMe();
+    // Mutual teach/learn with ME.
+    await seedStudent("u-en", { spoken: ["en"], learning: ["nl"] });
+    // No language complementarity → must not appear.
+    await seedStudent("u-none", { spoken: ["es"], learning: ["fr"] });
+
+    const { partners } = await getRankedCandidates(ME, { limit: 20 });
+
+    expect(partners.map((p) => p.userId)).toEqual(["u-en"]);
+    expect(partners[0]!.compatibleLanguages.sort()).toEqual(["en", "nl"]);
+  });
+
+  it("excludes candidates who have not completed onboarding", async () => {
+    await seedMe();
+    await seedStudent("u-en", {
+      spoken: ["en"],
+      learning: ["nl"],
+      onboardingComplete: false,
+    });
+
+    const { partners, nextCursor } = await getRankedCandidates(ME, { limit: 20 });
+
+    expect(partners).toHaveLength(0);
+    expect(nextCursor).toBeUndefined();
+  });
+
+  it("excludes suspended and soft-deleted students even when complementary", async () => {
+    await seedMe();
+    await seedStudent("u-susp", { spoken: ["en"], learning: ["nl"], studentStatus: "suspended" });
+    await seedStudent("u-del", { spoken: ["en"], learning: ["nl"], deletedAt: new Date() });
+    await seedStudent("u-ok", { spoken: ["en"], learning: ["nl"] });
+
+    const { partners } = await getRankedCandidates(ME, { limit: 20 });
+
+    expect(partners.map((p) => p.userId)).toEqual(["u-ok"]);
+  });
+
+  it("paginates with limit and cursor, exposing nextCursor only while more remain", async () => {
+    await seedMe();
+    await seedStudent("u-1", { spoken: ["en"], learning: ["nl"] });
+    await seedStudent("u-2", { spoken: ["en"], learning: ["nl"] });
+
+    const page1 = await getRankedCandidates(ME, { limit: 1 });
+    expect(page1.partners).toHaveLength(1);
+    expect(page1.nextCursor).toBe("1");
+
+    const page2 = await getRankedCandidates(ME, { limit: 1, cursor: page1.nextCursor });
+    expect(page2.partners).toHaveLength(1);
+    expect(page2.nextCursor).toBeUndefined();
+
+    const ids = [page1.partners[0]!.userId, page2.partners[0]!.userId].sort();
+    expect(ids).toEqual(["u-1", "u-2"]);
+  });
+});

--- a/packages/api/src/contexts/matching/matching-read-model.ts
+++ b/packages/api/src/contexts/matching/matching-read-model.ts
@@ -1,0 +1,180 @@
+/**
+ * Matching read model — the query side of the Matching context.
+ *
+ * The MatchRequest aggregate owns transitions (the write side). This module owns
+ * the read side of partner discovery: the candidate queries, the per-user
+ * grouping of languages and interests, candidate assembly, staging into the pure
+ * `scoreCandidates` ranker, and cursor pagination — everything the `discover`
+ * procedure used to inline.
+ *
+ * Pulling these out of the router gives the ranking a small interface (`userId`
+ * + limit/cursor/filter) over a large implementation (exclusion-list
+ * construction, onboarding/suspension/deleted-account filtering, batch fetches,
+ * grouping maps, and compatible-language derivation) — and makes it testable
+ * through the harness without driving the full tRPC procedure.
+ */
+import { and, eq, ne, inArray, notInArray, or, isNull } from "drizzle-orm";
+import { db } from "@sip-and-speak/db";
+import { languageProfile, userLanguage, userInterest } from "@sip-and-speak/db/schema/identity";
+import { matchRequest } from "@sip-and-speak/db/schema/matching";
+import { user } from "@sip-and-speak/db/schema/auth";
+import { buildExcludedUserIds, scoreCandidates } from "./matching-utils";
+
+export type DiscoverOptions = {
+  filterLanguage?: string;
+  cursor?: string;
+  limit: number;
+};
+
+/**
+ * Discoverable partners for the user, ranked by language complementarity and
+ * paginated. Excludes pairs with an active request in either direction (#125),
+ * candidates who haven't completed onboarding, suspended/removed Students
+ * (#100/#108), and soft-deleted accounts (#447). Each returned partner carries
+ * the languages compatible with the user for the discover card.
+ */
+export async function getRankedCandidates(
+  userId: string,
+  { filterLanguage, cursor, limit }: DiscoverOptions,
+) {
+  const myLanguages = await db
+    .select()
+    .from(userLanguage)
+    .where(eq(userLanguage.userId, userId));
+
+  const mySpoken = myLanguages
+    .filter((l) => l.type === "spoken")
+    .map((l) => l.language);
+  const myLearning = myLanguages
+    .filter((l) => l.type === "learning")
+    .map((l) => l.language);
+
+  // #125 — Build exclusion list: candidates with an active request in either direction
+  const activeRequests = await db
+    .select({
+      requesterId: matchRequest.requesterId,
+      receiverId: matchRequest.receiverId,
+    })
+    .from(matchRequest)
+    .where(
+      and(
+        or(
+          eq(matchRequest.requesterId, userId),
+          eq(matchRequest.receiverId, userId),
+        ),
+        // "voided" = an unmatch (#7) — keep that pair out of discover for good.
+        inArray(matchRequest.status, ["pending", "accepted", "voided"]),
+      ),
+    );
+
+  const excludedUserIds = buildExcludedUserIds(userId, activeRequests);
+
+  // Fetch all other users who have completed onboarding
+  const otherProfiles = await db
+    .select()
+    .from(languageProfile)
+    .where(
+      and(
+        ne(languageProfile.userId, userId),
+        eq(languageProfile.onboardingComplete, true),
+        excludedUserIds.length > 0
+          ? notInArray(languageProfile.userId, excludedUserIds)
+          : undefined,
+      ),
+    );
+
+  if (otherProfiles.length === 0) {
+    return { partners: [], nextCursor: undefined };
+  }
+
+  const otherUserIds = otherProfiles.map((p) => p.userId);
+
+  // Batch-fetch languages and interests for all candidates
+  const allLanguages = await db
+    .select()
+    .from(userLanguage)
+    .where(inArray(userLanguage.userId, otherUserIds));
+
+  const allInterests = await db
+    .select()
+    .from(userInterest)
+    .where(inArray(userInterest.userId, otherUserIds));
+
+  // Fetch user info (name, image) for candidates — exclude suspended AND
+  // permanently removed Students (#100/#108) and soft-deleted accounts (#447)
+  const allUsers = await db
+    .select({ id: user.id, name: user.name, image: user.image })
+    .from(user)
+    .where(
+      and(
+        inArray(user.id, otherUserIds),
+        notInArray(user.studentStatus, ["suspended", "removed"]),
+        isNull(user.deletedAt),
+      ),
+    );
+
+  const userMap = new Map(allUsers.map((u) => [u.id, u]));
+
+  // Group languages and interests by userId
+  const langByUser = new Map<string, typeof allLanguages>();
+  for (const l of allLanguages) {
+    const arr = langByUser.get(l.userId) ?? [];
+    arr.push(l);
+    langByUser.set(l.userId, arr);
+  }
+
+  const interestByUser = new Map<string, typeof allInterests>();
+  for (const i of allInterests) {
+    const arr = interestByUser.get(i.userId) ?? [];
+    arr.push(i);
+    interestByUser.set(i.userId, arr);
+  }
+
+  // Build candidate list (suspended users absent from userMap are excluded)
+  const candidates = otherProfiles
+    .filter((profile) => userMap.has(profile.userId))
+    .map((profile) => {
+      const langs = langByUser.get(profile.userId) ?? [];
+      const interests = interestByUser.get(profile.userId) ?? [];
+      const userInfo = userMap.get(profile.userId)!;
+      return {
+        userId: profile.userId,
+        name: userInfo.name ?? "Unknown",
+        image: userInfo.image ?? null,
+        bio: profile.bio,
+        university: profile.university,
+        age: profile.age,
+        spokenLanguages: langs
+          .filter((l) => l.type === "spoken")
+          .map((l) => ({ language: l.language, proficiency: l.proficiency })),
+        learningLanguages: langs
+          .filter((l) => l.type === "learning")
+          .map((l) => l.language),
+        interests: interests.map((i) => i.interest),
+      };
+    });
+
+  const scored = scoreCandidates(
+    { spoken: mySpoken, learning: myLearning },
+    candidates,
+    filterLanguage ? { language: filterLanguage } : undefined,
+  );
+
+  // Cursor-based pagination (cursor = index offset as string)
+  const startIndex = cursor ? parseInt(cursor, 10) : 0;
+  const page = scored.slice(startIndex, startIndex + limit).map((candidate) => {
+    const partnerSpoken = candidate.spokenLanguages.map((l) => l.language);
+    const compatibleLanguages = Array.from(new Set([
+      ...myLearning.filter((lang) => partnerSpoken.includes(lang)),
+      ...mySpoken.filter((lang) => candidate.learningLanguages.includes(lang)),
+      ...myLearning.filter((lang) => candidate.learningLanguages.includes(lang)),
+    ]));
+    return { ...candidate, compatibleLanguages };
+  });
+  const nextCursor =
+    startIndex + limit < scored.length
+      ? String(startIndex + limit)
+      : undefined;
+
+  return { partners: page, nextCursor };
+}

--- a/packages/api/src/contexts/matching/matching.ts
+++ b/packages/api/src/contexts/matching/matching.ts
@@ -1,4 +1,4 @@
-import { and, eq, ne, inArray, notInArray, or, sql, isNull } from "drizzle-orm";
+import { and, eq, ne, inArray, or, sql } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { db } from "@sip-and-speak/db";
@@ -7,7 +7,7 @@ import { matchRequest, studentMatch } from "@sip-and-speak/db/schema/matching";
 import { meetup, attendanceReport } from "@sip-and-speak/db/schema/scheduling";
 import { user } from "@sip-and-speak/db/schema/auth";
 import { protectedProcedure, router } from "../../index";
-import { buildExcludedUserIds, scoreCandidates } from "./matching-utils";
+import { getRankedCandidates } from "./matching-read-model";
 import {
   MatchRequest,
   MatchRuleError,
@@ -51,148 +51,7 @@ export const matchingRouter = router({
       }),
     )
     .query(async ({ ctx, input }) => {
-      const userId = ctx.session.user.id;
-
-      const myLanguages = await db
-        .select()
-        .from(userLanguage)
-        .where(eq(userLanguage.userId, userId));
-
-      const mySpoken = myLanguages
-        .filter((l) => l.type === "spoken")
-        .map((l) => l.language);
-      const myLearning = myLanguages
-        .filter((l) => l.type === "learning")
-        .map((l) => l.language);
-
-      // #125 — Build exclusion list: candidates with an active request in either direction
-      const activeRequests = await db
-        .select({
-          requesterId: matchRequest.requesterId,
-          receiverId: matchRequest.receiverId,
-        })
-        .from(matchRequest)
-        .where(
-          and(
-            or(
-              eq(matchRequest.requesterId, userId),
-              eq(matchRequest.receiverId, userId),
-            ),
-            // "voided" = an unmatch (#7) — keep that pair out of discover for good.
-            inArray(matchRequest.status, ["pending", "accepted", "voided"]),
-          ),
-        );
-
-      const excludedUserIds = buildExcludedUserIds(userId, activeRequests);
-
-      // Fetch all other users who have completed onboarding
-      const otherProfiles = await db
-        .select()
-        .from(languageProfile)
-        .where(
-          and(
-            ne(languageProfile.userId, userId),
-            eq(languageProfile.onboardingComplete, true),
-            excludedUserIds.length > 0
-              ? notInArray(languageProfile.userId, excludedUserIds)
-              : undefined,
-          ),
-        );
-
-      if (otherProfiles.length === 0) {
-        return { partners: [], nextCursor: undefined };
-      }
-
-      const otherUserIds = otherProfiles.map((p) => p.userId);
-
-      // Batch-fetch languages and interests for all candidates
-      const allLanguages = await db
-        .select()
-        .from(userLanguage)
-        .where(inArray(userLanguage.userId, otherUserIds));
-
-      const allInterests = await db
-        .select()
-        .from(userInterest)
-        .where(inArray(userInterest.userId, otherUserIds));
-
-      // Fetch user info (name, image) for candidates — exclude suspended AND
-      // permanently removed Students (#100/#108) and soft-deleted accounts (#447)
-      const allUsers = await db
-        .select({ id: user.id, name: user.name, image: user.image })
-        .from(user)
-        .where(
-          and(
-            inArray(user.id, otherUserIds),
-            notInArray(user.studentStatus, ["suspended", "removed"]),
-            isNull(user.deletedAt),
-          ),
-        );
-
-      const userMap = new Map(allUsers.map((u) => [u.id, u]));
-
-      // Group languages and interests by userId
-      const langByUser = new Map<string, typeof allLanguages>();
-      for (const l of allLanguages) {
-        const arr = langByUser.get(l.userId) ?? [];
-        arr.push(l);
-        langByUser.set(l.userId, arr);
-      }
-
-      const interestByUser = new Map<string, typeof allInterests>();
-      for (const i of allInterests) {
-        const arr = interestByUser.get(i.userId) ?? [];
-        arr.push(i);
-        interestByUser.set(i.userId, arr);
-      }
-
-      // Build candidate list (suspended users absent from userMap are excluded)
-      const candidates = otherProfiles
-        .filter((profile) => userMap.has(profile.userId))
-        .map((profile) => {
-          const langs = langByUser.get(profile.userId) ?? [];
-          const interests = interestByUser.get(profile.userId) ?? [];
-          const userInfo = userMap.get(profile.userId)!;
-          return {
-            userId: profile.userId,
-            name: userInfo.name ?? "Unknown",
-            image: userInfo.image ?? null,
-            bio: profile.bio,
-            university: profile.university,
-            age: profile.age,
-            spokenLanguages: langs
-              .filter((l) => l.type === "spoken")
-              .map((l) => ({ language: l.language, proficiency: l.proficiency })),
-            learningLanguages: langs
-              .filter((l) => l.type === "learning")
-              .map((l) => l.language),
-            interests: interests.map((i) => i.interest),
-          };
-        });
-
-      const scored = scoreCandidates(
-        { spoken: mySpoken, learning: myLearning },
-        candidates,
-        input.filterLanguage ? { language: input.filterLanguage } : undefined,
-      );
-
-      // Cursor-based pagination (cursor = index offset as string)
-      const startIndex = input.cursor ? parseInt(input.cursor, 10) : 0;
-      const page = scored.slice(startIndex, startIndex + input.limit).map((candidate) => {
-        const partnerSpoken = candidate.spokenLanguages.map((l) => l.language);
-        const compatibleLanguages = Array.from(new Set([
-          ...myLearning.filter((lang) => partnerSpoken.includes(lang)),
-          ...mySpoken.filter((lang) => candidate.learningLanguages.includes(lang)),
-          ...myLearning.filter((lang) => candidate.learningLanguages.includes(lang)),
-        ]));
-        return { ...candidate, compatibleLanguages };
-      });
-      const nextCursor =
-        startIndex + input.limit < scored.length
-          ? String(startIndex + input.limit)
-          : undefined;
-
-      return { partners: page, nextCursor };
+      return getRankedCandidates(ctx.session.user.id, input);
     }),
 
   getIncomingRequests: protectedProcedure

--- a/packages/notifications/src/__tests__/notifications-conversation-opened.test.ts
+++ b/packages/notifications/src/__tests__/notifications-conversation-opened.test.ts
@@ -4,93 +4,20 @@
  * Covers:
  *   - Both Students receive a "messaging is now open" push notification
  *   - No notification sent when neither Student has a device token
+ *
+ * Uses the dispatch seam (InMemoryDelivery + InMemoryTokenStore) — no DB,
+ * drizzle, or fetch mocking.
  */
-import { describe, it, expect, mock, beforeEach } from "bun:test";
-
-// ── Fetch mock ────────────────────────────────────────────────────────────────
-
-interface CapturedFetchCall {
-  url: string;
-  messages: Array<{ to: string; title?: string; body?: string; data?: Record<string, unknown> }>;
-}
-
-const fetchCalls: CapturedFetchCall[] = [];
-
-(global as unknown as { fetch: unknown }).fetch = mock(async (url: string, options: RequestInit) => {
-  fetchCalls.push({
-    url,
-    messages: JSON.parse(options.body as string) as CapturedFetchCall["messages"],
-  });
-  return {
-    json: async () => ({ data: [{ status: "ok", id: "ticket-1" }] }),
-  };
-});
-
-// ── Schema mocks ──────────────────────────────────────────────────────────────
-
-const USER_TABLE = "user";
-const DEVICE_TOKEN_TABLE = "userDeviceToken";
-
-mock.module("@sip-and-speak/db/schema/identity", () => ({
-  userDeviceToken: DEVICE_TOKEN_TABLE,
-  userLanguage: "userLanguage",
-}));
-
-mock.module("@sip-and-speak/db/schema/auth", () => ({
-  user: USER_TABLE,
-}));
-
-// ── drizzle-orm mock ──────────────────────────────────────────────────────────
-
-mock.module("drizzle-orm", () => ({
-  eq: (_col: unknown, val: unknown) => ({ _val: val }),
-  or: (...args: unknown[]) => args,
-}));
-
-// ── DB mock ───────────────────────────────────────────────────────────────────
+import { beforeEach, describe, expect, it } from "bun:test";
+import { InMemoryDelivery, setDelivery } from "../delivery";
+import { InMemoryTokenStore, setTokenStore } from "../recipe";
+import { handleConversationOpened } from "../dispatcher";
 
 const STUDENT_A_ID = "student-a-id";
 const STUDENT_B_ID = "student-b-id";
 
-let mockStudentATokens: Array<{ id: string; token: string }> = [];
-let mockStudentBTokens: Array<{ id: string; token: string }> = [];
-
-const STUDENT_A_NAME = [{ name: "Alice" }];
-const STUDENT_B_NAME = [{ name: "Bob" }];
-
-mock.module("@sip-and-speak/db", () => ({
-  db: {
-    select: (fields: Record<string, unknown>) => {
-      const isNameQuery = "name" in fields;
-      return {
-        from: (_table: unknown) => ({
-          where: (clause: { _val: string }) => {
-            if (isNameQuery) {
-              const rows = clause._val === STUDENT_A_ID ? STUDENT_A_NAME : STUDENT_B_NAME;
-              return { limit: (_n: number) => Promise.resolve(rows) };
-            }
-            const rows =
-              clause._val === STUDENT_A_ID ? mockStudentATokens : mockStudentBTokens;
-            return Promise.resolve(rows);
-          },
-        }),
-      };
-    },
-  },
-}));
-
-// ── Domain events mock ────────────────────────────────────────────────────────
-
-mock.module("@sip-and-speak/api/domain-events", () => ({
-  domainEvents: { on: mock((_evt: string, _fn: unknown) => undefined), emit: mock(() => undefined), removeAllListeners: mock(() => undefined) },
-}));
-
-// ── Import under test (after mocks) ──────────────────────────────────────────
-
-// eslint-disable-next-line import/first
-import { handleConversationOpened } from "../dispatcher";
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
+const delivery = new InMemoryDelivery();
+const tokens = new InMemoryTokenStore();
 
 function makeConversationOpenedEvent(
   overrides: Partial<{
@@ -114,29 +41,27 @@ function makeConversationOpenedEvent(
 }
 
 beforeEach(() => {
-  fetchCalls.length = 0;
-  mockStudentATokens = [];
-  mockStudentBTokens = [];
+  delivery.reset();
+  tokens.reset();
+  setDelivery(delivery);
+  setTokenStore(tokens);
 });
-
-// ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe("#141 — Notify both Students when conversation channel opens", () => {
   it("sends a push to both Students with partner name and conversation deep link", async () => {
-    mockStudentATokens = [{ id: "tok-a", token: "ExponentPushToken[alice]" }];
-    mockStudentBTokens = [{ id: "tok-b", token: "ExponentPushToken[bob]" }];
+    tokens.set(STUDENT_A_ID, [{ id: "tok-a", token: "ExponentPushToken[alice]" }]);
+    tokens.set(STUDENT_B_ID, [{ id: "tok-b", token: "ExponentPushToken[bob]" }]);
 
     await handleConversationOpened(makeConversationOpenedEvent());
 
-    expect(fetchCalls).toHaveLength(1);
+    expect(delivery.sent).toHaveLength(1);
 
-    const call = fetchCalls[0];
-    if (!call) throw new Error("Expected a fetch call");
+    const messages = delivery.sent[0];
+    if (!messages) throw new Error("Expected a delivery batch");
+    expect(messages).toHaveLength(2);
 
-    expect(call.messages).toHaveLength(2);
-
-    const aliceMsg = call.messages.find((m) => m.to === "ExponentPushToken[alice]");
-    const bobMsg = call.messages.find((m) => m.to === "ExponentPushToken[bob]");
+    const aliceMsg = messages.find((m) => m.to === "ExponentPushToken[alice]");
+    const bobMsg = messages.find((m) => m.to === "ExponentPushToken[bob]");
 
     expect(aliceMsg?.title).toBe("Your messaging channel is open!");
     expect(aliceMsg?.body).toContain("Bob");
@@ -150,11 +75,8 @@ describe("#141 — Notify both Students when conversation channel opens", () => 
   });
 
   it("sends no notification when neither Student has a registered device token", async () => {
-    mockStudentATokens = [];
-    mockStudentBTokens = [];
-
     await handleConversationOpened(makeConversationOpenedEvent());
 
-    expect(fetchCalls).toHaveLength(0);
+    expect(delivery.sent).toHaveLength(0);
   });
 });

--- a/packages/notifications/src/__tests__/notifications-match-accepted.test.ts
+++ b/packages/notifications/src/__tests__/notifications-match-accepted.test.ts
@@ -4,90 +4,17 @@
  * Covers:
  *   - Notification sent to requester when their match request is accepted
  *   - No notification sent when requester has no registered device token
+ *
+ * Uses the dispatch seam (InMemoryDelivery + InMemoryTokenStore) — no DB,
+ * drizzle, or fetch mocking.
  */
-import { describe, it, expect, mock, beforeEach } from "bun:test";
-
-// ── Fetch mock ────────────────────────────────────────────────────────────────
-
-interface CapturedFetchCall {
-  url: string;
-  messages: Array<{ to: string; title?: string; body?: string; data?: Record<string, unknown> }>;
-}
-
-const fetchCalls: CapturedFetchCall[] = [];
-
-(global as unknown as { fetch: unknown }).fetch = mock(async (url: string, options: RequestInit) => {
-  fetchCalls.push({
-    url,
-    messages: JSON.parse(options.body as string) as CapturedFetchCall["messages"],
-  });
-  return {
-    json: async () => ({ data: [{ status: "ok", id: "ticket-1" }] }),
-  };
-});
-
-// ── Schema mocks ──────────────────────────────────────────────────────────────
-
-const USER_TABLE = "user";
-const DEVICE_TOKEN_TABLE = "userDeviceToken";
-
-mock.module("@sip-and-speak/db/schema/identity", () => ({
-  userDeviceToken: DEVICE_TOKEN_TABLE,
-  userLanguage: "userLanguage",
-}));
-
-mock.module("@sip-and-speak/db/schema/auth", () => ({
-  user: USER_TABLE,
-}));
-
-// ── drizzle-orm mock ──────────────────────────────────────────────────────────
-
-mock.module("drizzle-orm", () => ({
-  eq: (_col: unknown, val: unknown) => ({ _val: val }),
-}));
-
-// ── DB mock ───────────────────────────────────────────────────────────────────
-
-let mockReceiverRows: Array<{ name: string }> = [{ name: "Alice" }];
-let mockTokenRows: Array<{ id: string; token: string }> = [];
-
-mock.module("@sip-and-speak/db", () => ({
-  db: {
-    select: (fields: Record<string, unknown>) => {
-      const isNameQuery = "name" in fields;
-      return {
-        from: (_table: unknown) => {
-          const rows = isNameQuery ? mockReceiverRows : mockTokenRows;
-          return {
-            where: (_cond: unknown) => ({
-              limit: (_n: number) => Promise.resolve(rows),
-              then: (
-                resolve: (v: unknown) => unknown,
-                reject?: (e: unknown) => unknown,
-              ) => Promise.resolve(rows).then(resolve, reject),
-            }),
-          };
-        },
-      };
-    },
-    delete: (_table: unknown) => ({
-      where: (_cond: unknown) => Promise.resolve(),
-    }),
-  },
-}));
-
-// ── Import under test (after mocks) ──────────────────────────────────────────
-
-// ── Domain events mock ────────────────────────────────────────────────────────
-
-mock.module("@sip-and-speak/api/domain-events", () => ({
-  domainEvents: { on: mock((_evt: string, _fn: unknown) => undefined), emit: mock(() => undefined), removeAllListeners: mock(() => undefined) },
-}));
-
-// eslint-disable-next-line import/first
+import { beforeEach, describe, expect, it } from "bun:test";
+import { InMemoryDelivery, setDelivery } from "../delivery";
+import { InMemoryTokenStore, setTokenStore } from "../recipe";
 import { handleMatchRequestAccepted } from "../dispatcher";
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
+const delivery = new InMemoryDelivery();
+const tokens = new InMemoryTokenStore();
 
 function makeAcceptedEvent(
   overrides: Partial<{ requesterId: string; receiverId: string; matchRequestId: string; receiverName: string }> = {},
@@ -102,28 +29,25 @@ function makeAcceptedEvent(
 }
 
 beforeEach(() => {
-  fetchCalls.length = 0;
-  mockReceiverRows = [{ name: "Alice" }];
-  mockTokenRows = [];
+  delivery.reset();
+  tokens.reset();
+  setDelivery(delivery);
+  setTokenStore(tokens);
 });
-
-// ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe("#134 — Push notification on MatchRequestAccepted", () => {
   it("sends a push notification to the requester when their request is accepted", async () => {
-    mockTokenRows = [{ id: "tok-1", token: "ExponentPushToken[abc]" }];
+    tokens.set("requester-id", [{ id: "tok-1", token: "ExponentPushToken[abc]" }]);
 
     await handleMatchRequestAccepted(makeAcceptedEvent());
 
-    expect(fetchCalls).toHaveLength(1);
+    expect(delivery.sent).toHaveLength(1);
 
-    const call = fetchCalls[0];
-    if (!call) throw new Error("Expected a fetch call");
+    const messages = delivery.sent[0];
+    if (!messages) throw new Error("Expected a delivery batch");
+    expect(messages).toHaveLength(1);
 
-    expect(call.url).toBe("https://exp.host/--/api/v2/push/send");
-    expect(call.messages).toHaveLength(1);
-
-    const msg = call.messages[0];
+    const msg = messages[0];
     if (!msg) throw new Error("Expected a message");
 
     expect(msg.to).toBe("ExponentPushToken[abc]");
@@ -133,10 +57,8 @@ describe("#134 — Push notification on MatchRequestAccepted", () => {
   });
 
   it("does not send a push notification when the requester has no registered device token", async () => {
-    mockTokenRows = [];
-
     await handleMatchRequestAccepted(makeAcceptedEvent());
 
-    expect(fetchCalls).toHaveLength(0);
+    expect(delivery.sent).toHaveLength(0);
   });
 });

--- a/packages/notifications/src/__tests__/notifications-match-declined.test.ts
+++ b/packages/notifications/src/__tests__/notifications-match-declined.test.ts
@@ -5,82 +5,17 @@
  *   - Notification sent to requester when their match request is declined
  *   - Notification body does not identify the declining receiver
  *   - No notification sent when requester has no registered device token
+ *
+ * Uses the dispatch seam (InMemoryDelivery + InMemoryTokenStore) — no DB,
+ * drizzle, or fetch mocking.
  */
-import { describe, it, expect, mock, beforeEach } from "bun:test";
-
-// ── Fetch mock ────────────────────────────────────────────────────────────────
-
-interface CapturedFetchCall {
-  url: string;
-  messages: Array<{ to: string; title?: string; body?: string; data?: Record<string, unknown> }>;
-}
-
-const fetchCalls: CapturedFetchCall[] = [];
-
-(global as unknown as { fetch: unknown }).fetch = mock(async (url: string, options: RequestInit) => {
-  fetchCalls.push({
-    url,
-    messages: JSON.parse(options.body as string) as CapturedFetchCall["messages"],
-  });
-  return {
-    json: async () => ({ data: [{ status: "ok", id: "ticket-1" }] }),
-  };
-});
-
-// ── Schema mocks ──────────────────────────────────────────────────────────────
-
-const DEVICE_TOKEN_TABLE = "userDeviceToken";
-
-mock.module("@sip-and-speak/db/schema/identity", () => ({
-  userDeviceToken: DEVICE_TOKEN_TABLE,
-  userLanguage: "userLanguage",
-}));
-
-mock.module("@sip-and-speak/db/schema/auth", () => ({
-  user: "user",
-}));
-
-// ── drizzle-orm mock ──────────────────────────────────────────────────────────
-
-mock.module("drizzle-orm", () => ({
-  eq: (_col: unknown, val: unknown) => ({ _val: val }),
-}));
-
-// ── DB mock ───────────────────────────────────────────────────────────────────
-
-let mockTokenRows: Array<{ id: string; token: string }> = [];
-
-mock.module("@sip-and-speak/db", () => ({
-  db: {
-    select: (_fields: Record<string, unknown>) => ({
-      from: (_table: unknown) => ({
-        where: (_cond: unknown) => ({
-          limit: (_n: number) => Promise.resolve(mockTokenRows),
-          then: (
-            resolve: (v: unknown) => unknown,
-            reject?: (e: unknown) => unknown,
-          ) => Promise.resolve(mockTokenRows).then(resolve, reject),
-        }),
-      }),
-    }),
-    delete: (_table: unknown) => ({
-      where: (_cond: unknown) => Promise.resolve(),
-    }),
-  },
-}));
-
-// ── Import under test (after mocks) ──────────────────────────────────────────
-
-// ── Domain events mock ────────────────────────────────────────────────────────
-
-mock.module("@sip-and-speak/api/domain-events", () => ({
-  domainEvents: { on: mock((_evt: string, _fn: unknown) => undefined), emit: mock(() => undefined), removeAllListeners: mock(() => undefined) },
-}));
-
-// eslint-disable-next-line import/first
+import { beforeEach, describe, expect, it } from "bun:test";
+import { InMemoryDelivery, setDelivery } from "../delivery";
+import { InMemoryTokenStore, setTokenStore } from "../recipe";
 import { handleMatchRequestDeclined } from "../dispatcher";
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
+const delivery = new InMemoryDelivery();
+const tokens = new InMemoryTokenStore();
 
 function makeDeclinedEvent(
   overrides: Partial<{ requesterId: string; receiverId: string; matchRequestId: string }> = {},
@@ -94,27 +29,25 @@ function makeDeclinedEvent(
 }
 
 beforeEach(() => {
-  fetchCalls.length = 0;
-  mockTokenRows = [];
+  delivery.reset();
+  tokens.reset();
+  setDelivery(delivery);
+  setTokenStore(tokens);
 });
-
-// ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe("#135 — Push notification on MatchRequestDeclined", () => {
   it("sends a push notification to the requester when their request is declined", async () => {
-    mockTokenRows = [{ id: "tok-2", token: "ExponentPushToken[def]" }];
+    tokens.set("requester-id", [{ id: "tok-2", token: "ExponentPushToken[def]" }]);
 
     await handleMatchRequestDeclined(makeDeclinedEvent());
 
-    expect(fetchCalls).toHaveLength(1);
+    expect(delivery.sent).toHaveLength(1);
 
-    const call = fetchCalls[0];
-    if (!call) throw new Error("Expected a fetch call");
+    const messages = delivery.sent[0];
+    if (!messages) throw new Error("Expected a delivery batch");
+    expect(messages).toHaveLength(1);
 
-    expect(call.url).toBe("https://exp.host/--/api/v2/push/send");
-    expect(call.messages).toHaveLength(1);
-
-    const msg = call.messages[0];
+    const msg = messages[0];
     if (!msg) throw new Error("Expected a message");
 
     expect(msg.to).toBe("ExponentPushToken[def]");
@@ -124,11 +57,11 @@ describe("#135 — Push notification on MatchRequestDeclined", () => {
   });
 
   it("does not include the receiver's name in the notification body", async () => {
-    mockTokenRows = [{ id: "tok-2", token: "ExponentPushToken[def]" }];
+    tokens.set("requester-id", [{ id: "tok-2", token: "ExponentPushToken[def]" }]);
 
     await handleMatchRequestDeclined(makeDeclinedEvent({ receiverId: "receiver-xyz" }));
 
-    const msg = fetchCalls[0]?.messages[0];
+    const msg = delivery.sent[0]?.[0];
     if (!msg) throw new Error("Expected a message");
 
     // Body must not reference the receiver identity — privacy invariant
@@ -137,10 +70,8 @@ describe("#135 — Push notification on MatchRequestDeclined", () => {
   });
 
   it("does not send a push notification when the requester has no registered device token", async () => {
-    mockTokenRows = [];
-
     await handleMatchRequestDeclined(makeDeclinedEvent());
 
-    expect(fetchCalls).toHaveLength(0);
+    expect(delivery.sent).toHaveLength(0);
   });
 });

--- a/packages/notifications/src/__tests__/notifications-match-request-sent.test.ts
+++ b/packages/notifications/src/__tests__/notifications-match-request-sent.test.ts
@@ -4,90 +4,17 @@
  * Covers:
  *   - Notification sent to receiver when a match request is sent to them
  *   - No notification sent when receiver has no registered device token
+ *
+ * Uses the dispatch seam (InMemoryDelivery + InMemoryTokenStore) — no DB,
+ * drizzle, or fetch mocking.
  */
-import { describe, it, expect, mock, beforeEach } from "bun:test";
-
-// ── Fetch mock ────────────────────────────────────────────────────────────────
-
-interface CapturedFetchCall {
-  url: string;
-  messages: Array<{ to: string; title?: string; body?: string; data?: Record<string, unknown> }>;
-}
-
-const fetchCalls: CapturedFetchCall[] = [];
-
-(global as unknown as { fetch: unknown }).fetch = mock(async (url: string, options: RequestInit) => {
-  fetchCalls.push({
-    url,
-    messages: JSON.parse(options.body as string) as CapturedFetchCall["messages"],
-  });
-  return {
-    json: async () => ({ data: [{ status: "ok", id: "ticket-1" }] }),
-  };
-});
-
-// ── Schema mocks ──────────────────────────────────────────────────────────────
-
-const USER_TABLE = "user";
-const DEVICE_TOKEN_TABLE = "userDeviceToken";
-
-mock.module("@sip-and-speak/db/schema/identity", () => ({
-  userDeviceToken: DEVICE_TOKEN_TABLE,
-  userLanguage: "userLanguage",
-}));
-
-mock.module("@sip-and-speak/db/schema/auth", () => ({
-  user: USER_TABLE,
-}));
-
-// ── drizzle-orm mock ──────────────────────────────────────────────────────────
-
-mock.module("drizzle-orm", () => ({
-  eq: (_col: unknown, val: unknown) => ({ _val: val }),
-}));
-
-// ── DB mock ───────────────────────────────────────────────────────────────────
-
-let mockReceiverRows: Array<{ name: string }> = [{ name: "Bob" }];
-let mockTokenRows: Array<{ id: string; token: string }> = [];
-
-mock.module("@sip-and-speak/db", () => ({
-  db: {
-    select: (fields: Record<string, unknown>) => {
-      const isNameQuery = "name" in fields;
-      return {
-        from: (_table: unknown) => {
-          const rows = isNameQuery ? mockReceiverRows : mockTokenRows;
-          return {
-            where: (_cond: unknown) => ({
-              limit: (_n: number) => Promise.resolve(rows),
-              then: (
-                resolve: (v: unknown) => unknown,
-                reject?: (e: unknown) => unknown,
-              ) => Promise.resolve(rows).then(resolve, reject),
-            }),
-          };
-        },
-      };
-    },
-    delete: (_table: unknown) => ({
-      where: (_cond: unknown) => Promise.resolve(),
-    }),
-  },
-}));
-
-// ── Domain events mock ────────────────────────────────────────────────────────
-
-mock.module("@sip-and-speak/api/domain-events", () => ({
-  domainEvents: { on: mock((_evt: string, _fn: unknown) => undefined), emit: mock(() => undefined), removeAllListeners: mock(() => undefined) },
-}));
-
-// ── Import under test (after mocks) ──────────────────────────────────────────
-
-// eslint-disable-next-line import/first
+import { beforeEach, describe, expect, it } from "bun:test";
+import { InMemoryDelivery, setDelivery } from "../delivery";
+import { InMemoryTokenStore, setTokenStore } from "../recipe";
 import { handleMatchRequestSent } from "../dispatcher";
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
+const delivery = new InMemoryDelivery();
+const tokens = new InMemoryTokenStore();
 
 function makeSentEvent(
   overrides: Partial<{
@@ -111,28 +38,25 @@ function makeSentEvent(
 }
 
 beforeEach(() => {
-  fetchCalls.length = 0;
-  mockReceiverRows = [{ name: "Bob" }];
-  mockTokenRows = [];
+  delivery.reset();
+  tokens.reset();
+  setDelivery(delivery);
+  setTokenStore(tokens);
 });
-
-// ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe("#347 — Push notification on MatchRequestSent", () => {
   it("sends a push notification to the receiver when a match request is sent", async () => {
-    mockTokenRows = [{ id: "tok-1", token: "ExponentPushToken[xyz]" }];
+    tokens.set("receiver-id", [{ id: "tok-1", token: "ExponentPushToken[xyz]" }]);
 
     await handleMatchRequestSent(makeSentEvent());
 
-    expect(fetchCalls).toHaveLength(1);
+    expect(delivery.sent).toHaveLength(1);
 
-    const call = fetchCalls[0];
-    if (!call) throw new Error("Expected a fetch call");
+    const messages = delivery.sent[0];
+    if (!messages) throw new Error("Expected a delivery batch");
+    expect(messages).toHaveLength(1);
 
-    expect(call.url).toBe("https://exp.host/--/api/v2/push/send");
-    expect(call.messages).toHaveLength(1);
-
-    const msg = call.messages[0];
+    const msg = messages[0];
     if (!msg) throw new Error("Expected a message");
 
     expect(msg.to).toBe("ExponentPushToken[xyz]");
@@ -142,10 +66,8 @@ describe("#347 — Push notification on MatchRequestSent", () => {
   });
 
   it("does not send a push notification when the receiver has no registered device token", async () => {
-    mockTokenRows = [];
-
     await handleMatchRequestSent(makeSentEvent());
 
-    expect(fetchCalls).toHaveLength(0);
+    expect(delivery.sent).toHaveLength(0);
   });
 });

--- a/packages/notifications/src/__tests__/notifications-meetup-cancelled.test.ts
+++ b/packages/notifications/src/__tests__/notifications-meetup-cancelled.test.ts
@@ -1,56 +1,48 @@
 /**
  * Tests for task #83 — Push notification on MeetupCancelled
+ *
+ * Drives the real `domainEvents` wiring via `registerNotificationHandlers`, with
+ * the dispatch seam (InMemoryDelivery + InMemoryTokenStore) replacing DB,
+ * drizzle, and fetch mocks.
  */
-import { describe, it, expect, mock, beforeEach } from "bun:test";
-
-interface CapturedFetchCall {
-  url: string;
-  messages: Array<{ to: string; title?: string; body?: string; data?: Record<string, unknown> }>;
-}
-
-const fetchCalls: CapturedFetchCall[] = [];
-(global as unknown as { fetch: unknown }).fetch = mock(async (url: string, options: RequestInit) => {
-  fetchCalls.push({ url, messages: JSON.parse(options.body as string) as CapturedFetchCall["messages"] });
-  return { json: async () => ({ data: [{ status: "ok", id: "t-1" }] }) };
-});
-
-mock.module("@sip-and-speak/db/schema/identity", () => ({ userDeviceToken: "userDeviceToken", userLanguage: "userLanguage" }));
-mock.module("@sip-and-speak/db/schema/auth", () => ({ user: "user" }));
-mock.module("drizzle-orm", () => ({ eq: (_col: unknown, val: unknown) => ({ _val: val }) }));
-
-let mockTokenRows: Array<{ id: string; token: string }> = [];
-mock.module("@sip-and-speak/db", () => ({
-  db: {
-    select: () => ({ from: () => ({ where: () => Promise.resolve(mockTokenRows) }) }),
-  },
-}));
-
-// ── Domain events mock ────────────────────────────────────────────────────────
-
-mock.module("@sip-and-speak/api/domain-events", () => {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { EventEmitter } = require("events") as typeof import("events");
-  return { domainEvents: new EventEmitter() };
-});
-
-import { registerNotificationHandlers } from "../dispatcher";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { domainEvents } from "@sip-and-speak/api/domain-events";
+import { InMemoryDelivery, setDelivery } from "../delivery";
+import { InMemoryTokenStore, setTokenStore } from "../recipe";
+import { registerNotificationHandlers } from "../dispatcher";
+
+const OTHER_STUDENT_ID = "user-b";
+
+const delivery = new InMemoryDelivery();
+const tokens = new InMemoryTokenStore();
+
+const flush = () => new Promise((r) => setTimeout(r, 10));
 
 describe("handleMeetupCancelled", () => {
-  beforeEach(() => { fetchCalls.length = 0; mockTokenRows = []; registerNotificationHandlers(); });
+  beforeEach(() => {
+    delivery.reset();
+    tokens.reset();
+    setDelivery(delivery);
+    setTokenStore(tokens);
+    domainEvents.removeAllListeners();
+    registerNotificationHandlers();
+  });
+
+  afterEach(() => {
+    domainEvents.removeAllListeners();
+  });
 
   it("notifies the other Student when a meetup is cancelled", async () => {
-    mockTokenRows = [{ id: "t-1", token: "ExponentPushToken[other]" }];
-    domainEvents.emit("MeetupCancelled", { meetupId: "m-1", cancelledById: "user-a", otherStudentId: "user-b", cancelledAt: new Date() });
-    await new Promise((r) => setTimeout(r, 20));
-    expect(fetchCalls.length).toBe(1);
-    expect(fetchCalls[0]!.messages[0]!.title).toBe("Meetup cancelled");
+    tokens.set(OTHER_STUDENT_ID, [{ id: "t-1", token: "ExponentPushToken[other]" }]);
+    domainEvents.emit("MeetupCancelled", { meetupId: "m-1", cancelledById: "user-a", otherStudentId: OTHER_STUDENT_ID, cancelledAt: new Date() });
+    await flush();
+    expect(delivery.sent.length).toBe(1);
+    expect(delivery.sent[0]![0]!.title).toBe("Meetup cancelled");
   });
 
   it("sends no notification when the other Student has no token", async () => {
-    mockTokenRows = [];
-    domainEvents.emit("MeetupCancelled", { meetupId: "m-2", cancelledById: "user-a", otherStudentId: "user-b", cancelledAt: new Date() });
-    await new Promise((r) => setTimeout(r, 20));
-    expect(fetchCalls.length).toBe(0);
+    domainEvents.emit("MeetupCancelled", { meetupId: "m-2", cancelledById: "user-a", otherStudentId: OTHER_STUDENT_ID, cancelledAt: new Date() });
+    await flush();
+    expect(delivery.sent.length).toBe(0);
   });
 });

--- a/packages/notifications/src/__tests__/notifications-meetup-confirmed.test.ts
+++ b/packages/notifications/src/__tests__/notifications-meetup-confirmed.test.ts
@@ -4,94 +4,42 @@
  * Covers:
  *   - Both Students notified when a meetup is confirmed
  *   - No notification sent when neither Student has a device token
+ *
+ * Drives the real `domainEvents` wiring via `registerNotificationHandlers`, with
+ * the dispatch seam (InMemoryDelivery + InMemoryTokenStore) replacing DB,
+ * drizzle, and fetch mocks.
  */
-import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { domainEvents } from "@sip-and-speak/api/domain-events";
+import { InMemoryDelivery, setDelivery } from "../delivery";
+import { InMemoryTokenStore, setTokenStore } from "../recipe";
+import { registerNotificationHandlers } from "../dispatcher";
 
-// ── Fetch mock ────────────────────────────────────────────────────────────────
-
-interface CapturedFetchCall {
-  url: string;
-  messages: Array<{ to: string; title?: string; body?: string; data?: Record<string, unknown> }>;
-}
-
-const fetchCalls: CapturedFetchCall[] = [];
-
-(global as unknown as { fetch: unknown }).fetch = mock(async (url: string, options: RequestInit) => {
-  fetchCalls.push({
-    url,
-    messages: JSON.parse(options.body as string) as CapturedFetchCall["messages"],
-  });
-  return {
-    json: async () => ({ data: [{ status: "ok", id: "ticket-1" }] }),
-  };
-});
-
-// ── Schema mocks ──────────────────────────────────────────────────────────────
-
-const DEVICE_TOKEN_TABLE = "userDeviceToken";
-
-mock.module("@sip-and-speak/db/schema/identity", () => ({
-  userDeviceToken: DEVICE_TOKEN_TABLE,
-  userLanguage: "userLanguage",
-}));
-
-mock.module("@sip-and-speak/db/schema/auth", () => ({
-  user: "user",
-}));
-
-// ── drizzle-orm mock ──────────────────────────────────────────────────────────
-
-mock.module("drizzle-orm", () => ({
-  eq: (_col: unknown, val: unknown) => ({ _val: val }),
-}));
-
-// ── DB mock ───────────────────────────────────────────────────────────────────
-
-// Track which userId is queried to return the right tokens
-let proposerTokens: Array<{ id: string; token: string }> = [];
-let receiverTokens: Array<{ id: string; token: string }> = [];
-let lastQueriedUserId = "";
 const PROPOSER_ID = "proposer-123";
 const RECEIVER_ID = "receiver-456";
 
-mock.module("@sip-and-speak/db", () => ({
-  db: {
-    select: () => ({
-      from: () => ({
-        where: (clause: { _val: string }) => {
-          lastQueriedUserId = clause._val;
-          const tokens = clause._val === PROPOSER_ID ? proposerTokens : receiverTokens;
-          return Promise.resolve(tokens);
-        },
-      }),
-    }),
-  },
-}));
+const delivery = new InMemoryDelivery();
+const tokens = new InMemoryTokenStore();
 
-// ── Domain events mock ────────────────────────────────────────────────────────
-
-mock.module("@sip-and-speak/api/domain-events", () => {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { EventEmitter } = require("events") as typeof import("events");
-  return { domainEvents: new EventEmitter() };
-});
-
-// ── Subject under test ────────────────────────────────────────────────────────
-
-import { registerNotificationHandlers } from "../dispatcher";
-import { domainEvents } from "@sip-and-speak/api/domain-events";
+const flush = () => new Promise((r) => setTimeout(r, 10));
 
 describe("handleMeetupConfirmed", () => {
   beforeEach(() => {
-    fetchCalls.length = 0;
-    proposerTokens = [];
-    receiverTokens = [];
+    delivery.reset();
+    tokens.reset();
+    setDelivery(delivery);
+    setTokenStore(tokens);
+    domainEvents.removeAllListeners();
     registerNotificationHandlers();
   });
 
+  afterEach(() => {
+    domainEvents.removeAllListeners();
+  });
+
   it("notifies both Students when a meetup is confirmed", async () => {
-    proposerTokens = [{ id: "pt-1", token: "ExponentPushToken[proposer-token]" }];
-    receiverTokens = [{ id: "rt-1", token: "ExponentPushToken[receiver-token]" }];
+    tokens.set(PROPOSER_ID, [{ id: "pt-1", token: "ExponentPushToken[proposer-token]" }]);
+    tokens.set(RECEIVER_ID, [{ id: "rt-1", token: "ExponentPushToken[receiver-token]" }]);
 
     domainEvents.emit("MeetupConfirmed", {
       meetupId: "meetup-1",
@@ -103,11 +51,10 @@ describe("handleMeetupConfirmed", () => {
       confirmedAt: new Date(),
     });
 
-    // Allow async handler to flush
-    await new Promise((r) => setTimeout(r, 20));
+    await flush();
 
-    expect(fetchCalls.length).toBe(1);
-    const sentMessages = fetchCalls[0]!.messages;
+    expect(delivery.sent.length).toBe(1);
+    const sentMessages = delivery.sent[0]!;
     expect(sentMessages.length).toBe(2);
     expect(sentMessages.map((m) => m.to)).toContain("ExponentPushToken[proposer-token]");
     expect(sentMessages.map((m) => m.to)).toContain("ExponentPushToken[receiver-token]");
@@ -116,9 +63,6 @@ describe("handleMeetupConfirmed", () => {
   });
 
   it("sends no notification when neither Student has a device token", async () => {
-    proposerTokens = [];
-    receiverTokens = [];
-
     domainEvents.emit("MeetupConfirmed", {
       meetupId: "meetup-2",
       proposerId: PROPOSER_ID,
@@ -129,8 +73,8 @@ describe("handleMeetupConfirmed", () => {
       confirmedAt: new Date(),
     });
 
-    await new Promise((r) => setTimeout(r, 20));
+    await flush();
 
-    expect(fetchCalls.length).toBe(0);
+    expect(delivery.sent.length).toBe(0);
   });
 });

--- a/packages/notifications/src/__tests__/notifications-meetup-counter-proposed.test.ts
+++ b/packages/notifications/src/__tests__/notifications-meetup-counter-proposed.test.ts
@@ -4,82 +4,40 @@
  * Covers:
  *   - Original proposer (now the new receiver) notified when a counter-proposal arrives
  *   - No notification sent when the new receiver has no device token
+ *
+ * Drives the real `domainEvents` wiring via `registerNotificationHandlers`, with
+ * the dispatch seam (InMemoryDelivery + InMemoryTokenStore) replacing DB,
+ * drizzle, and fetch mocks.
  */
-import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { domainEvents } from "@sip-and-speak/api/domain-events";
+import { InMemoryDelivery, setDelivery } from "../delivery";
+import { InMemoryTokenStore, setTokenStore } from "../recipe";
+import { registerNotificationHandlers } from "../dispatcher";
 
-// ── Fetch mock ────────────────────────────────────────────────────────────────
-
-interface CapturedFetchCall {
-  url: string;
-  messages: Array<{ to: string; title?: string; body?: string; data?: Record<string, unknown> }>;
-}
-
-const fetchCalls: CapturedFetchCall[] = [];
-
-(global as unknown as { fetch: unknown }).fetch = mock(async (url: string, options: RequestInit) => {
-  fetchCalls.push({
-    url,
-    messages: JSON.parse(options.body as string) as CapturedFetchCall["messages"],
-  });
-  return {
-    json: async () => ({ data: [{ status: "ok", id: "ticket-1" }] }),
-  };
-});
-
-// ── Schema mocks ──────────────────────────────────────────────────────────────
-
-mock.module("@sip-and-speak/db/schema/identity", () => ({
-  userDeviceToken: "userDeviceToken",
-  userLanguage: "userLanguage",
-}));
-
-mock.module("@sip-and-speak/db/schema/auth", () => ({
-  user: "user",
-}));
-
-// ── drizzle-orm mock ──────────────────────────────────────────────────────────
-
-mock.module("drizzle-orm", () => ({
-  eq: (_col: unknown, val: unknown) => ({ _val: val }),
-}));
-
-// ── DB mock ───────────────────────────────────────────────────────────────────
-
-let mockTokenRows: Array<{ id: string; token: string }> = [];
 const ORIGINAL_PROPOSER_ID = "orig-proposer-123"; // becomes newReceiverId after counter
 
-mock.module("@sip-and-speak/db", () => ({
-  db: {
-    select: () => ({
-      from: () => ({
-        where: () => Promise.resolve(mockTokenRows),
-      }),
-    }),
-  },
-}));
+const delivery = new InMemoryDelivery();
+const tokens = new InMemoryTokenStore();
 
-// ── Domain events mock ────────────────────────────────────────────────────────
-
-mock.module("@sip-and-speak/api/domain-events", () => {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { EventEmitter } = require("events") as typeof import("events");
-  return { domainEvents: new EventEmitter() };
-});
-
-// ── Subject under test ────────────────────────────────────────────────────────
-
-import { registerNotificationHandlers } from "../dispatcher";
-import { domainEvents } from "@sip-and-speak/api/domain-events";
+const flush = () => new Promise((r) => setTimeout(r, 10));
 
 describe("handleMeetupCounterProposed", () => {
   beforeEach(() => {
-    fetchCalls.length = 0;
-    mockTokenRows = [];
+    delivery.reset();
+    tokens.reset();
+    setDelivery(delivery);
+    setTokenStore(tokens);
+    domainEvents.removeAllListeners();
     registerNotificationHandlers();
   });
 
+  afterEach(() => {
+    domainEvents.removeAllListeners();
+  });
+
   it("notifies the original proposer (new receiver) of the counter-proposal", async () => {
-    mockTokenRows = [{ id: "token-1", token: "ExponentPushToken[orig-proposer]" }];
+    tokens.set(ORIGINAL_PROPOSER_ID, [{ id: "token-1", token: "ExponentPushToken[orig-proposer]" }]);
 
     domainEvents.emit("MeetupCounterProposed", {
       meetupId: "meetup-1",
@@ -92,18 +50,16 @@ describe("handleMeetupCounterProposed", () => {
       counterProposedAt: new Date(),
     });
 
-    await new Promise((r) => setTimeout(r, 20));
+    await flush();
 
-    expect(fetchCalls.length).toBe(1);
-    const msg = fetchCalls[0]!.messages[0]!;
+    expect(delivery.sent.length).toBe(1);
+    const msg = delivery.sent[0]![0]!;
     expect(msg.to).toBe("ExponentPushToken[orig-proposer]");
     expect(msg.title).toContain("round 2");
     expect(msg.body).toContain("Vertigo");
   });
 
   it("sends no notification when new receiver has no device token", async () => {
-    mockTokenRows = [];
-
     domainEvents.emit("MeetupCounterProposed", {
       meetupId: "meetup-2",
       newProposerId: "counter-proposer-456",
@@ -115,8 +71,8 @@ describe("handleMeetupCounterProposed", () => {
       counterProposedAt: new Date(),
     });
 
-    await new Promise((r) => setTimeout(r, 20));
+    await flush();
 
-    expect(fetchCalls.length).toBe(0);
+    expect(delivery.sent.length).toBe(0);
   });
 });

--- a/packages/notifications/src/__tests__/notifications-meetup-declined.test.ts
+++ b/packages/notifications/src/__tests__/notifications-meetup-declined.test.ts
@@ -4,89 +4,42 @@
  * Covers:
  *   - Both Students notified when a proposal is declined
  *   - No notification sent when neither Student has a device token
+ *
+ * Drives the real `domainEvents` wiring via `registerNotificationHandlers`, with
+ * the dispatch seam (InMemoryDelivery + InMemoryTokenStore) replacing DB,
+ * drizzle, and fetch mocks.
  */
-import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { domainEvents } from "@sip-and-speak/api/domain-events";
+import { InMemoryDelivery, setDelivery } from "../delivery";
+import { InMemoryTokenStore, setTokenStore } from "../recipe";
+import { registerNotificationHandlers } from "../dispatcher";
 
-// ── Fetch mock ────────────────────────────────────────────────────────────────
-
-interface CapturedFetchCall {
-  url: string;
-  messages: Array<{ to: string; title?: string; body?: string; data?: Record<string, unknown> }>;
-}
-
-const fetchCalls: CapturedFetchCall[] = [];
-
-(global as unknown as { fetch: unknown }).fetch = mock(async (url: string, options: RequestInit) => {
-  fetchCalls.push({
-    url,
-    messages: JSON.parse(options.body as string) as CapturedFetchCall["messages"],
-  });
-  return {
-    json: async () => ({ data: [{ status: "ok", id: "ticket-1" }] }),
-  };
-});
-
-// ── Schema mocks ──────────────────────────────────────────────────────────────
-
-mock.module("@sip-and-speak/db/schema/identity", () => ({
-  userDeviceToken: "userDeviceToken",
-  userLanguage: "userLanguage",
-}));
-
-mock.module("@sip-and-speak/db/schema/auth", () => ({
-  user: "user",
-}));
-
-// ── drizzle-orm mock ──────────────────────────────────────────────────────────
-
-mock.module("drizzle-orm", () => ({
-  eq: (_col: unknown, val: unknown) => ({ _val: val }),
-}));
-
-// ── DB mock ───────────────────────────────────────────────────────────────────
-
-let proposerTokens: Array<{ id: string; token: string }> = [];
-let receiverTokens: Array<{ id: string; token: string }> = [];
 const PROPOSER_ID = "proposer-abc";
 const RECEIVER_ID = "receiver-xyz";
 
-mock.module("@sip-and-speak/db", () => ({
-  db: {
-    select: () => ({
-      from: () => ({
-        where: (clause: { _val: string }) => {
-          const tokens = clause._val === PROPOSER_ID ? proposerTokens : receiverTokens;
-          return Promise.resolve(tokens);
-        },
-      }),
-    }),
-  },
-}));
+const delivery = new InMemoryDelivery();
+const tokens = new InMemoryTokenStore();
 
-// ── Domain events mock ────────────────────────────────────────────────────────
-
-mock.module("@sip-and-speak/api/domain-events", () => {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { EventEmitter } = require("events") as typeof import("events");
-  return { domainEvents: new EventEmitter() };
-});
-
-// ── Subject under test ────────────────────────────────────────────────────────
-
-import { registerNotificationHandlers } from "../dispatcher";
-import { domainEvents } from "@sip-and-speak/api/domain-events";
+const flush = () => new Promise((r) => setTimeout(r, 10));
 
 describe("handleMeetupDeclined", () => {
   beforeEach(() => {
-    fetchCalls.length = 0;
-    proposerTokens = [];
-    receiverTokens = [];
+    delivery.reset();
+    tokens.reset();
+    setDelivery(delivery);
+    setTokenStore(tokens);
+    domainEvents.removeAllListeners();
     registerNotificationHandlers();
   });
 
+  afterEach(() => {
+    domainEvents.removeAllListeners();
+  });
+
   it("notifies both Students when a proposal is declined", async () => {
-    proposerTokens = [{ id: "pt-1", token: "ExponentPushToken[proposer-token]" }];
-    receiverTokens = [{ id: "rt-1", token: "ExponentPushToken[receiver-token]" }];
+    tokens.set(PROPOSER_ID, [{ id: "pt-1", token: "ExponentPushToken[proposer-token]" }]);
+    tokens.set(RECEIVER_ID, [{ id: "rt-1", token: "ExponentPushToken[receiver-token]" }]);
 
     domainEvents.emit("MeetupDeclined", {
       meetupId: "meetup-1",
@@ -95,10 +48,10 @@ describe("handleMeetupDeclined", () => {
       declinedAt: new Date(),
     });
 
-    await new Promise((r) => setTimeout(r, 20));
+    await flush();
 
-    expect(fetchCalls.length).toBe(1);
-    const msgs = fetchCalls[0]!.messages;
+    expect(delivery.sent.length).toBe(1);
+    const msgs = delivery.sent[0]!;
     expect(msgs.length).toBe(2);
     expect(msgs.map((m) => m.to)).toContain("ExponentPushToken[proposer-token]");
     expect(msgs.map((m) => m.to)).toContain("ExponentPushToken[receiver-token]");
@@ -106,9 +59,6 @@ describe("handleMeetupDeclined", () => {
   });
 
   it("sends no notification when neither Student has a device token", async () => {
-    proposerTokens = [];
-    receiverTokens = [];
-
     domainEvents.emit("MeetupDeclined", {
       meetupId: "meetup-2",
       proposerId: PROPOSER_ID,
@@ -116,8 +66,8 @@ describe("handleMeetupDeclined", () => {
       declinedAt: new Date(),
     });
 
-    await new Promise((r) => setTimeout(r, 20));
+    await flush();
 
-    expect(fetchCalls.length).toBe(0);
+    expect(delivery.sent.length).toBe(0);
   });
 });

--- a/packages/notifications/src/__tests__/notifications-message-sent-suppression.test.ts
+++ b/packages/notifications/src/__tests__/notifications-message-sent-suppression.test.ts
@@ -7,79 +7,21 @@
  * Covers:
  *   - No push sent when recipientIsPresent is true
  *   - Push sent when recipientIsPresent is false
+ *
+ * Uses the dispatch seam (InMemoryDelivery + InMemoryTokenStore) — no DB,
+ * drizzle, or fetch mocking.
  */
-import { describe, it, expect, mock, beforeEach } from "bun:test";
-
-// ── Fetch mock ────────────────────────────────────────────────────────────────
-
-interface CapturedFetchCall {
-  url: string;
-  messages: Array<{ to: string; title?: string; body?: string; data?: Record<string, unknown> }>;
-}
-
-const fetchCalls: CapturedFetchCall[] = [];
-
-(global as unknown as { fetch: unknown }).fetch = mock(async (url: string, options: RequestInit) => {
-  fetchCalls.push({
-    url,
-    messages: JSON.parse(options.body as string) as CapturedFetchCall["messages"],
-  });
-  return {
-    json: async () => ({ data: [{ status: "ok", id: "ticket-1" }] }),
-  };
-});
-
-// ── Schema mocks ──────────────────────────────────────────────────────────────
-
-mock.module("@sip-and-speak/db/schema/identity", () => ({
-  userDeviceToken: "userDeviceToken",
-  userLanguage: "userLanguage",
-}));
-
-mock.module("@sip-and-speak/db/schema/auth", () => ({
-  user: "user",
-}));
-
-// ── drizzle-orm mock ──────────────────────────────────────────────────────────
-
-mock.module("drizzle-orm", () => ({
-  eq: (_col: unknown, val: unknown) => ({ _col: _col, _val: val }),
-  and: (...args: unknown[]) => ({ _and: args }),
-}));
-
-// ── DB mock ───────────────────────────────────────────────────────────────────
+import { beforeEach, describe, expect, it } from "bun:test";
+import { InMemoryDelivery, setDelivery } from "../delivery";
+import { InMemoryTokenStore, setTokenStore } from "../recipe";
+import { handleMessageSent } from "../dispatcher";
 
 const RECIPIENT_ID = "recipient-id";
 const SENDER_ID = "sender-id";
 const CONVERSATION_ID = "conv-1";
 
-const RECIPIENT_TOKEN = [{ id: "tok-1", token: "ExponentPushToken[recipient]" }];
-
-mock.module("@sip-and-speak/db", () => ({
-  db: {
-    select: (_fields: Record<string, unknown>) => ({
-      from: (_table: unknown) => ({
-        where: (_clause: unknown) => Promise.resolve(RECIPIENT_TOKEN),
-      }),
-    }),
-    delete: (_table: unknown) => ({
-      where: (_clause: unknown) => Promise.resolve([]),
-    }),
-  },
-}));
-
-// ── Import under test (after mocks) ──────────────────────────────────────────
-
-// ── Domain events mock ────────────────────────────────────────────────────────
-
-mock.module("@sip-and-speak/api/domain-events", () => ({
-  domainEvents: { on: mock((_evt: string, _fn: unknown) => undefined), emit: mock(() => undefined), removeAllListeners: mock(() => undefined) },
-}));
-
-// eslint-disable-next-line import/first
-import { handleMessageSent } from "../dispatcher";
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
+const delivery = new InMemoryDelivery();
+const tokens = new InMemoryTokenStore();
 
 function makeEvent(recipientIsPresent = false) {
   return {
@@ -92,21 +34,24 @@ function makeEvent(recipientIsPresent = false) {
 }
 
 beforeEach(() => {
-  fetchCalls.length = 0;
+  delivery.reset();
+  tokens.reset();
+  setDelivery(delivery);
+  setTokenStore(tokens);
+  // Recipient always has a registered device — suppression must be the only reason no push is sent.
+  tokens.set(RECIPIENT_ID, [{ id: "tok-1", token: "ExponentPushToken[recipient]" }]);
 });
-
-// ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe("#153 — Suppress push when recipient is actively viewing", () => {
   it("suppresses push when recipientIsPresent is true", async () => {
     await handleMessageSent(makeEvent(true));
 
-    expect(fetchCalls).toHaveLength(0);
+    expect(delivery.sent).toHaveLength(0);
   });
 
   it("sends push when recipientIsPresent is false", async () => {
     await handleMessageSent(makeEvent(false));
 
-    expect(fetchCalls).toHaveLength(1);
+    expect(delivery.sent).toHaveLength(1);
   });
 });

--- a/packages/notifications/src/__tests__/notifications-message-sent.test.ts
+++ b/packages/notifications/src/__tests__/notifications-message-sent.test.ts
@@ -8,95 +8,22 @@
  *   - No push sent when recipient has no registered device token
  *   - DeviceNotRegistered receipt error is handled gracefully (stale token removed)
  *   - Notification payload shape: title = sender name, body = generic, conversationId in data
+ *
+ * Uses the dispatch seam (InMemoryDelivery + InMemoryTokenStore) — no DB,
+ * drizzle, or fetch mocking. Per-token Expo errors are simulated with
+ * `InMemoryDelivery.setNextTickets`; pruned tokens are read from
+ * `InMemoryTokenStore.removed`.
  */
-import { describe, it, expect, mock, beforeEach } from "bun:test";
-
-// ── Fetch mock ────────────────────────────────────────────────────────────────
-
-interface CapturedFetchCall {
-  url: string;
-  messages: Array<{ to: string; title?: string; body?: string; data?: Record<string, unknown> }>;
-}
-
-const fetchCalls: CapturedFetchCall[] = [];
-let mockFetchTickets: Array<{ status: string; id?: string; details?: { error?: string } }> = [
-  { status: "ok", id: "ticket-1" },
-];
-
-(global as unknown as { fetch: unknown }).fetch = mock(async (url: string, options: RequestInit) => {
-  fetchCalls.push({
-    url,
-    messages: JSON.parse(options.body as string) as CapturedFetchCall["messages"],
-  });
-  return {
-    // Expo returns HTTP 200 even when individual tickets carry per-token errors
-    // like DeviceNotRegistered; only non-2xx means the whole request failed.
-    ok: true,
-    status: 200,
-    statusText: "OK",
-    text: async () => "",
-    json: async () => ({ data: mockFetchTickets }),
-  };
-});
-
-// ── Schema mocks ──────────────────────────────────────────────────────────────
-
-const DEVICE_TOKEN_TABLE = "userDeviceToken";
-
-mock.module("@sip-and-speak/db/schema/identity", () => ({
-  userDeviceToken: DEVICE_TOKEN_TABLE,
-  userLanguage: "userLanguage",
-}));
-
-mock.module("@sip-and-speak/db/schema/auth", () => ({
-  user: "user",
-}));
-
-// ── drizzle-orm mock ──────────────────────────────────────────────────────────
-
-mock.module("drizzle-orm", () => ({
-  eq: (_col: unknown, val: unknown) => ({ _val: val }),
-}));
-
-// ── DB mock ───────────────────────────────────────────────────────────────────
+import { beforeEach, describe, expect, it } from "bun:test";
+import { InMemoryDelivery, setDelivery } from "../delivery";
+import { InMemoryTokenStore, setTokenStore } from "../recipe";
+import { handleMessageSent } from "../dispatcher";
 
 const SENDER_ID = "sender-id";
 const RECIPIENT_ID = "recipient-id";
 
-let mockRecipientTokens: Array<{ id: string; token: string }> = [];
-const deletedTokenIds: string[] = [];
-
-mock.module("@sip-and-speak/db", () => ({
-  db: {
-    select: (_fields: Record<string, unknown>) => ({
-      from: (_table: unknown) => ({
-        where: (clause: { _val: string }) => {
-          const rows = clause._val === RECIPIENT_ID ? mockRecipientTokens : [];
-          return Promise.resolve(rows);
-        },
-      }),
-    }),
-    delete: (_table: unknown) => ({
-      where: (clause: { _val: string }) => {
-        deletedTokenIds.push(clause._val);
-        return Promise.resolve([]);
-      },
-    }),
-  },
-}));
-
-// ── Domain events mock ────────────────────────────────────────────────────────
-
-mock.module("@sip-and-speak/api/domain-events", () => ({
-  domainEvents: { on: mock((_evt: string, _fn: unknown) => undefined), emit: mock(() => undefined), removeAllListeners: mock(() => undefined) },
-}));
-
-// ── Import under test (after mocks) ──────────────────────────────────────────
-
-// eslint-disable-next-line import/first
-import { handleMessageSent } from "../dispatcher";
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
+const delivery = new InMemoryDelivery();
+const tokens = new InMemoryTokenStore();
 
 function makeMessageSentEvent(
   overrides: Partial<{
@@ -117,27 +44,25 @@ function makeMessageSentEvent(
 }
 
 beforeEach(() => {
-  fetchCalls.length = 0;
-  deletedTokenIds.length = 0;
-  mockRecipientTokens = [];
-  mockFetchTickets = [{ status: "ok", id: "ticket-1" }];
+  delivery.reset();
+  tokens.reset();
+  setDelivery(delivery);
+  setTokenStore(tokens);
 });
-
-// ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe("#152 — Send push notification to recipient when a new message arrives", () => {
   it("sends a push to the recipient identifying the sender without message content", async () => {
-    mockRecipientTokens = [{ id: "tok-1", token: "ExponentPushToken[recipient]" }];
+    tokens.set(RECIPIENT_ID, [{ id: "tok-1", token: "ExponentPushToken[recipient]" }]);
 
     await handleMessageSent(makeMessageSentEvent());
 
-    expect(fetchCalls).toHaveLength(1);
+    expect(delivery.sent).toHaveLength(1);
 
-    const call = fetchCalls[0];
-    if (!call) throw new Error("Expected a fetch call");
+    const messages = delivery.sent[0];
+    if (!messages) throw new Error("Expected a delivery batch");
+    expect(messages).toHaveLength(1);
 
-    expect(call.messages).toHaveLength(1);
-    const msg = call.messages[0];
+    const msg = messages[0];
     if (!msg) throw new Error("Expected a message");
 
     expect(msg.to).toBe("ExponentPushToken[recipient]");
@@ -150,21 +75,19 @@ describe("#152 — Send push notification to recipient when a new message arrive
   });
 
   it("sends no notification when recipient has no registered device token", async () => {
-    mockRecipientTokens = [];
-
     await handleMessageSent(makeMessageSentEvent());
 
-    expect(fetchCalls).toHaveLength(0);
+    expect(delivery.sent).toHaveLength(0);
   });
 });
 
 describe("#154 — Notification payload includes sender identity but not message content", () => {
   it("sets title to sender display name and body to a generic string", async () => {
-    mockRecipientTokens = [{ id: "tok-1", token: "ExponentPushToken[recipient]" }];
+    tokens.set(RECIPIENT_ID, [{ id: "tok-1", token: "ExponentPushToken[recipient]" }]);
 
     await handleMessageSent(makeMessageSentEvent({ senderName: "Bob" }));
 
-    const msg = fetchCalls[0]?.messages[0];
+    const msg = delivery.sent[0]?.[0];
     if (!msg) throw new Error("Expected a message");
 
     expect(msg.title).toBe("Bob");
@@ -172,11 +95,11 @@ describe("#154 — Notification payload includes sender identity but not message
   });
 
   it("payload contains conversationId for deep-linking", async () => {
-    mockRecipientTokens = [{ id: "tok-1", token: "ExponentPushToken[recipient]" }];
+    tokens.set(RECIPIENT_ID, [{ id: "tok-1", token: "ExponentPushToken[recipient]" }]);
 
     await handleMessageSent(makeMessageSentEvent({ conversationId: "conv-deep-link" }));
 
-    const msg = fetchCalls[0]?.messages[0];
+    const msg = delivery.sent[0]?.[0];
     if (!msg) throw new Error("Expected a message");
 
     expect(msg.data?.conversationId).toBe("conv-deep-link");
@@ -185,22 +108,17 @@ describe("#154 — Notification payload includes sender identity but not message
 
 describe("#156 — Handle gracefully when recipient has not granted push permissions", () => {
   it("removes stale token and does not throw when Expo returns DeviceNotRegistered", async () => {
-    mockRecipientTokens = [{ id: "stale-tok-id", token: "ExponentPushToken[stale]" }];
-    mockFetchTickets = [{ status: "error", details: { error: "DeviceNotRegistered" } }];
+    tokens.set(RECIPIENT_ID, [{ id: "stale-tok-id", token: "ExponentPushToken[stale]" }]);
+    delivery.setNextTickets([{ status: "error", details: { error: "DeviceNotRegistered" } }]);
 
     await expect(handleMessageSent(makeMessageSentEvent())).resolves.toBeUndefined();
 
-    expect(deletedTokenIds).toContain("stale-tok-id");
+    expect(tokens.removed).toContain("stale-tok-id");
   });
 
-  it("still resolves when fetch returns DeviceNotRegistered for all tokens", async () => {
-    mockRecipientTokens = [{ id: "tok-bad", token: "ExponentPushToken[bad]" }];
-    mockFetchTickets = [{ status: "error", details: { error: "DeviceNotRegistered" } }];
-
-    // Second call — token already removed, no tokens left, so no push attempt
-    mockRecipientTokens = [];
-
+  it("still resolves when the recipient has no tokens left", async () => {
+    // Token already pruned on a prior send — no tokens left, so no push attempt.
     await expect(handleMessageSent(makeMessageSentEvent())).resolves.toBeUndefined();
-    expect(fetchCalls).toHaveLength(0);
+    expect(delivery.sent).toHaveLength(0);
   });
 });

--- a/packages/notifications/src/__tests__/notifications-messaging-decline.test.ts
+++ b/packages/notifications/src/__tests__/notifications-messaging-decline.test.ts
@@ -1,71 +1,41 @@
 /**
  * Tests for task #142 — Notify both Students when messaging channel won't open (decline outcome)
+ *
+ * Uses the dispatch seam (InMemoryDelivery + InMemoryTokenStore) — no DB,
+ * drizzle, or fetch mocking.
  */
-import { describe, it, expect, mock, beforeEach } from "bun:test";
-
-interface CapturedFetchCall {
-  url: string;
-  messages: Array<{ to: string; title?: string; body?: string; data?: Record<string, unknown> }>;
-}
-const fetchCalls: CapturedFetchCall[] = [];
-
-(global as unknown as { fetch: unknown }).fetch = mock(async (url: string, options: RequestInit) => {
-  fetchCalls.push({ url, messages: JSON.parse(options.body as string) as CapturedFetchCall["messages"] });
-  return { json: async () => ({ data: [{ status: "ok", id: "ticket-1" }] }) };
-});
-
-mock.module("@sip-and-speak/db/schema/identity", () => ({ userDeviceToken: "userDeviceToken", userLanguage: "userLanguage" }));
-mock.module("@sip-and-speak/db/schema/auth", () => ({ user: "user" }));
-mock.module("drizzle-orm", () => ({ eq: (_col: unknown, val: unknown) => ({ _val: val }), or: (...args: unknown[]) => args }));
+import { beforeEach, describe, expect, it } from "bun:test";
+import { InMemoryDelivery, setDelivery } from "../delivery";
+import { InMemoryTokenStore, setTokenStore } from "../recipe";
+import { handleMessagingDeclineOutcome } from "../dispatcher";
 
 const STUDENT_A_ID = "student-a-id";
 const STUDENT_B_ID = "student-b-id";
 
-let mockStudentATokens: Array<{ id: string; token: string }> = [];
-let mockStudentBTokens: Array<{ id: string; token: string }> = [];
-
-mock.module("@sip-and-speak/db", () => ({
-  db: {
-    select: (_fields: Record<string, unknown>) => ({
-      from: (_t: unknown) => ({
-        where: (clause: { _val: string }) => {
-          const rows = clause._val === STUDENT_A_ID ? mockStudentATokens : mockStudentBTokens;
-          return Promise.resolve(rows);
-        },
-      }),
-    }),
-  },
-}));
-
-// ── Domain events mock ────────────────────────────────────────────────────────
-
-mock.module("@sip-and-speak/api/domain-events", () => ({
-  domainEvents: { on: mock((_evt: string, _fn: unknown) => undefined), emit: mock(() => undefined), removeAllListeners: mock(() => undefined) },
-}));
-
-// eslint-disable-next-line import/first
-import { handleMessagingDeclineOutcome } from "../dispatcher";
+const delivery = new InMemoryDelivery();
+const tokens = new InMemoryTokenStore();
 
 beforeEach(() => {
-  fetchCalls.length = 0;
-  mockStudentATokens = [];
-  mockStudentBTokens = [];
+  delivery.reset();
+  tokens.reset();
+  setDelivery(delivery);
+  setTokenStore(tokens);
 });
 
 describe("#142 — Notify both Students on decline outcome", () => {
   it("sends decline notification to both Students", async () => {
-    mockStudentATokens = [{ id: "tok-a", token: "ExponentPushToken[alice]" }];
-    mockStudentBTokens = [{ id: "tok-b", token: "ExponentPushToken[bob]" }];
+    tokens.set(STUDENT_A_ID, [{ id: "tok-a", token: "ExponentPushToken[alice]" }]);
+    tokens.set(STUDENT_B_ID, [{ id: "tok-b", token: "ExponentPushToken[bob]" }]);
 
     await handleMessagingDeclineOutcome({ meetupId: "meetup-1", studentAId: STUDENT_A_ID, studentBId: STUDENT_B_ID });
 
-    expect(fetchCalls).toHaveLength(1);
-    const msgs = fetchCalls[0]!.messages;
-    expect(msgs).toHaveLength(2);
-    const tokens = msgs.map((m) => m.to);
-    expect(tokens).toContain("ExponentPushToken[alice]");
-    expect(tokens).toContain("ExponentPushToken[bob]");
-    msgs.forEach((m) => {
+    expect(delivery.sent).toHaveLength(1);
+    const messages = delivery.sent[0]!;
+    expect(messages).toHaveLength(2);
+    const tokenList = messages.map((m) => m.to);
+    expect(tokenList).toContain("ExponentPushToken[alice]");
+    expect(tokenList).toContain("ExponentPushToken[bob]");
+    messages.forEach((m) => {
       expect(m.title).toBe("Messaging not available");
       expect(m.data?.type).toBe("messaging_decline_outcome");
     });
@@ -73,6 +43,6 @@ describe("#142 — Notify both Students on decline outcome", () => {
 
   it("sends no notification when neither Student has a device token", async () => {
     await handleMessagingDeclineOutcome({ meetupId: "meetup-1", studentAId: STUDENT_A_ID, studentBId: STUDENT_B_ID });
-    expect(fetchCalls).toHaveLength(0);
+    expect(delivery.sent).toHaveLength(0);
   });
 });

--- a/packages/notifications/src/__tests__/notifications-messaging-nudge.test.ts
+++ b/packages/notifications/src/__tests__/notifications-messaging-nudge.test.ts
@@ -4,94 +4,20 @@
  * Covers:
  *   - Pending Student receives a nudge push when their match accepts
  *   - No nudge sent when pending Student has no device token
+ *
+ * Uses the dispatch seam (InMemoryDelivery + InMemoryTokenStore) — no DB,
+ * drizzle, or fetch mocking.
  */
-import { describe, it, expect, mock, beforeEach } from "bun:test";
-
-// ── Fetch mock ────────────────────────────────────────────────────────────────
-
-interface CapturedFetchCall {
-  url: string;
-  messages: Array<{ to: string; title?: string; body?: string; data?: Record<string, unknown> }>;
-}
-
-const fetchCalls: CapturedFetchCall[] = [];
-
-(global as unknown as { fetch: unknown }).fetch = mock(async (url: string, options: RequestInit) => {
-  fetchCalls.push({
-    url,
-    messages: JSON.parse(options.body as string) as CapturedFetchCall["messages"],
-  });
-  return {
-    json: async () => ({ data: [{ status: "ok", id: "ticket-1" }] }),
-  };
-});
-
-// ── Schema mocks ──────────────────────────────────────────────────────────────
-
-const USER_TABLE = "user";
-const DEVICE_TOKEN_TABLE = "userDeviceToken";
-
-mock.module("@sip-and-speak/db/schema/identity", () => ({
-  userDeviceToken: DEVICE_TOKEN_TABLE,
-  userLanguage: "userLanguage",
-}));
-
-mock.module("@sip-and-speak/db/schema/auth", () => ({
-  user: USER_TABLE,
-}));
-
-// ── drizzle-orm mock ──────────────────────────────────────────────────────────
-
-mock.module("drizzle-orm", () => ({
-  eq: (_col: unknown, val: unknown) => ({ _val: val }),
-  or: (...args: unknown[]) => args,
-}));
-
-// ── DB mock ───────────────────────────────────────────────────────────────────
+import { beforeEach, describe, expect, it } from "bun:test";
+import { InMemoryDelivery, setDelivery } from "../delivery";
+import { InMemoryTokenStore, setTokenStore } from "../recipe";
+import { handleMessagingNudge } from "../dispatcher";
 
 const ACCEPTING_STUDENT_ID = "student-a-id";
 const PENDING_STUDENT_ID = "student-b-id";
 
-let mockAcceptingStudentTokens: Array<{ id: string; token: string }> = [];
-let mockPendingStudentTokens: Array<{ id: string; token: string }> = [];
-
-const ACCEPTING_STUDENT_NAME = [{ name: "Alice" }];
-
-mock.module("@sip-and-speak/db", () => ({
-  db: {
-    select: (fields: Record<string, unknown>) => {
-      const isNameQuery = "name" in fields;
-      return {
-        from: (_table: unknown) => ({
-          where: (clause: { _val: string }) => {
-            if (isNameQuery) {
-              const rows = clause._val === ACCEPTING_STUDENT_ID ? ACCEPTING_STUDENT_NAME : [];
-              return { limit: (_n: number) => Promise.resolve(rows) };
-            }
-            const rows =
-              clause._val === ACCEPTING_STUDENT_ID
-                ? mockAcceptingStudentTokens
-                : mockPendingStudentTokens;
-            return Promise.resolve(rows);
-          },
-        }),
-      };
-    },
-  },
-}));
-
-// ── Domain events mock ────────────────────────────────────────────────────────
-
-mock.module("@sip-and-speak/api/domain-events", () => ({
-  domainEvents: { on: mock((_evt: string, _fn: unknown) => undefined), emit: mock(() => undefined), removeAllListeners: mock(() => undefined) },
-}));
-
-// ── Import under test (after mocks) ──────────────────────────────────────────
-
-// eslint-disable-next-line import/first
-import { handleMessagingNudge } from "../dispatcher";
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
+const delivery = new InMemoryDelivery();
+const tokens = new InMemoryTokenStore();
 
 function makeNudgeEvent(
   overrides: Partial<{
@@ -110,26 +36,25 @@ function makeNudgeEvent(
 }
 
 beforeEach(() => {
-  fetchCalls.length = 0;
-  mockAcceptingStudentTokens = [];
-  mockPendingStudentTokens = [];
+  delivery.reset();
+  tokens.reset();
+  setDelivery(delivery);
+  setTokenStore(tokens);
 });
-
-// ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe("#140 — Send second push to pending Student when their match accepts", () => {
   it("sends a nudge push to the pending Student with the accepting Student's name", async () => {
-    mockPendingStudentTokens = [{ id: "tok-b", token: "ExponentPushToken[bob]" }];
+    tokens.set(PENDING_STUDENT_ID, [{ id: "tok-b", token: "ExponentPushToken[bob]" }]);
 
     await handleMessagingNudge(makeNudgeEvent());
 
-    expect(fetchCalls).toHaveLength(1);
+    expect(delivery.sent).toHaveLength(1);
 
-    const call = fetchCalls[0];
-    if (!call) throw new Error("Expected a fetch call");
+    const messages = delivery.sent[0];
+    if (!messages) throw new Error("Expected a delivery batch");
+    expect(messages).toHaveLength(1);
 
-    expect(call.messages).toHaveLength(1);
-    const msg = call.messages[0];
+    const msg = messages[0];
     if (!msg) throw new Error("Expected a message");
 
     expect(msg.to).toBe("ExponentPushToken[bob]");
@@ -140,10 +65,8 @@ describe("#140 — Send second push to pending Student when their match accepts"
   });
 
   it("sends no notification when pending Student has no registered device token", async () => {
-    mockPendingStudentTokens = [];
-
     await handleMessagingNudge(makeNudgeEvent());
 
-    expect(fetchCalls).toHaveLength(0);
+    expect(delivery.sent).toHaveLength(0);
   });
 });

--- a/packages/notifications/src/__tests__/notifications-messaging-opt-in.test.ts
+++ b/packages/notifications/src/__tests__/notifications-messaging-opt-in.test.ts
@@ -4,92 +4,20 @@
  * Covers:
  *   - Both Students receive an opt-in prompt when their meetup is completed
  *   - No notification sent when neither Student has a device token
+ *
+ * Uses the dispatch seam (InMemoryDelivery + InMemoryTokenStore) — no DB,
+ * drizzle, or fetch mocking.
  */
-import { describe, it, expect, mock, beforeEach } from "bun:test";
-
-// ── Fetch mock ────────────────────────────────────────────────────────────────
-
-interface CapturedFetchCall {
-  url: string;
-  messages: Array<{ to: string; title?: string; body?: string; data?: Record<string, unknown> }>;
-}
-
-const fetchCalls: CapturedFetchCall[] = [];
-
-(global as unknown as { fetch: unknown }).fetch = mock(async (url: string, options: RequestInit) => {
-  fetchCalls.push({
-    url,
-    messages: JSON.parse(options.body as string) as CapturedFetchCall["messages"],
-  });
-  return {
-    json: async () => ({ data: [{ status: "ok", id: "ticket-1" }] }),
-  };
-});
-
-// ── Schema mocks ──────────────────────────────────────────────────────────────
-
-const USER_TABLE = "user";
-const DEVICE_TOKEN_TABLE = "userDeviceToken";
-
-mock.module("@sip-and-speak/db/schema/identity", () => ({
-  userDeviceToken: DEVICE_TOKEN_TABLE,
-  userLanguage: "userLanguage",
-}));
-
-mock.module("@sip-and-speak/db/schema/auth", () => ({
-  user: USER_TABLE,
-}));
-
-// ── drizzle-orm mock ──────────────────────────────────────────────────────────
-
-mock.module("drizzle-orm", () => ({
-  eq: (_col: unknown, val: unknown) => ({ _val: val }),
-  or: (...args: unknown[]) => args,
-}));
-
-// ── DB mock ───────────────────────────────────────────────────────────────────
+import { beforeEach, describe, expect, it } from "bun:test";
+import { InMemoryDelivery, setDelivery } from "../delivery";
+import { InMemoryTokenStore, setTokenStore } from "../recipe";
+import { handleMessagingOptInPrompted } from "../dispatcher";
 
 const STUDENT_A_ID = "student-a-id";
 const STUDENT_B_ID = "student-b-id";
 
-let mockStudentATokens: Array<{ id: string; token: string }> = [];
-let mockStudentBTokens: Array<{ id: string; token: string }> = [];
-
-const STUDENT_A_NAME = [{ name: "Alice" }];
-const STUDENT_B_NAME = [{ name: "Bob" }];
-
-mock.module("@sip-and-speak/db", () => ({
-  db: {
-    select: (fields: Record<string, unknown>) => {
-      const isNameQuery = "name" in fields;
-      return {
-        from: (_table: unknown) => ({
-          where: (clause: { _val: string }) => {
-            if (isNameQuery) {
-              const rows = clause._val === STUDENT_A_ID ? STUDENT_A_NAME : STUDENT_B_NAME;
-              return { limit: (_n: number) => Promise.resolve(rows) };
-            }
-            const rows = clause._val === STUDENT_A_ID ? mockStudentATokens : mockStudentBTokens;
-            return Promise.resolve(rows);
-          },
-        }),
-      };
-    },
-  },
-}));
-
-// ── Import under test (after mocks) ──────────────────────────────────────────
-
-// ── Domain events mock ────────────────────────────────────────────────────────
-
-mock.module("@sip-and-speak/api/domain-events", () => ({
-  domainEvents: { on: mock((_evt: string, _fn: unknown) => undefined), emit: mock(() => undefined), removeAllListeners: mock(() => undefined) },
-}));
-
-// eslint-disable-next-line import/first
-import { handleMessagingOptInPrompted } from "../dispatcher";
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
+const delivery = new InMemoryDelivery();
+const tokens = new InMemoryTokenStore();
 
 function makeOptInEvent(
   overrides: Partial<{ meetupId: string; studentAId: string; studentAName: string; studentBId: string; studentBName: string }> = {},
@@ -105,40 +33,38 @@ function makeOptInEvent(
 }
 
 beforeEach(() => {
-  fetchCalls.length = 0;
-  mockStudentATokens = [];
-  mockStudentBTokens = [];
+  delivery.reset();
+  tokens.reset();
+  setDelivery(delivery);
+  setTokenStore(tokens);
 });
-
-// ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe("#138 — Send opt-in push notification to both Students after meetup is completed", () => {
   it("sends an opt-in push to both Students when their meetup is completed", async () => {
-    mockStudentATokens = [{ id: "tok-a", token: "ExponentPushToken[alice]" }];
-    mockStudentBTokens = [{ id: "tok-b", token: "ExponentPushToken[bob]" }];
+    tokens.set(STUDENT_A_ID, [{ id: "tok-a", token: "ExponentPushToken[alice]" }]);
+    tokens.set(STUDENT_B_ID, [{ id: "tok-b", token: "ExponentPushToken[bob]" }]);
 
     await handleMessagingOptInPrompted(makeOptInEvent());
 
-    expect(fetchCalls).toHaveLength(1);
+    expect(delivery.sent).toHaveLength(1);
 
-    const call = fetchCalls[0];
-    if (!call) throw new Error("Expected a fetch call");
+    const messages = delivery.sent[0];
+    if (!messages) throw new Error("Expected a delivery batch");
+    expect(messages).toHaveLength(2);
 
-    expect(call.messages).toHaveLength(2);
-
-    const tokens = call.messages.map((m) => m.to);
-    expect(tokens).toContain("ExponentPushToken[alice]");
-    expect(tokens).toContain("ExponentPushToken[bob]");
+    const tokenList = messages.map((m) => m.to);
+    expect(tokenList).toContain("ExponentPushToken[alice]");
+    expect(tokenList).toContain("ExponentPushToken[bob]");
 
     // Student A (Alice) sees Bob's name
-    const aliceMsg = call.messages.find((m) => m.to === "ExponentPushToken[alice]");
+    const aliceMsg = messages.find((m) => m.to === "ExponentPushToken[alice]");
     expect(aliceMsg?.title).toBe("Want to keep in touch?");
     expect(aliceMsg?.body).toContain("Bob");
     expect(aliceMsg?.data?.type).toBe("messaging_opt_in");
     expect(aliceMsg?.data?.meetupId).toBe("meetup-1");
 
     // Student B (Bob) sees Alice's name
-    const bobMsg = call.messages.find((m) => m.to === "ExponentPushToken[bob]");
+    const bobMsg = messages.find((m) => m.to === "ExponentPushToken[bob]");
     expect(bobMsg?.title).toBe("Want to keep in touch?");
     expect(bobMsg?.body).toContain("Alice");
     expect(bobMsg?.data?.type).toBe("messaging_opt_in");
@@ -146,11 +72,8 @@ describe("#138 — Send opt-in push notification to both Students after meetup i
   });
 
   it("sends no notification when neither Student has a registered device token", async () => {
-    mockStudentATokens = [];
-    mockStudentBTokens = [];
-
     await handleMessagingOptInPrompted(makeOptInEvent());
 
-    expect(fetchCalls).toHaveLength(0);
+    expect(delivery.sent).toHaveLength(0);
   });
 });

--- a/packages/notifications/src/__tests__/notifications-removal.test.ts
+++ b/packages/notifications/src/__tests__/notifications-removal.test.ts
@@ -3,106 +3,64 @@
  *
  * Covers:
  *   - Removed Student receives push notification
- *   - Notification failure does not roll back removal (flag stays resolved)
+ *   - Notification failure does not roll back removal (dispatch never throws)
+ *
+ * Drives the real `domainEvents` wiring via `registerNotificationHandlers`, with
+ * the dispatch seam (InMemoryDelivery + InMemoryTokenStore) replacing DB,
+ * drizzle, and fetch mocks.
  */
-import { describe, it, expect, mock, beforeEach } from "bun:test";
-
-interface CapturedFetchCall {
-  url: string;
-  messages: Array<{ to: string; title?: string; body?: string; data?: Record<string, unknown> }>;
-}
-
-const fetchCalls: CapturedFetchCall[] = [];
-let fetchShouldFail = false;
-(global as unknown as { fetch: unknown }).fetch = mock(async (url: string, options: RequestInit) => {
-  if (fetchShouldFail) throw new Error("Expo push failed");
-  fetchCalls.push({ url, messages: JSON.parse(options.body as string) as CapturedFetchCall["messages"] });
-  return { json: async () => ({ data: [{ status: "ok", id: "t-1" }] }) };
-});
-
-let mockTokenRows: Array<{ token: string }> = [];
-
-mock.module("@sip-and-speak/db/schema/identity", () => ({
-  userDeviceToken: "userDeviceToken",
-  userLanguage: "userLanguage",
-  conversationPresence: "conversationPresence",
-  meetup: "meetup",
-  blockedEmail: "blockedEmail",
-  conversation: "conversation",
-}));
-mock.module("@sip-and-speak/db/schema/auth", () => ({ user: "user" }));
-mock.module("drizzle-orm", () => ({
-  eq: (_col: unknown, val: unknown) => ({ _eq: val }),
-  and: (...args: unknown[]) => ({ _and: args }),
-  or: (...args: unknown[]) => ({ _or: args }),
-  inArray: (_col: unknown, vals: unknown) => ({ _inArray: vals }),
-}));
-
-mock.module("@sip-and-speak/db", () => ({
-  db: {
-    select: (_cols?: unknown) => ({
-      from: (_table: unknown) => ({
-        where: () => Promise.resolve(mockTokenRows),
-        limit: () => Promise.resolve([]),
-      }),
-    }),
-    update: (_table: unknown) => ({
-      set: (_vals: unknown) => ({
-        where: () => Promise.resolve(),
-      }),
-    }),
-    insert: (_table: unknown) => ({
-      values: (_vals: unknown) => ({
-        onConflictDoNothing: () => Promise.resolve(),
-      }),
-    }),
-  },
-}));
-
-// ── Domain events mock ────────────────────────────────────────────────────────
-
-mock.module("@sip-and-speak/api/domain-events", () => {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { EventEmitter } = require("events") as typeof import("events");
-  return { domainEvents: new EventEmitter() };
-});
-
-import { registerNotificationHandlers } from "../dispatcher";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import { domainEvents } from "@sip-and-speak/api/domain-events";
+import { InMemoryDelivery, setDelivery, type NotificationDelivery } from "../delivery";
+import { InMemoryTokenStore, setTokenStore } from "../recipe";
+import { registerNotificationHandlers } from "../dispatcher";
+
+const delivery = new InMemoryDelivery();
+const tokens = new InMemoryTokenStore();
+
+const flush = () => new Promise((r) => setTimeout(r, 10));
 
 describe("handleStudentRemovedNotify (#112)", () => {
   beforeEach(() => {
-    fetchCalls.length = 0;
-    fetchShouldFail = false;
-    mockTokenRows = [];
+    delivery.reset();
+    tokens.reset();
+    setDelivery(delivery);
+    setTokenStore(tokens);
     domainEvents.removeAllListeners();
     registerNotificationHandlers();
   });
 
+  afterEach(() => {
+    domainEvents.removeAllListeners();
+  });
+
   it("sends push notification to removed Student", async () => {
-    mockTokenRows = [{ token: "ExponentPushToken[removed-student]" }];
+    tokens.set("student-1", [{ id: "tok-removed", token: "ExponentPushToken[removed-student]" }]);
     domainEvents.emit("StudentRemoved", { flagId: "flag-1", targetId: "student-1", moderatorId: "mod-1", removedAt: new Date() });
-    await new Promise((r) => setTimeout(r, 30));
-    const msg = fetchCalls.find((c) => c.messages[0]?.title === "Your account has been removed");
-    expect(msg).toBeDefined();
-    expect(msg!.messages[0]!.to).toBe("ExponentPushToken[removed-student]");
+    await flush();
+    const batch = delivery.sent.find((b) => b[0]?.title === "Your account has been removed");
+    expect(batch).toBeDefined();
+    expect(batch![0]!.to).toBe("ExponentPushToken[removed-student]");
   });
 
   it("no notification sent when Student has no device token", async () => {
-    mockTokenRows = [];
     domainEvents.emit("StudentRemoved", { flagId: "flag-2", targetId: "student-2", moderatorId: "mod-1", removedAt: new Date() });
-    await new Promise((r) => setTimeout(r, 30));
-    const msg = fetchCalls.find((c) => c.messages[0]?.title === "Your account has been removed");
-    expect(msg).toBeUndefined();
+    await flush();
+    const batch = delivery.sent.find((b) => b[0]?.title === "Your account has been removed");
+    expect(batch).toBeUndefined();
   });
 
   it("notification failure does not throw — removal stands", async () => {
-    mockTokenRows = [{ token: "ExponentPushToken[student-3]" }];
-    fetchShouldFail = true;
-    // Should not throw
+    const errorSpy = spyOn(console, "error").mockImplementation(() => undefined);
+    const failing: NotificationDelivery = {
+      send: () => Promise.reject(new Error("Expo push failed")),
+    };
+    setDelivery(failing);
+    tokens.set("student-3", [{ id: "tok-3", token: "ExponentPushToken[student-3]" }]);
+    // Should not throw / produce an unhandled rejection
     domainEvents.emit("StudentRemoved", { flagId: "flag-3", targetId: "student-3", moderatorId: "mod-1", removedAt: new Date() });
-    await new Promise((r) => setTimeout(r, 30));
-    // No assertion on push — just verifying no unhandled rejection
-    expect(true).toBe(true);
+    await flush();
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
   });
 });

--- a/packages/notifications/src/__tests__/notifications-reschedule-proposed.test.ts
+++ b/packages/notifications/src/__tests__/notifications-reschedule-proposed.test.ts
@@ -1,52 +1,37 @@
 /**
  * Tests for task #89 — Push notification on MeetupRescheduleProposed
+ *
+ * Drives the real `domainEvents` wiring via `registerNotificationHandlers`, with
+ * the dispatch seam (InMemoryDelivery + InMemoryTokenStore) replacing DB,
+ * drizzle, and fetch mocks.
  */
-import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
-
-const mockFetch = mock(async () =>
-  Response.json({ data: [{ status: "ok", id: "ticket-1" }] }),
-);
-global.fetch = mockFetch as unknown as typeof fetch;
-
-const mockDb = {
-  select: mock(() => mockDb),
-  from: mock(() => mockDb),
-  where: mock(() => Promise.resolve([])),
-};
-
-mock.module("@sip-and-speak/db", () => ({ db: mockDb }));
-mock.module("@sip-and-speak/db/schema/identity", () => ({
-  userDeviceToken: { id: "id", token: "token", userId: "user_id" },
-  userLanguage: {},
-}));
-mock.module("@sip-and-speak/db/schema/auth", () => ({ user: { id: "id", name: "name" } }));
-mock.module("@sip-and-speak/api/routers/matching-utils", () => ({
-  buildMatchRequestNotificationBody: () => "body",
-}));
-
-// ── Domain events mock ────────────────────────────────────────────────────────
-
-mock.module("@sip-and-speak/api/domain-events", () => {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { EventEmitter } = require("events") as typeof import("events");
-  return { domainEvents: new EventEmitter() };
-});
-
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { domainEvents } from "@sip-and-speak/api/domain-events";
+import { InMemoryDelivery, setDelivery } from "../delivery";
+import { InMemoryTokenStore, setTokenStore } from "../recipe";
 import { registerNotificationHandlers } from "../dispatcher";
+
+const delivery = new InMemoryDelivery();
+const tokens = new InMemoryTokenStore();
+
+const flush = () => new Promise((r) => setTimeout(r, 10));
 
 describe("#89 — MeetupRescheduleProposed push notification", () => {
   beforeEach(() => {
+    delivery.reset();
+    tokens.reset();
+    setDelivery(delivery);
+    setTokenStore(tokens);
+    domainEvents.removeAllListeners();
     registerNotificationHandlers();
-    mockFetch.mockClear();
   });
 
   afterEach(() => {
-    domainEvents.removeAllListeners("MeetupRescheduleProposed");
+    domainEvents.removeAllListeners();
   });
 
   it("sends a push notification to the receiver when a reschedule is proposed", async () => {
-    mockDb.where.mockResolvedValueOnce([{ id: "dt-1", token: "ExponentPushToken[abc]" }]);
+    tokens.set("receiver-1", [{ id: "dt-1", token: "ExponentPushToken[abc]" }]);
 
     domainEvents.emit("MeetupRescheduleProposed", {
       meetupId: "m-1",
@@ -59,19 +44,16 @@ describe("#89 — MeetupRescheduleProposed push notification", () => {
       proposedAt: new Date(),
     });
 
-    await new Promise((r) => setTimeout(r, 10));
+    await flush();
 
-    expect(mockFetch).toHaveBeenCalledTimes(1);
-    const body = JSON.parse((mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string) as unknown[];
-    const msg = (body as Array<{ title: string; body: string; data: Record<string, unknown> }>)[0];
-    expect(msg?.title).toBe("Reschedule request");
-    expect(msg?.body).toContain("Atlas Building");
-    expect(msg?.data?.type).toBe("meetup_reschedule_proposed");
+    expect(delivery.sent.length).toBe(1);
+    const msg = delivery.sent[0]![0]!;
+    expect(msg.title).toBe("Reschedule request");
+    expect(msg.body).toContain("Atlas Building");
+    expect(msg.data?.type).toBe("meetup_reschedule_proposed");
   });
 
   it("skips notification when receiver has no device token", async () => {
-    mockDb.where.mockResolvedValueOnce([]);
-
     domainEvents.emit("MeetupRescheduleProposed", {
       meetupId: "m-2",
       proposerId: "proposer-1",
@@ -83,7 +65,7 @@ describe("#89 — MeetupRescheduleProposed push notification", () => {
       proposedAt: new Date(),
     });
 
-    await new Promise((r) => setTimeout(r, 10));
-    expect(mockFetch).not.toHaveBeenCalled();
+    await flush();
+    expect(delivery.sent.length).toBe(0);
   });
 });

--- a/packages/notifications/src/__tests__/notifications-student-warned.test.ts
+++ b/packages/notifications/src/__tests__/notifications-student-warned.test.ts
@@ -1,69 +1,59 @@
 /**
  * Tests for task #94 — Push notification on StudentWarned
+ *
+ * Drives the real `domainEvents` wiring via `registerNotificationHandlers`, with
+ * the dispatch seam (InMemoryDelivery + InMemoryTokenStore) replacing DB,
+ * drizzle, and fetch mocks.
  */
-import { describe, it, expect, mock, beforeEach } from "bun:test";
-
-interface CapturedFetchCall {
-  url: string;
-  messages: Array<{ to: string; title?: string; body?: string; data?: Record<string, unknown> }>;
-}
-
-const fetchCalls: CapturedFetchCall[] = [];
-(global as unknown as { fetch: unknown }).fetch = mock(async (url: string, options: RequestInit) => {
-  fetchCalls.push({ url, messages: JSON.parse(options.body as string) as CapturedFetchCall["messages"] });
-  return { json: async () => ({ data: [{ status: "ok", id: "t-1" }] }) };
-});
-
-mock.module("@sip-and-speak/db/schema/identity", () => ({ userDeviceToken: "userDeviceToken", userLanguage: "userLanguage", conversationPresence: "conversationPresence" }));
-mock.module("@sip-and-speak/db/schema/auth", () => ({ user: "user" }));
-mock.module("drizzle-orm", () => ({ eq: (_col: unknown, val: unknown) => ({ _val: val }), and: (...args: unknown[]) => ({ _args: args }) }));
-
-let mockTokenRows: Array<{ id: string; token: string }> = [];
-mock.module("@sip-and-speak/db", () => ({
-  db: {
-    select: () => ({ from: () => ({ where: () => Promise.resolve(mockTokenRows) }) }),
-  },
-}));
-
-// ── Domain events mock ────────────────────────────────────────────────────────
-
-mock.module("@sip-and-speak/api/domain-events", () => {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { EventEmitter } = require("events") as typeof import("events");
-  return { domainEvents: new EventEmitter() };
-});
-
-import { registerNotificationHandlers } from "../dispatcher";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { domainEvents } from "@sip-and-speak/api/domain-events";
+import { InMemoryDelivery, setDelivery } from "../delivery";
+import { InMemoryTokenStore, setTokenStore } from "../recipe";
+import { registerNotificationHandlers } from "../dispatcher";
+
+const delivery = new InMemoryDelivery();
+const tokens = new InMemoryTokenStore();
+
+const flush = () => new Promise((r) => setTimeout(r, 10));
 
 describe("handleStudentWarned", () => {
-  beforeEach(() => { fetchCalls.length = 0; mockTokenRows = []; domainEvents.removeAllListeners(); registerNotificationHandlers(); });
+  beforeEach(() => {
+    delivery.reset();
+    tokens.reset();
+    setDelivery(delivery);
+    setTokenStore(tokens);
+    domainEvents.removeAllListeners();
+    registerNotificationHandlers();
+  });
+
+  afterEach(() => {
+    domainEvents.removeAllListeners();
+  });
 
   it("sends push notification to warned Student's device", async () => {
-    mockTokenRows = [{ id: "t-1", token: "ExponentPushToken[warned]" }];
+    tokens.set("student-1", [{ id: "t-1", token: "ExponentPushToken[warned]" }]);
     domainEvents.emit("StudentWarned", { flagId: "flag-1", targetId: "student-1", moderatorId: "mod-1", warnedAt: new Date() });
-    await new Promise((r) => setTimeout(r, 20));
-    expect(fetchCalls.length).toBe(1);
-    expect(fetchCalls[0]!.messages[0]!.to).toBe("ExponentPushToken[warned]");
-    expect(fetchCalls[0]!.messages[0]!.title).toBe("Moderation notice");
-    expect(fetchCalls[0]!.messages[0]!.data?.type).toBe("student_warned");
+    await flush();
+    expect(delivery.sent.length).toBe(1);
+    expect(delivery.sent[0]![0]!.to).toBe("ExponentPushToken[warned]");
+    expect(delivery.sent[0]![0]!.title).toBe("Moderation notice");
+    expect(delivery.sent[0]![0]!.data?.type).toBe("student_warned");
   });
 
   it("sends no notification when Student has no registered token", async () => {
-    mockTokenRows = [];
     domainEvents.emit("StudentWarned", { flagId: "flag-2", targetId: "student-2", moderatorId: "mod-1", warnedAt: new Date() });
-    await new Promise((r) => setTimeout(r, 20));
-    expect(fetchCalls.length).toBe(0);
+    await flush();
+    expect(delivery.sent.length).toBe(0);
   });
 
   it("sends to all registered tokens when Student has multiple devices", async () => {
-    mockTokenRows = [
+    tokens.set("student-3", [
       { id: "t-1", token: "ExponentPushToken[device1]" },
       { id: "t-2", token: "ExponentPushToken[device2]" },
-    ];
+    ]);
     domainEvents.emit("StudentWarned", { flagId: "flag-3", targetId: "student-3", moderatorId: "mod-1", warnedAt: new Date() });
-    await new Promise((r) => setTimeout(r, 20));
-    expect(fetchCalls.length).toBe(1);
-    expect(fetchCalls[0]!.messages.length).toBe(2);
+    await flush();
+    expect(delivery.sent.length).toBe(1);
+    expect(delivery.sent[0]!.length).toBe(2);
   });
 });

--- a/packages/notifications/src/__tests__/notifications-suspension.test.ts
+++ b/packages/notifications/src/__tests__/notifications-suspension.test.ts
@@ -7,120 +7,76 @@
  * The proposal cancellation (DB side) and peer-id resolution now live in the
  * moderation context handlers. The notifications package subscribes to
  * ProposalsCancelledByCascade (which carries peer IDs) instead of re-querying.
+ *
+ * Drives the real `domainEvents` wiring via `registerNotificationHandlers`, with
+ * the dispatch seam (InMemoryDelivery + InMemoryTokenStore) replacing DB,
+ * drizzle, and fetch mocks.
  */
-import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { domainEvents } from "@sip-and-speak/api/domain-events";
+import { InMemoryDelivery, setDelivery } from "../delivery";
+import { InMemoryTokenStore, setTokenStore } from "../recipe";
+import { registerNotificationHandlers } from "../dispatcher";
 
-interface CapturedFetchCall {
-  url: string;
-  messages: Array<{ to: string; title?: string; body?: string; data?: Record<string, unknown> }>;
+const delivery = new InMemoryDelivery();
+const tokens = new InMemoryTokenStore();
+
+const flush = () => new Promise((r) => setTimeout(r, 10));
+
+function setup() {
+  delivery.reset();
+  tokens.reset();
+  setDelivery(delivery);
+  setTokenStore(tokens);
+  domainEvents.removeAllListeners();
+  registerNotificationHandlers();
 }
 
-const fetchCalls: CapturedFetchCall[] = [];
-(global as unknown as { fetch: unknown }).fetch = mock(async (url: string, options: RequestInit) => {
-  fetchCalls.push({ url, messages: JSON.parse(options.body as string) as CapturedFetchCall["messages"] });
-  return { json: async () => ({ data: [{ status: "ok", id: "t-1" }] }) };
-});
-
-mock.module("@sip-and-speak/db/schema/identity", () => ({
-  userDeviceToken: "userDeviceToken",
-  userLanguage: "userLanguage",
-}));
-mock.module("@sip-and-speak/db/schema/auth", () => ({ user: "user" }));
-mock.module("drizzle-orm", () => ({
-  eq: (_col: unknown, val: unknown) => ({ _eq: val }),
-  and: (...args: unknown[]) => ({ _and: args }),
-  or: (...args: unknown[]) => ({ _or: args }),
-  inArray: (_col: unknown, vals: unknown) => ({ _inArray: vals }),
-}));
-
-let mockTokenRows: Array<{ token: string }> = [];
-let mockTokenRowsForSuspended: Array<{ token: string }> = [];
-
-// Controls which token set is returned depending on query context.
-// Peer tokens → mockTokenRows; suspended student tokens → mockTokenRowsForSuspended.
-let returnPeerTokens = false;
-
-mock.module("@sip-and-speak/db", () => ({
-  db: {
-    select: (_cols?: unknown) => ({
-      from: (_table: unknown) => ({
-        where: () => Promise.resolve(returnPeerTokens ? mockTokenRows : mockTokenRowsForSuspended),
-      }),
-    }),
-  },
-}));
-
-// ── Domain events mock ────────────────────────────────────────────────────────
-
-mock.module("@sip-and-speak/api/domain-events", () => {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { EventEmitter } = require("events") as typeof import("events");
-  return { domainEvents: new EventEmitter() };
-});
-
-import { registerNotificationHandlers } from "../dispatcher";
-import { domainEvents } from "@sip-and-speak/api/domain-events";
-
 describe("handleStudentSuspended — proposal cancellation (#102)", () => {
-  beforeEach(() => {
-    fetchCalls.length = 0;
-    mockTokenRows = [];
-    mockTokenRowsForSuspended = [];
-    returnPeerTokens = false;
-    domainEvents.removeAllListeners();
-    registerNotificationHandlers();
-  });
+  beforeEach(setup);
+  afterEach(() => domainEvents.removeAllListeners());
 
   it("notifies affected peer when proposal is cancelled", async () => {
-    returnPeerTokens = true;
-    mockTokenRows = [{ token: "ExponentPushToken[peer]" }];
+    tokens.set("student-2", [{ id: "peer-tok", token: "ExponentPushToken[peer]" }]);
     domainEvents.emit("ProposalsCancelledByCascade", { targetId: "student-1", peerIds: ["student-2"] });
-    await new Promise((r) => setTimeout(r, 30));
-    const proposalCancelMsg = fetchCalls.find((c) => c.messages[0]?.title === "Meetup proposal cancelled");
-    expect(proposalCancelMsg).toBeDefined();
-    expect(proposalCancelMsg!.messages[0]!.body).toBe("Your meetup proposal has been cancelled.");
+    await flush();
+    const batch = delivery.sent.find((b) => b[0]?.title === "Meetup proposal cancelled");
+    expect(batch).toBeDefined();
+    expect(batch![0]!.body).toBe("Your meetup proposal has been cancelled.");
   });
 
   it("notification does not reveal moderation reason", async () => {
-    returnPeerTokens = true;
-    mockTokenRows = [{ token: "ExponentPushToken[peer]" }];
+    tokens.set("student-2", [{ id: "peer-tok", token: "ExponentPushToken[peer]" }]);
     domainEvents.emit("ProposalsCancelledByCascade", { targetId: "student-1", peerIds: ["student-2"] });
-    await new Promise((r) => setTimeout(r, 30));
-    const proposalCancelMsg = fetchCalls.find((c) => c.messages[0]?.title === "Meetup proposal cancelled");
-    expect(proposalCancelMsg!.messages[0]!.body).not.toContain("suspend");
-    expect(proposalCancelMsg!.messages[0]!.body).not.toContain("moderation");
+    await flush();
+    const batch = delivery.sent.find((b) => b[0]?.title === "Meetup proposal cancelled");
+    expect(batch![0]!.body).not.toContain("suspend");
+    expect(batch![0]!.body).not.toContain("moderation");
   });
 
   it("does not push proposal-cancelled when peerIds is empty", async () => {
     domainEvents.emit("ProposalsCancelledByCascade", { targetId: "student-1", peerIds: [] });
-    await new Promise((r) => setTimeout(r, 30));
-    const proposalCancelMsg = fetchCalls.find((c) => c.messages[0]?.title === "Meetup proposal cancelled");
-    expect(proposalCancelMsg).toBeUndefined();
+    await flush();
+    const batch = delivery.sent.find((b) => b[0]?.title === "Meetup proposal cancelled");
+    expect(batch).toBeUndefined();
   });
 });
 
 describe("handleSuspensionLifted — notify Student (#106)", () => {
-  beforeEach(() => {
-    fetchCalls.length = 0;
-    mockTokenRows = [];
-    mockTokenRowsForSuspended = [];
-    returnPeerTokens = false;
-    domainEvents.removeAllListeners();
-    registerNotificationHandlers();
-  });
+  beforeEach(setup);
+  afterEach(() => domainEvents.removeAllListeners());
 
   it("notifies Student when suspension is lifted", async () => {
-    mockTokenRowsForSuspended = [{ token: "ExponentPushToken[student]" }];
+    tokens.set("student-1", [{ id: "s-tok", token: "ExponentPushToken[student]" }]);
     domainEvents.emit("SuspensionLifted", { targetId: "student-1", moderatorId: "mod-1", liftedAt: new Date() });
-    await new Promise((r) => setTimeout(r, 30));
-    const liftedMsg = fetchCalls.find((c) => c.messages[0]?.title === "Suspension lifted");
-    expect(liftedMsg).toBeDefined();
+    await flush();
+    const batch = delivery.sent.find((b) => b[0]?.title === "Suspension lifted");
+    expect(batch).toBeDefined();
   });
 
   it("sends no notification when Student has no device token", async () => {
-    mockTokenRowsForSuspended = [];
     domainEvents.emit("SuspensionLifted", { targetId: "student-2", moderatorId: "mod-1", liftedAt: new Date() });
-    await new Promise((r) => setTimeout(r, 30));
-    expect(fetchCalls.filter((c) => c.messages[0]?.title === "Suspension lifted").length).toBe(0);
+    await flush();
+    expect(delivery.sent.filter((b) => b[0]?.title === "Suspension lifted").length).toBe(0);
   });
 });

--- a/packages/notifications/src/__tests__/recipe.test.ts
+++ b/packages/notifications/src/__tests__/recipe.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Seam tests for the notification dispatch pipeline.
+ *
+ * Proves the dispatch seam with ZERO module mocks:
+ *   - `toDeliveryMessages` and `staleTokenIds` are pure and tested directly.
+ *   - `dispatch` is exercised through the injectable `setDelivery` /
+ *     `setTokenStore` seams, asserting on `InMemoryDelivery.sent` and the
+ *     in-memory store's pruned token ids — no DB, drizzle, or fetch mocking.
+ */
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import {
+  InMemoryDelivery,
+  setDelivery,
+  type DeliveryTicket,
+  type NotificationDelivery,
+} from "../delivery";
+import {
+  dispatch,
+  staleTokenIds,
+  toDeliveryMessages,
+  InMemoryTokenStore,
+  setTokenStore,
+  type Recipe,
+  type TokenRow,
+} from "../recipe";
+
+// ── toDeliveryMessages (pure) ───────────────────────────────────────────────────
+
+describe("toDeliveryMessages", () => {
+  it("maps each recipient token to a delivery message with aligned token ids", () => {
+    const recipes: Recipe[] = [
+      {
+        recipientId: "u1",
+        title: "Hi",
+        body: "There",
+        data: { type: "x" },
+        category: "cat",
+      },
+    ];
+    const tokens = new Map<string, TokenRow[]>([
+      ["u1", [{ id: "tok-1", token: "ExponentPushToken[a]" }]],
+    ]);
+
+    const { messages, tokenIds } = toDeliveryMessages(recipes, tokens);
+
+    expect(messages).toEqual([
+      {
+        to: "ExponentPushToken[a]",
+        title: "Hi",
+        body: "There",
+        data: { type: "x" },
+        categoryIdentifier: "cat",
+      },
+    ]);
+    expect(tokenIds).toEqual(["tok-1"]);
+  });
+
+  it("emits one message per token when a recipient has multiple devices", () => {
+    const recipes: Recipe[] = [{ recipientId: "u1", title: "T", body: "B" }];
+    const tokens = new Map<string, TokenRow[]>([
+      [
+        "u1",
+        [
+          { id: "tok-1", token: "ExponentPushToken[a]" },
+          { id: "tok-2", token: "ExponentPushToken[b]" },
+        ],
+      ],
+    ]);
+
+    const { messages, tokenIds } = toDeliveryMessages(recipes, tokens);
+
+    expect(messages.map((m) => m.to)).toEqual([
+      "ExponentPushToken[a]",
+      "ExponentPushToken[b]",
+    ]);
+    expect(tokenIds).toEqual(["tok-1", "tok-2"]);
+  });
+
+  it("skips recipients that have no registered tokens", () => {
+    const recipes: Recipe[] = [
+      { recipientId: "u1", title: "T", body: "B" },
+      { recipientId: "u2", title: "T", body: "B" },
+    ];
+    const tokens = new Map<string, TokenRow[]>([
+      ["u1", [{ id: "tok-1", token: "ExponentPushToken[a]" }]],
+      // u2 has no entry
+    ]);
+
+    const { messages, tokenIds } = toDeliveryMessages(recipes, tokens);
+
+    expect(messages).toHaveLength(1);
+    expect(tokenIds).toEqual(["tok-1"]);
+  });
+
+  it("returns empty arrays for no recipes", () => {
+    expect(toDeliveryMessages([], new Map())).toEqual({ messages: [], tokenIds: [] });
+  });
+});
+
+// ── staleTokenIds (pure) ─────────────────────────────────────────────────────────
+
+describe("staleTokenIds", () => {
+  it("returns ids of tokens Expo reports as DeviceNotRegistered", () => {
+    const tickets: DeliveryTicket[] = [
+      { status: "ok", id: "ticket-1" },
+      { status: "error", details: { error: "DeviceNotRegistered" } },
+    ];
+    expect(staleTokenIds(tickets, ["tok-keep", "tok-stale"])).toEqual(["tok-stale"]);
+  });
+
+  it("ignores error tickets that are not DeviceNotRegistered", () => {
+    const tickets: DeliveryTicket[] = [
+      { status: "error", details: { error: "MessageRateExceeded" } },
+    ];
+    expect(staleTokenIds(tickets, ["tok-1"])).toEqual([]);
+  });
+
+  it("returns nothing when all tickets are ok", () => {
+    const tickets: DeliveryTicket[] = [
+      { status: "ok", id: "a" },
+      { status: "ok", id: "b" },
+    ];
+    expect(staleTokenIds(tickets, ["tok-1", "tok-2"])).toEqual([]);
+  });
+
+  it("maps stale tickets back to tokens positionally", () => {
+    const tickets: DeliveryTicket[] = [
+      { status: "error", details: { error: "DeviceNotRegistered" } },
+      { status: "ok", id: "b" },
+      { status: "error", details: { error: "DeviceNotRegistered" } },
+    ];
+    expect(staleTokenIds(tickets, ["t0", "t1", "t2"])).toEqual(["t0", "t2"]);
+  });
+});
+
+// ── dispatch (via injected seams) ────────────────────────────────────────────────
+
+describe("dispatch", () => {
+  const delivery = new InMemoryDelivery();
+  const store = new InMemoryTokenStore();
+
+  beforeEach(() => {
+    delivery.reset();
+    store.reset();
+    setDelivery(delivery);
+    setTokenStore(store);
+  });
+
+  it("short-circuits on empty recipes without touching delivery", async () => {
+    await dispatch([]);
+    expect(delivery.sent).toHaveLength(0);
+  });
+
+  it("sends nothing when no recipient has a registered token", async () => {
+    await dispatch([{ recipientId: "u1", title: "T", body: "B" }]);
+    expect(delivery.sent).toHaveLength(0);
+  });
+
+  it("delivers one batch of messages built from the loaded tokens", async () => {
+    store.set("u1", [{ id: "tok-1", token: "ExponentPushToken[a]" }]);
+    store.set("u2", [{ id: "tok-2", token: "ExponentPushToken[b]" }]);
+
+    await dispatch([
+      { recipientId: "u1", title: "Hello", body: "u1", data: { type: "x" } },
+      { recipientId: "u2", title: "Hello", body: "u2" },
+    ]);
+
+    expect(delivery.sent).toHaveLength(1);
+    const batch = delivery.sent[0]!;
+    expect(batch.map((m) => m.to)).toEqual([
+      "ExponentPushToken[a]",
+      "ExponentPushToken[b]",
+    ]);
+    expect(batch[0]!.title).toBe("Hello");
+    expect(store.removed).toHaveLength(0);
+  });
+
+  it("prunes tokens the delivery reports as DeviceNotRegistered", async () => {
+    store.set("u1", [{ id: "stale-tok", token: "ExponentPushToken[gone]" }]);
+    delivery.setNextTickets([{ status: "error", details: { error: "DeviceNotRegistered" } }]);
+
+    await dispatch([{ recipientId: "u1", title: "T", body: "B" }]);
+
+    expect(delivery.sent).toHaveLength(1);
+    expect(store.removed).toEqual(["stale-tok"]);
+  });
+
+  it("does not prune tokens when delivery succeeds", async () => {
+    store.set("u1", [{ id: "tok-1", token: "ExponentPushToken[ok]" }]);
+
+    await dispatch([{ recipientId: "u1", title: "T", body: "B" }]);
+
+    expect(store.removed).toHaveLength(0);
+  });
+
+  it("swallows delivery errors so callers never see a rejection", async () => {
+    const errorSpy = spyOn(console, "error").mockImplementation(() => undefined);
+    const failing: NotificationDelivery = {
+      send: () => Promise.reject(new Error("network down")),
+    };
+    setDelivery(failing);
+    store.set("u1", [{ id: "tok-1", token: "ExponentPushToken[a]" }]);
+
+    await expect(dispatch([{ recipientId: "u1", title: "T", body: "B" }])).resolves.toBeUndefined();
+    expect(store.removed).toHaveLength(0);
+    expect(errorSpy).toHaveBeenCalled();
+
+    errorSpy.mockRestore();
+  });
+
+  afterEach(() => {
+    delivery.reset();
+    store.reset();
+  });
+});

--- a/packages/notifications/src/index.ts
+++ b/packages/notifications/src/index.ts
@@ -19,4 +19,15 @@ export {
   setDelivery,
 } from "./delivery";
 
-export { type Recipe, dispatch } from "./recipe";
+export {
+  type Recipe,
+  type TokenRow,
+  type TokenStore,
+  dispatch,
+  toDeliveryMessages,
+  staleTokenIds,
+  getTokenStore,
+  setTokenStore,
+  DbTokenStore,
+  InMemoryTokenStore,
+} from "./recipe";

--- a/packages/notifications/src/recipe.ts
+++ b/packages/notifications/src/recipe.ts
@@ -1,7 +1,4 @@
-import { eq } from "drizzle-orm";
-import { db } from "@sip-and-speak/db";
-import { userDeviceToken } from "@sip-and-speak/db/schema/identity";
-import { getDelivery, type DeliveryMessage } from "./delivery";
+import { getDelivery, type DeliveryMessage, type DeliveryTicket } from "./delivery";
 
 export interface Recipe {
   recipientId: string;
@@ -11,36 +8,25 @@ export interface Recipe {
   category?: string;
 }
 
-interface TokenRow {
+export interface TokenRow {
   id: string;
   token: string;
 }
 
-async function loadTokensFor(recipientIds: string[]): Promise<Map<string, TokenRow[]>> {
-  const map = new Map<string, TokenRow[]>();
-  if (recipientIds.length === 0) return map;
-  const results = await Promise.all(
-    recipientIds.map(async (uid) => {
-      const rows = await db
-        .select({ id: userDeviceToken.id, token: userDeviceToken.token })
-        .from(userDeviceToken)
-        .where(eq(userDeviceToken.userId, uid));
-      return [uid, rows] as const;
-    }),
-  );
-  for (const [uid, rows] of results) {
-    map.set(uid, rows);
-  }
-  return map;
-}
+// ── Pure transforms ────────────────────────────────────────────────────────────
 
-export async function dispatch(recipes: Recipe[]): Promise<void> {
-  if (recipes.length === 0) return;
-  const recipientIds = [...new Set(recipes.map((r) => r.recipientId))];
-  const tokensByRecipient = await loadTokensFor(recipientIds);
-
+/**
+ * Flattens recipes against their recipients' device tokens into the list of
+ * delivery messages to send, alongside the token id backing each message
+ * (positionally aligned with the returned messages, so delivery tickets can be
+ * mapped back to the token that produced them).
+ */
+export function toDeliveryMessages(
+  recipes: Recipe[],
+  tokensByRecipient: Map<string, TokenRow[]>,
+): { messages: DeliveryMessage[]; tokenIds: string[] } {
   const messages: DeliveryMessage[] = [];
-  const tokenIdByIndex: string[] = [];
+  const tokenIds: string[] = [];
   for (const recipe of recipes) {
     for (const t of tokensByRecipient.get(recipe.recipientId) ?? []) {
       messages.push({
@@ -50,29 +36,129 @@ export async function dispatch(recipes: Recipe[]): Promise<void> {
         data: recipe.data,
         categoryIdentifier: recipe.category,
       });
-      tokenIdByIndex.push(t.id);
+      tokenIds.push(t.id);
     }
   }
+  return { messages, tokenIds };
+}
 
+/**
+ * Given delivery tickets (positionally aligned with `tokenIds`), returns the ids
+ * of tokens Expo reported as `DeviceNotRegistered` so they can be pruned.
+ */
+export function staleTokenIds(tickets: DeliveryTicket[], tokenIds: string[]): string[] {
+  const stale: string[] = [];
+  for (let i = 0; i < tickets.length; i++) {
+    const ticket = tickets[i];
+    if (ticket?.status === "error" && ticket.details?.error === "DeviceNotRegistered") {
+      const id = tokenIds[i];
+      if (id) stale.push(id);
+    }
+  }
+  return stale;
+}
+
+// ── TokenStore seam ─────────────────────────────────────────────────────────────
+
+export interface TokenStore {
+  load(recipientIds: string[]): Promise<Map<string, TokenRow[]>>;
+  removeStale(tokenIds: string[]): Promise<void>;
+}
+
+/**
+ * Default DB-backed token store. The `@sip-and-speak/db` (and drizzle) imports
+ * are deferred to call time so that merely importing this module does not pull
+ * in the env-validated DB client — letting tests inject a fake store without
+ * mocking `@sip-and-speak/db`.
+ */
+export class DbTokenStore implements TokenStore {
+  async load(recipientIds: string[]): Promise<Map<string, TokenRow[]>> {
+    const map = new Map<string, TokenRow[]>();
+    if (recipientIds.length === 0) return map;
+    const { eq } = await import("drizzle-orm");
+    const { db } = await import("@sip-and-speak/db");
+    const { userDeviceToken } = await import("@sip-and-speak/db/schema/identity");
+    const results = await Promise.all(
+      recipientIds.map(async (uid) => {
+        const rows = await db
+          .select({ id: userDeviceToken.id, token: userDeviceToken.token })
+          .from(userDeviceToken)
+          .where(eq(userDeviceToken.userId, uid));
+        return [uid, rows] as const;
+      }),
+    );
+    for (const [uid, rows] of results) {
+      map.set(uid, rows);
+    }
+    return map;
+  }
+
+  async removeStale(tokenIds: string[]): Promise<void> {
+    if (tokenIds.length === 0) return;
+    const { eq } = await import("drizzle-orm");
+    const { db } = await import("@sip-and-speak/db");
+    const { userDeviceToken } = await import("@sip-and-speak/db/schema/identity");
+    await Promise.all(
+      tokenIds.map((id) => db.delete(userDeviceToken).where(eq(userDeviceToken.id, id))),
+    );
+  }
+}
+
+/**
+ * In-memory token store for tests. Mirrors `InMemoryDelivery`: seed tokens with
+ * `set()`, inspect pruned ids via `removed`, and `reset()` between tests.
+ */
+export class InMemoryTokenStore implements TokenStore {
+  private readonly tokens = new Map<string, TokenRow[]>();
+  readonly removed: string[] = [];
+
+  set(recipientId: string, tokens: TokenRow[]): void {
+    this.tokens.set(recipientId, tokens);
+  }
+
+  async load(recipientIds: string[]): Promise<Map<string, TokenRow[]>> {
+    const map = new Map<string, TokenRow[]>();
+    for (const id of recipientIds) {
+      map.set(id, this.tokens.get(id) ?? []);
+    }
+    return map;
+  }
+
+  async removeStale(tokenIds: string[]): Promise<void> {
+    this.removed.push(...tokenIds);
+  }
+
+  reset(): void {
+    this.tokens.clear();
+    this.removed.length = 0;
+  }
+}
+
+let currentTokenStore: TokenStore | undefined;
+
+export function getTokenStore(): TokenStore {
+  if (!currentTokenStore) currentTokenStore = new DbTokenStore();
+  return currentTokenStore;
+}
+
+export function setTokenStore(store: TokenStore): void {
+  currentTokenStore = store;
+}
+
+// ── Orchestrator ────────────────────────────────────────────────────────────────
+
+export async function dispatch(recipes: Recipe[]): Promise<void> {
+  if (recipes.length === 0) return;
+  const recipientIds = [...new Set(recipes.map((r) => r.recipientId))];
+  const tokensByRecipient = await getTokenStore().load(recipientIds);
+
+  const { messages, tokenIds } = toDeliveryMessages(recipes, tokensByRecipient);
   if (messages.length === 0) return;
 
   try {
     const tickets = await getDelivery().send(messages);
-    const staleTokenIds: string[] = [];
-    for (let i = 0; i < tickets.length; i++) {
-      const ticket = tickets[i];
-      if (ticket?.status === "error" && ticket.details?.error === "DeviceNotRegistered") {
-        const id = tokenIdByIndex[i];
-        if (id) staleTokenIds.push(id);
-      }
-    }
-    if (staleTokenIds.length > 0) {
-      await Promise.all(
-        staleTokenIds.map((id) =>
-          db.delete(userDeviceToken).where(eq(userDeviceToken.id, id)),
-        ),
-      );
-    }
+    const stale = staleTokenIds(tickets, tokenIds);
+    if (stale.length > 0) await getTokenStore().removeStale(stale);
   } catch (err) {
     console.error("[push] delivery failed", err);
   }


### PR DESCRIPTION
Third architecture-deepening round. Rounds 1–2 deepened the **write** side of `packages/api` (pure aggregates, `commitAndEmit` unit-of-work, pg-mem harness) plus exactly **one** read model — Meetup. This round makes the same incision everywhere the pattern didn't reach.

## What changed

| # | Candidate | Deepening | LOC |
|---|-----------|-----------|-----|
| 1 | **Matching read model** | `discover`'s 6 queries + grouping + scorer staging + pagination → `matching-read-model.ts` (`getRankedCandidates`); scorer stays in `matching-utils` | router 750 → 609 |
| 2 | **Notification dispatch seam** | pure `toDeliveryMessages` + `staleTokenIds` freed from `dispatch`; device tokens behind a `TokenStore` seam (mirrors the `Delivery` seam) | `dispatch` now thin |
| 3 | **Conversation read model** | inbox joins in `listConversations`/`unreadCount`/`listEntries` → `chat-read-model.ts`; access checks stay in router, stay split (ADR-0004) | router 544 → 262 |
| 4 | **Profile read model** | `getMyProfile` 4-table assembly → `profile-read-model.ts`; write side untouched | router 764 → 747 |
| 5 | **Meetup-flow view-model** | date math / slot computation / submit validation → `utils/meetup-flow.ts` (mirrors `onboarding-flow.ts`) | modal 1002 → 959 |

## Why

Each candidate was a **shallow** module: a small interface (`discover()`, `getMyProfile()`, `dispatch()`) over a large inlined implementation with no seam to test through. Deepening concentrates each read/transform behind one interface — **leverage** for callers, **locality** for maintainers, and a real test surface.

The notification seam resolves the **ADR-0002 mock-leak follow-up**: `@sip-and-speak/db` validated env at import, so every test mocked it. `DbTokenStore` now defers that import, and `InMemoryTokenStore`/`InMemoryDelivery` let tests run with **zero `mock.module`** — all 17 notification tests converted.

No ADR contradicted. ADR-0004 (split messaging access) explicitly respected — the conversation read model contains no access logic.

## Tests
- api: **228 pass / 0 fail** · notifications: **68 pass / 0 fail** (zero DB mocks) · native: **235 pass / 0 fail**
- `check-types`: 4/4 green
- New: 4 matching + 4 conversation + 4 profile (harness) + 14 notification seam + 28 meetup-flow = **54 new tests**; 17 notification tests de-fragilized.

Docs: `docs/CONTEXT.md` glossary updated with all five new modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)